### PR TITLE
feat: predict output contract — per-root .slp + per-scan manifest (prediction-output)

### DIFF
--- a/API.md
+++ b/API.md
@@ -88,6 +88,61 @@ Run prediction on a sleap_io.Video object.
 
 **Returns:** Path to saved .slp file or Labels object with predictions
 
+### Output Contract
+
+Write the per-scan artifacts the downstream sleap-roots traits stage reads — named
+per-root `.slp` (`{scan_key}.model{model_id}.root{root_type}.slp`) plus a combined
+`{scan_key}.predictions.json` manifest. See the `prediction-output` OpenSpec spec and the
+`sleap_roots_predict.output_contract` docstrings for the full artifact grammar and manifest
+schema (kept single-sourced there to avoid drift).
+
+```python
+from sleap_roots_predict import (
+    write_prediction_outputs,  # write one scan's artifacts, return a PredictionManifest
+    predict_and_write_batch,   # drive a warm worker over N scans (one subdir per scan)
+    ScanRequest,               # a batch scan input (scan_key, video, params, ...)
+    PredictionManifest,        # per-scan manifest (manifest + predict-side provenance)
+    PredictionArtifact,        # one per-root record (model_id, ModelRef, slp_path, checksum, size)
+)
+```
+
+#### `write_prediction_outputs`
+```python
+write_prediction_outputs(
+    labels_by_root: Dict[str, sio.Labels],
+    refs_by_root: Dict[str, ModelRef],
+    out_dir: Union[str, Path],
+    *,
+    scan_key: str,
+    plant_qr_code: Optional[str] = None,
+    inference_config: Dict[str, Any],
+    output_params: Dict[str, Any],
+    predict_code_sha: Optional[str] = None,
+    predict_container_digest: Optional[str] = None,
+) -> PredictionManifest
+```
+Write the named per-root `.slp` files and a combined `{scan_key}.predictions.json` into
+`out_dir` (created if missing); returns the `PredictionManifest`. `plant_qr_code` defaults
+to `scan_key`. Build identity falls back to `SRP_PREDICT_CODE_SHA` /
+`SRP_PREDICT_CONTAINER_DIGEST` then `""`. Re-runs overwrite in place.
+
+**Raises:** `ValueError` if `scan_key` is unsafe as a path segment, or `labels_by_root`
+and `refs_by_root` cover different root types.
+
+#### `predict_and_write_batch`
+```python
+predict_and_write_batch(
+    worker: WarmModelWorker,
+    requests: Iterable[ScanRequest],
+    out_dir: Union[str, Path],
+    *,
+    predict_code_sha: Optional[str] = None,
+    predict_container_digest: Optional[str] = None,
+) -> List[PredictionManifest]
+```
+Drive one warm worker over N scans, writing `out_dir/{scan_key}/` per scan and reusing
+resident predictors. Returns one manifest per scan, in request order.
+
 ---
 
 ## Utility Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Predict output contract** (`sleap_roots_predict.output_contract`): the per-scan
+  artifacts the downstream traits stage reads. `write_prediction_outputs` writes one
+  named per-root `.slp` (`{scan_key}.model{model_id}.root{root_type}.slp`, sleap-roots
+  `Series`-compatible) plus a combined `{scan_key}.predictions.json` manifest — per-root
+  paths + `model_id` + `plant_qr_code` and the predict-side provenance (resolved
+  `ModelRef`s, effective inference config, `predict_code_sha` / `predict_container_digest`,
+  and each `.slp`'s sha256 checksum + size). `predict_and_write_batch` drives one warm
+  `WarmModelWorker` over many scans (one subdirectory per scan; resident predictors
+  reused). New public exports: `PredictionArtifact`, `PredictionManifest`, `ScanRequest`,
+  `write_prediction_outputs`, `predict_and_write_batch`. Build identity is read from
+  `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST` (fail-soft to `""`). Added
+  `sleap-roots` as a test-only (`dev`) dependency for the `Series.load` acceptance test.
+  See the `prediction-output` OpenSpec spec.
+
 ### Changed
 
 - **Rebuilt the inference core on sleap-nn 0.3.0.** `make_predictor` now builds a

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ sleap_roots_predict/
 ├── model_selection.py              # Pure model-selection matcher (choose_models)
 ├── model_registry.py               # Model-card sources (Local + Wandb registry)
 ├── warm_worker.py                  # WarmModelWorker: resident predictors across scans
+├── output_contract.py              # Per-scan output artifacts (.slp + predictions.json)
 ├── video_utils.py                  # Core image processing utilities
 ├── plates_timelapse_experiment.py  # Timelapse experiment processing
 └── __init__.py                     # Package exports and version
@@ -221,6 +222,7 @@ tests/
 ├── test_model_selection.py     # Model-selection matcher tests
 ├── test_model_registry.py      # Card-source tests (offline + gated wandb)
 ├── test_warm_worker.py         # Warm worker tests (real CPU inference)
+├── test_output_contract.py     # Output-contract writer/batch tests (real CPU inference)
 ├── test_public_api.py          # Public-surface import test
 ├── test_video_utils.py         # Video utilities tests
 └── conftest.py                 # Shared test fixtures

--- a/docs/superpowers/specs/2026-07-05-predict-output-contract-design.md
+++ b/docs/superpowers/specs/2026-07-05-predict-output-contract-design.md
@@ -1,0 +1,280 @@
+# Design: predict output contract
+
+- **Date:** 2026-07-05
+- **Branch:** `add-predict-output-contract`
+- **Status:** Approved (brainstorming) — proceeding to OpenSpec proposal + TDD
+- **Slice origin:** deferred task 9.3 of the archived `add-warm-model-worker` change
+- **Roadmap tier:** A3-predict → the predict→traits handoff on the A4 DAG
+  (`images-downloader → predict(warm) → traits → write-back`)
+
+## 1. Problem & goal
+
+PR #9 shipped `WarmModelWorker`. Its `predict(params, video, save_dir=…)` currently
+writes only raw `save_dir/<root_type>.slp` — no manifest, no scan-aware naming, no
+provenance. This slice makes predict emit the **downstream output contract**: the
+on-disk artifacts the traits stage (sleap-roots / A3-traits) reads to assemble a
+`ResultEnvelope`.
+
+This slice is the **output FORMAT only** — the files predict writes. It is independent
+of *how* predict is invoked (per-scan container vs long-lived service — an open
+A4/serving decision that writes the same files either way). The serving
+protocol/entrypoint is a separate slice, out of scope here.
+
+### The consumer grounds the format
+
+`sleap_roots.Series.load(series_name, primary_path, lateral_path, crown_path, csv_path)`
+(`c:/repos/sleap-roots/sleap_roots/series.py`) takes **explicit per-root `.slp` paths**
+(loaded via `sio.load_slp`). `csv_path` is a plant-metadata CSV keyed on
+`plant_qr_code` and is **optional** — Series loads fine without it, and it is upstream
+Bloom scan metadata, not predict's inference output. Because `Series.load` accepts
+explicit paths, the **manifest is the robust interface**; filenames are for
+organization/discovery.
+
+`load_series_from_h5s` documents the naming convention predict must match:
+`{series_name}.model{model_id}.root{primary|lateral|crown}.slp` — no underscores,
+`root`+type concatenated, and `series_name = Path(filename).name.split(".")[0]`
+(⟹ `scan_key` and `model_id` must be **dot-free**).
+
+## 2. Legacy reference (ported + redone)
+
+The previous implementation is the GitLab `salk-tm/sleap-roots-predict` service (cloned
+to `c:/repos/legacy-salk-tm-sleap-roots-predict`). Its `src/main.py` + `src/predict.py`:
+
+- Invocation: `python src/main.py <images_input> <models_input> <output>` — read staged
+  frames + the models-downloader output (`model_paths.csv` + model zips) and wrote
+  predictions to `<output>`.
+- Per-root `.slp` named `scan_{scan_id}.model_{model_id}.root_{model_type}.slp`.
+- One **run-level** `predictions.csv` = the input `scans.csv` merged with a per-scan
+  record `{scan_id, <model_type>: <slp filename>}`.
+- **No provenance sidecar.**
+
+### Deliberate deviations in this version
+
+- **Drop `models_input`** — models are fetched from the wandb registry in-process
+  (consolidated in PR #9). No `model_paths.csv`.
+- **Modernize output** to `sleap-roots-contracts` types (`ModelRef` and the fields of
+  `Provenance`/`BlobRef`) and `Series`-loadable `.slp`.
+- **Per-scan artifacts** (not one run-level CSV): the warm worker's `predict()` is
+  per-scan (one video), and traits is 1 envelope : 1 scan, so the per-scan combined
+  JSON is the atomic unit. A run-level aggregate is deferred (YAGNI; trivially additive).
+- **Add a provenance sidecar** so traits can assemble `Provenance` + `BlobRef` without
+  recomputing predict's identity.
+
+## 3. Settled decisions (with rationale)
+
+1. **Schema home → predict-local now, upstream to contracts later.** The load-bearing
+   contract (`ModelRef`, and the `Provenance`/`BlobRef` *fields*) already lives in
+   `sleap-roots-contracts`. The only un-promoted shapes are (a) the top-level per-scan
+   envelope and (b) a "partial `BlobRef`" (predict has no `s3_location`/`box_link` yet —
+   those are filled downstream at A4 step G, and `BlobRef`'s validator rejects a
+   location-less object, so predict cannot emit a valid `BlobRef` today). The reader
+   (A3-traits) does not exist yet, so freezing a shared type now risks freezing it
+   wrong; migrating later is cheap because it moves **one wrapper class**, not the
+   boundary types. Define the wrapper in `sleap_roots_predict`, reuse `ModelRef` from
+   contracts, document the JSON in the spec, and promote when A3-traits consumes it.
+2. **Artifact layout → single combined per-scan JSON** (`{scan_key}.predictions.json`)
+   holding *both* the manifest (per-root `.slp` paths + `model_id` + `plant_qr_code`)
+   and the predict-side provenance (resolved `ModelRef`s, inference config, code
+   sha/digest, per-`.slp` checksum + file_size). Atomic; traits reads one file per scan.
+3. **Writer integration → thin standalone writer on top of `predict()`.** No change to
+   `WarmModelWorker`. The writer is independently unit-testable.
+4. **Build identity → env var + explicit-arg override, fail-soft.** The writer's only
+   job is to record two strings (`predict_code_sha`, `predict_container_digest`). It
+   accepts them as optional explicit args, defaulting to reading
+   `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST` from the environment, and
+   fails soft to `""` when absent (local runs still produce a sidecar). *How* the image
+   stamps these (Dockerfile `ARG`/`ENV` + CI `--build-arg`) is a deployment detail owned
+   by the serving/entrypoint slice; the writer stays agnostic and env-free-testable.
+5. **Batch warmth → first-class now.** Warmth across a batch already lives in
+   `WarmModelWorker` (predictors cached by `(registry_id, version)`; construct once,
+   reuse across scans). A `predict_and_write_batch` convenience drives one warm worker
+   over N scans and writes one subdirectory per scan. The output format is unchanged for
+   batches.
+6. **Plant-metadata CSV → out of scope.** Optional in `Series`, and it is upstream Bloom
+   scan metadata, not inference output. `plant_qr_code` is recorded in the manifest
+   (defaulting to `scan_key`) so traits can key metadata later, but predict does not
+   produce the CSV.
+
+## 4. Architecture
+
+New module `sleap_roots_predict/output_contract.py`: two pydantic models, one dataclass,
+one pure writer, one batch convenience. Exported from `__init__.py`. `WarmModelWorker` is
+unchanged.
+
+### 4.1 Schema (pydantic, predict-local)
+
+```python
+class PredictionArtifact(BaseModel):          # one per predicted root type
+    root_type: Literal["primary", "lateral", "crown"]
+    model_id: str          # filename-safe slug (discovery label)
+    model: ModelRef        # full ref from contracts (source of truth for identity)
+    slp_path: str          # BASENAME, relative to the manifest's directory
+    checksum: str          # sha256 hex of the .slp
+    file_size: int         # bytes
+
+class PredictionManifest(BaseModel):          # one per scan
+    schema_version: str = "1"                 # versions this predict-local shape
+    scan_key: str
+    plant_qr_code: str                        # defaults to scan_key
+    artifacts: list[PredictionArtifact]       # may be [] (predict produced nothing)
+    predict_inference_config: dict            # worker.inference_config() (FULL, audit)
+    predict_output_params: dict               # worker.output_params() (output-defining)
+    predict_code_sha: str                     # "" when unset
+    predict_container_digest: str             # "" when unset
+```
+
+`Provenance.predict_models` is **derived** by traits as `[a.model for a in artifacts]`
+— not duplicated in the file, so there is a single source of truth within the manifest.
+`InputRef`/`images_checksum` and the full `Provenance`/`ResultEnvelope`/`idempotency_key`
+are traits' responsibility (traits adds `traits_code_sha` etc.).
+
+### 4.2 Public API
+
+```python
+def write_prediction_outputs(
+    labels_by_root: dict[str, sio.Labels],    # from worker.predict(params, video)
+    refs_by_root: dict[str, ModelRef],         # from worker.resolve(params)
+    out_dir: str | Path,
+    *,
+    scan_key: str,
+    plant_qr_code: str | None = None,          # None -> scan_key
+    inference_config: dict,                    # worker.inference_config()
+    output_params: dict,                       # worker.output_params()
+    predict_code_sha: str | None = None,       # None -> env SRP_PREDICT_CODE_SHA -> ""
+    predict_container_digest: str | None = None,  # None -> env SRP_PREDICT_CONTAINER_DIGEST -> ""
+) -> PredictionManifest:
+    """Write named .slp per root + {scan_key}.predictions.json into out_dir."""
+
+@dataclass(frozen=True)
+class ScanRequest:
+    scan_key: str
+    video: "sio.Video"
+    params: ResolvedParams
+    plant_qr_code: str | None = None
+    overrides: dict[str, ModelRef] | None = None
+
+def predict_and_write_batch(
+    worker: WarmModelWorker,
+    requests: Iterable[ScanRequest],
+    out_dir: str | Path,
+    *,
+    predict_code_sha: str | None = None,
+    predict_container_digest: str | None = None,
+) -> list[PredictionManifest]:
+    """Drive one warm worker over N scans, one subdir per scan; reuses residents."""
+```
+
+### 4.3 Filenames
+
+- Per-root `.slp`: `{scan_key}.model{model_id}.root{root_type}.slp` (matches
+  `load_series_from_h5s`).
+- `model_id = slugify(f"{registry_id}_{version}")` — every char outside `[A-Za-z0-9-]`
+  becomes `-` (drops the `reg/rice-primary` slash and any dots). Discovery label only;
+  the full `ModelRef` is in the manifest.
+- `scan_key` is **identity, not mangled**: if it contains `.` / `/` / `\` (or is empty)
+  the writer **raises** rather than silently rewriting it.
+- Combined JSON: `{scan_key}.predictions.json`.
+
+### 4.4 Example on-disk output (batch of one scan; primary + lateral)
+
+```
+out_dir/
+└── scan0731/
+    ├── scan0731.modelreg-rice-primary-v1.rootprimary.slp
+    ├── scan0731.modelreg-rice-lateral-v1.rootlateral.slp
+    └── scan0731.predictions.json
+```
+```json
+{
+  "schema_version": "1",
+  "scan_key": "scan0731",
+  "plant_qr_code": "scan0731",
+  "predict_code_sha": "",
+  "predict_container_digest": "",
+  "predict_inference_config": {"device": "cpu", "peak_threshold": 0.2, "batch_size": 4},
+  "predict_output_params": {"peak_threshold": 0.2},
+  "artifacts": [
+    {"root_type": "primary", "model_id": "reg-rice-primary-v1",
+     "model": {"registry_id": "reg/rice-primary", "version": "v1",
+               "sleap_nn_version": "0.3.0", "root_type": "primary",
+               "weights_checksum": null},
+     "slp_path": "scan0731.modelreg-rice-primary-v1.rootprimary.slp",
+     "checksum": "9f2c…", "file_size": 20481}
+  ]
+}
+```
+(The single-scan pure writer writes these three files directly into whatever `out_dir`
+it is given; the batch convenience nests them under `out_dir/{scan_key}/`.)
+
+## 5. Data flow (pure writer)
+
+1. Validate `scan_key` is filename-safe (non-empty; no `.`/`/`/`\`); validate
+   `set(labels_by_root) == set(refs_by_root)`.
+2. `out_dir` created if missing (writer owns its output dir).
+3. Per root type: write `{scan_key}.model{slug}.root{root_type}.slp`
+   (`labels.save` / `sio.save_file`); compute sha256 hex + `file_size`; build a
+   `PredictionArtifact` (with basename `slp_path`).
+4. Build `PredictionManifest`; write `{scan_key}.predictions.json`
+   (`manifest.model_dump_json`).
+5. Return the manifest.
+
+## 6. Error handling & edge cases
+
+- Key mismatch between `labels_by_root` and `refs_by_root` → `ValueError`.
+- Non-filename-safe / empty `scan_key` → `ValueError` (identity must not be mangled).
+- Zero resolved roots → writes a manifest with `artifacts: []` (valid "predict produced
+  nothing" record).
+- `checksum` = sha256 hex; `slp_path` is a basename so the whole scan dir is
+  relocatable/uploadable (BlobRef locations are filled downstream).
+
+## 7. Scope boundaries
+
+**IN:** the output format — named per-root `.slp` + single combined per-scan JSON
+(manifest + provenance) — plus a pure writer and a batch convenience over the warm
+worker.
+
+**OUT:** MinIO/Box upload that fills `BlobRef` locations (A4 step G — predict writes
+local paths + checksums); traits' consumption + full `ResultEnvelope`/`Provenance`/
+`idempotency_key` (A3-traits, needs `traits_code_sha`); `InputRef`/`images_checksum`
+(upstream from images-downloader); the plant-metadata CSV (upstream); the serving
+protocol/entrypoint; the Dockerfile build-stamp wiring (deployment; the writer only
+*reads* the two strings); a run-level aggregate manifest across scans (deferred, additive).
+
+## 8. Testing — real TDD, no mocks
+
+Drive the vendored native + legacy models through the warm worker (the existing
+`rice_source` / `video` fixtures) to get **real** `Labels` + `ModelRef`s, then:
+
+- named `.slp` reload via `sio.load_file` and contain labeled frames;
+- `{scan_key}.predictions.json` round-trips `PredictionManifest`; per-root paths are
+  correct; `ModelRef` round-trips; `checksum`/`file_size` match recomputation;
+- **acceptance:** `sleap_roots.Series.load(series_name=scan_key, primary_path=…,
+  lateral_path=…, crown_path=…)` loads the output cleanly and exposes labels;
+- error cases: bad `scan_key` raises; key mismatch raises;
+- build identity: explicit arg wins → env fallback → `""` when absent;
+- **batch warmth:** one worker + `predict_and_write_batch` over 2 scans writes per-scan
+  subdirs and reuses the resident `Predictor`s (asserted by object identity).
+
+`sleap-roots` is added as a **test-only** dependency (`dev` extra); the acceptance test
+uses `pytest.importorskip("sleap_roots")` so it skips gracefully if unavailable. Predict
+must **not** runtime-depend on sleap-roots (no cycle: sleap-roots depends on the
+contract, not on predict).
+
+## 9. Risks
+
+- **sleap-io co-resolution (checked; not a conflict):** `sleap-roots` requires
+  `sleap-io>=0.0.11` (open upper) and has **no** `sleap-nn` dependency; sleap-nn 0.3.0
+  pins `sleap-io>=0.8.0,<0.9.0`; the env resolves to 0.8.0, satisfying both. Adding
+  `sleap-roots` to the `dev` extra also pulls `scikit-image`/`shapely`/`scipy`/
+  `pywavelets`/`seaborn`/`matplotlib` — flexible, no contention expected. First TDD step
+  still confirms the dev env resolves; if a real conflict appears, fall back to
+  `importorskip` + a documented compatible-env note (do **not** loosen the inference
+  pin). Optional low-priority advisory issue on `talmolab/sleap-roots` to tighten its
+  `sleap-io` range — not blocking.
+
+## 10. Post-merge (required)
+
+Update the pipeline roadmap
+(`sleap-roots-pipeline/docs/bloom-integration/roadmap.md`, A4 DAG ~line 109): predict
+output contract done → unblocks the A3-traits input. If/when the manifest+sidecar schema
+is promoted to `sleap-roots-contracts`, note the new contract + version there.

--- a/openspec/changes/add-predict-output-contract/design.md
+++ b/openspec/changes/add-predict-output-contract/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Full brainstorming design: `docs/superpowers/specs/2026-07-05-predict-output-contract-design.md`.
+This captures the technical decisions that shape the spec deltas. The consumer is
+sleap-roots `Series.load` (explicit per-root `.slp` paths; optional metadata CSV). The
+legacy reference is the GitLab `salk-tm/sleap-roots-predict` service (per-root `.slp` +
+one run-level `predictions.csv`, no provenance).
+
+## Goals / Non-Goals
+
+- **Goals:** a stable per-scan output format traits can read — named per-root `.slp`
+  (Series-compatible) + one combined JSON (manifest + predict-side provenance) — plus a
+  pure writer and a batch convenience that reuses the warm worker.
+- **Non-Goals:** upload/`BlobRef` locations, full `Provenance`/`ResultEnvelope`, run
+  identity (`idempotency_key`), `InputRef`/`images_checksum`, plant-metadata CSV, serving
+  entrypoint, Dockerfile build stamping. `WarmModelWorker` itself is unchanged.
+
+## Decisions
+
+- **Schema home = predict-local now, upstream later.** The load-bearing contract
+  (`ModelRef`, the `Provenance`/`BlobRef` fields) already lives in `sleap-roots-contracts`.
+  The only un-promoted shapes are the per-scan envelope and a "partial `BlobRef`" (predict
+  has no location yet; `BlobRef`'s validator rejects a location-less object). A3-traits (the
+  reader) does not exist yet, so freezing a shared type now risks freezing it wrong;
+  migrating later moves one wrapper class. Reuse `ModelRef` from contracts inside the
+  predict-local manifest.
+  - *Alternative:* add the schema to `sleap-roots-contracts` now — rejected: coordinated
+    multi-repo release + pin bump to freeze a shape with no live consumer.
+- **One combined per-scan JSON** (`{scan_key}.predictions.json`), not two files — atomic;
+  traits reads one file per scan. `predict_models` is derived by traits as
+  `[a.model for a in artifacts]` (single source of truth in-file, no duplication).
+- **Thin standalone writer** on top of `predict()`; `WarmModelWorker` untouched.
+- **Fail-soft build identity** (explicit arg → env → `""`): the writer only records two
+  strings; how they are stamped into the image is a deployment concern.
+- **Batch = first-class now.** Warmth already lives in `WarmModelWorker` (predictors cached
+  by `(registry_id, version)`). `predict_and_write_batch` drives one worker over N scans,
+  one subdir per scan. No run-level aggregate manifest (YAGNI; additive later).
+- **Filenames:** `{scan_key}.model{model_id}.root{primary|lateral|crown}.slp` matches
+  `load_series_from_h5s`. `series_name = filename.split(".")[0]`, so `scan_key` and
+  `model_id` must be dot-free: `model_id = slugify(f"{registry_id}_{version}")` (non
+  `[A-Za-z0-9-]` → `-`); `scan_key` is identity and is rejected (not mangled) if unsafe.
+
+## Risks / Trade-offs
+
+- **`sleap-roots` co-resolution (checked, not a conflict):** `sleap-roots` needs
+  `sleap-io>=0.0.11` (open upper) and no `sleap-nn`; sleap-nn 0.3.0 pins
+  `sleap-io>=0.8.0,<0.9.0`; env resolves to 0.8.0 → satisfies both. Mitigation: first TDD
+  task confirms the `dev` env resolves; the acceptance test uses
+  `pytest.importorskip("sleap_roots")` and never loosens the inference pin.
+- **Predict-local schema drift vs traits:** mitigated by `schema_version` on the manifest
+  and by co-designing the shape with A3-traits before promotion to contracts.
+
+## Migration Plan
+
+Additive: new module + new capability + a test-only dep. No behavior change to existing
+capabilities. Promotion of the manifest schema to `sleap-roots-contracts` is a future,
+separately-versioned step once A3-traits consumes it.
+
+## Open Questions
+
+- None blocking. Promotion timing to `sleap-roots-contracts` is deferred to the A3-traits
+  work (design decision 1).

--- a/openspec/changes/add-predict-output-contract/design.md
+++ b/openspec/changes/add-predict-output-contract/design.md
@@ -35,10 +35,16 @@ one run-level `predictions.csv`, no provenance).
 - **Batch = first-class now.** Warmth already lives in `WarmModelWorker` (predictors cached
   by `(registry_id, version)`). `predict_and_write_batch` drives one worker over N scans,
   one subdir per scan. No run-level aggregate manifest (YAGNI; additive later).
-- **Filenames:** `{scan_key}.model{model_id}.root{primary|lateral|crown}.slp` matches
+- **Filenames & paths (lab convention: `pathlib.Path` + `.as_posix()`):**
+  `{scan_key}.model{model_id}.root{primary|lateral|crown}.slp` matches
   `load_series_from_h5s`. `series_name = filename.split(".")[0]`, so `scan_key` and
   `model_id` must be dot-free: `model_id = slugify(f"{registry_id}_{version}")` (non
-  `[A-Za-z0-9-]` → `-`); `scan_key` is identity and is rejected (not mangled) if unsafe.
+  `[A-Za-z0-9-]` → `-`); `scan_key` is identity and is **rejected** (not mangled) if empty
+  or containing `. / \ : * ? " < > |` or a control char (safe as a single path segment on
+  POSIX + Windows). All path handling uses `pathlib.Path`; path strings (`slp_path`, and
+  paths passed across the sleap-io / sleap-roots boundary) are emitted via
+  `Path.as_posix()` so the manifest is portable. Re-running a scan overwrites its outputs
+  in place (idempotent).
 
 ## Risks / Trade-offs
 
@@ -47,6 +53,10 @@ one run-level `predictions.csv`, no provenance).
   `sleap-io>=0.8.0,<0.9.0`; env resolves to 0.8.0 → satisfies both. Mitigation: first TDD
   task confirms the `dev` env resolves; the acceptance test uses
   `pytest.importorskip("sleap_roots")` and never loosens the inference pin.
+- **Lockfile / 3-OS resolution:** adding `sleap-roots` to `dev` requires `uv lock` +
+  committing `uv.lock`. Mitigation: push the deps-only commit first so CI proves
+  resolution on ubuntu/windows/macos before code lands; review the lock diff to confirm no
+  `cpu`-closure pin moved (esp. `sleap-io` 0.8.0, torch/torchvision).
 - **Predict-local schema drift vs traits:** mitigated by `schema_version` on the manifest
   and by co-designing the shape with A3-traits before promotion to contracts.
 

--- a/openspec/changes/add-predict-output-contract/proposal.md
+++ b/openspec/changes/add-predict-output-contract/proposal.md
@@ -34,8 +34,9 @@ raw-`.slp` `save_dir` behavior and its tests are untouched.
 - Affected specs: **prediction-output** (new capability; ADDED requirements only).
 - Affected code: new `sleap_roots_predict/output_contract.py`; `__init__.py` (exports);
   `pyproject.toml` (`dev` extra gains `sleap-roots`) + regenerated `uv.lock`; new
-  `tests/test_output_contract.py`; docs (`CLAUDE.md`, `README.md`, `API.md`,
-  `CHANGELOG.md`, and the `openspec/project.md` roadmap note).
+  `tests/test_output_contract.py`; docs (`README.md`, `API.md`, `CHANGELOG.md`, and the
+  `openspec/project.md` roadmap note). `CLAUDE.md` is intentionally excluded — its drift
+  from the specs is tracked separately in talmolab/sleap-roots-predict#15.
 - Downstream: unblocks A3-traits' `Provenance`/`BlobRef` assembly and `Series` loading.
   Schema is predict-local now; promote to `sleap-roots-contracts` when A3-traits consumes
   it (design decision 1).

--- a/openspec/changes/add-predict-output-contract/proposal.md
+++ b/openspec/changes/add-predict-output-contract/proposal.md
@@ -33,7 +33,9 @@ raw-`.slp` `save_dir` behavior and its tests are untouched.
 
 - Affected specs: **prediction-output** (new capability; ADDED requirements only).
 - Affected code: new `sleap_roots_predict/output_contract.py`; `__init__.py` (exports);
-  `pyproject.toml` (`dev` extra gains `sleap-roots`); new `tests/test_output_contract.py`.
+  `pyproject.toml` (`dev` extra gains `sleap-roots`) + regenerated `uv.lock`; new
+  `tests/test_output_contract.py`; docs (`CLAUDE.md`, `README.md`, `API.md`,
+  `CHANGELOG.md`, and the `openspec/project.md` roadmap note).
 - Downstream: unblocks A3-traits' `Provenance`/`BlobRef` assembly and `Series` loading.
   Schema is predict-local now; promote to `sleap-roots-contracts` when A3-traits consumes
   it (design decision 1).

--- a/openspec/changes/add-predict-output-contract/proposal.md
+++ b/openspec/changes/add-predict-output-contract/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+`WarmModelWorker.predict(save_dir=…)` currently writes only raw `save_dir/<root_type>.slp`
+— no scan-aware naming, no manifest, no provenance. The downstream traits stage
+(sleap-roots / A3-traits) needs a stable **output contract** to load predictions and
+assemble a `ResultEnvelope`. This is the deferred task 9.3 slice from the archived
+`add-warm-model-worker` change, and the predict→traits handoff on the A4 DAG
+(`images-downloader → predict(warm) → traits → write-back`).
+
+## What Changes
+
+- Add a `prediction-output` capability: the on-disk artifacts predict writes per scan.
+- New module `sleap_roots_predict/output_contract.py` with:
+  - `PredictionArtifact` / `PredictionManifest` pydantic models (predict-local schema;
+    reuse `ModelRef` from `sleap-roots-contracts`).
+  - `write_prediction_outputs(...)` — pure per-scan writer: named per-root `.slp`
+    (`{scan_key}.model{model_id}.root{root_type}.slp`, sleap-roots `Series`-compatible)
+    plus a single combined `{scan_key}.predictions.json` (manifest + predict-side
+    provenance: resolved `ModelRef`s, inference config, output params, code sha /
+    container digest, and per-`.slp` checksum + file_size).
+  - `ScanRequest` + `predict_and_write_batch(...)` — drive one warm worker over N scans
+    (residents reused), one output subdirectory per scan.
+- Fail-soft build identity: `predict_code_sha` / `predict_container_digest` from explicit
+  arg → env (`SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST`) → `""`.
+- Add `sleap-roots` as a **test-only** dependency (`dev` extra) for the real acceptance
+  test (`Series.load`); predict does **not** runtime-depend on it (no cycle).
+- Export the new public API from `sleap_roots_predict/__init__.py`.
+
+Non-breaking: `WarmModelWorker` is unchanged (the writer sits on top of it); the existing
+raw-`.slp` `save_dir` behavior and its tests are untouched.
+
+## Impact
+
+- Affected specs: **prediction-output** (new capability; ADDED requirements only).
+- Affected code: new `sleap_roots_predict/output_contract.py`; `__init__.py` (exports);
+  `pyproject.toml` (`dev` extra gains `sleap-roots`); new `tests/test_output_contract.py`.
+- Downstream: unblocks A3-traits' `Provenance`/`BlobRef` assembly and `Series` loading.
+  Schema is predict-local now; promote to `sleap-roots-contracts` when A3-traits consumes
+  it (design decision 1).
+- Out of scope: upload/`BlobRef` locations (A4 step G), full `Provenance`/`ResultEnvelope`
+  + `idempotency_key` (traits), `InputRef`/`images_checksum` (upstream), plant-metadata CSV
+  (upstream), the serving entrypoint, and the Dockerfile build-stamp wiring.

--- a/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
+++ b/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
@@ -3,14 +3,17 @@
 ### Requirement: Named per-root prediction files
 
 The system SHALL write one `.slp` file per predicted root type named
-`{scan_key}.model{model_id}.root{root_type}.slp`, matching the sleap-roots `Series`
-naming convention (`load_series_from_h5s`: no underscores, `root` concatenated with the
-type). `model_id` SHALL be a filename-safe slug derived from the model's `registry_id`
-and `version` with every character outside `[A-Za-z0-9-]` replaced by `-` (so it is
-slash- and dot-free). `scan_key` is identity and SHALL NOT be mangled: the writer SHALL
-raise `ValueError` when `scan_key` is empty or contains any of `.` `/` `\` `:` `*` `?`
-`"` `<` `>` `|` or a control character (so the value is safe as a single path segment on
-both POSIX and Windows and preserves the `series_name = filename.split(".")[0]`
+`{scan_key}.model{model_id}.root{root_type}.slp`, following the sleap-roots `Series`
+filename convention (no underscores; `root` concatenated with the type). Because a scan's
+root types may resolve to *different* models (distinct `model_id` slugs), the robust load
+path is `Series.load` with the explicit per-root paths from the manifest — not the
+single-`model_id` directory scanner `load_series_from_h5s`. `model_id` SHALL be a
+filename-safe slug derived from the model's `registry_id` and `version` with every
+character outside `[A-Za-z0-9-]` replaced by `-` (so it is slash- and dot-free).
+`scan_key` is identity and SHALL NOT be mangled: the writer SHALL raise `ValueError` when
+`scan_key` is empty or contains any of `.` `/` `\` `:` `*` `?` `"` `<` `>` `|`, a control
+character, or leading/trailing whitespace (so the value is safe as a single path segment
+on both POSIX and Windows and preserves the `series_name = filename.split(".")[0]`
 invariant). Each written `.slp` SHALL be reloadable via `sio.load_file`.
 
 #### Scenario: Writes a reloadable named .slp per root type
@@ -23,7 +26,8 @@ invariant). Each written `.slp` SHALL be reloadable via `sio.load_file`.
 #### Scenario: Rejects a non-filename-safe scan_key
 
 - **WHEN** the writer is called with a `scan_key` that is empty or contains a reserved
-  character (`.`, a path separator, `:`, `*`, `?`, `"`, `<`, `>`, `|`, or a control char)
+  character (`.`, a path separator, `:`, `*`, `?`, `"`, `<`, `>`, `|`, a control char, or
+  leading/trailing whitespace)
 - **THEN** it raises `ValueError` and writes no files
 
 ### Requirement: Combined per-scan manifest and provenance sidecar
@@ -98,7 +102,9 @@ predict_container_digest=None)` that writes the named `.slp` files and the combi
 into `out_dir` (creating it if missing) and returns the resulting `PredictionManifest`.
 It SHALL raise `ValueError` when `labels_by_root` and `refs_by_root` do not cover the same
 set of root types. Re-running for the same `scan_key` into the same `out_dir` SHALL
-overwrite prior outputs in place (idempotent re-run). The writer SHALL use `pathlib.Path`
+overwrite prior outputs in place: the manifest is replaced and any prior `.slp` for that
+`scan_key` (matched by the `{scan_key}.model…` prefix) is removed first, so a changed
+`model_id` slug does not leave orphaned files. The writer SHALL use `pathlib.Path`
 for path handling and emit path strings — `slp_path` and any path passed across the
 sleap-io / sleap-roots boundary — via `Path.as_posix()` (lab convention; keeps the
 manifest portable across POSIX and Windows). It SHALL NOT import or depend on
@@ -122,6 +128,12 @@ manifest portable across POSIX and Windows). It SHALL NOT import or depend on
   manifest and `.slp` files for the same `scan_key`
 - **THEN** it overwrites them in place and the reloaded manifest reflects the new run
 
+#### Scenario: A changed model on re-run does not orphan the prior .slp
+
+- **WHEN** a scan is re-run with a different model for a root type (a new `model_id` slug)
+- **THEN** the prior `.slp` for that `scan_key` is removed, leaving only the current run's
+  files
+
 ### Requirement: Batch prediction-and-write over a warm worker
 
 The system SHALL provide `predict_and_write_batch(worker, requests, out_dir, *,
@@ -129,7 +141,9 @@ predict_code_sha=None, predict_container_digest=None)` that drives a single
 `WarmModelWorker` over an iterable of `ScanRequest`s, writing one output subdirectory per
 scan (`out_dir/{scan_key}/`), reusing the worker's resident `Predictor`s across scans, and
 returning one `PredictionManifest` per scan. A `ScanRequest` SHALL carry `scan_key`,
-`video`, `params`, and optional `plant_qr_code` and `overrides`.
+`video`, `params`, and optional `plant_qr_code` and `overrides`. It SHALL raise
+`ValueError` if two requests share a `scan_key` (which would otherwise silently overwrite
+a scan's subdirectory).
 
 #### Scenario: Batch writes one subdirectory of artifacts per scan
 
@@ -148,6 +162,11 @@ returning one `PredictionManifest` per scan. A `ScanRequest` SHALL carry `scan_k
 - **WHEN** a `ScanRequest` carries an explicit `overrides` mapping a root type to a
   `ModelRef`
 - **THEN** that scan's manifest records the overridden `ModelRef` for that root type
+
+#### Scenario: Duplicate scan_key in a batch is rejected
+
+- **WHEN** `predict_and_write_batch` is given two `ScanRequest`s with the same `scan_key`
+- **THEN** it raises `ValueError`
 
 ### Requirement: Series-loadable output verified without mocks
 

--- a/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
+++ b/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
@@ -8,8 +8,10 @@ naming convention (`load_series_from_h5s`: no underscores, `root` concatenated w
 type). `model_id` SHALL be a filename-safe slug derived from the model's `registry_id`
 and `version` with every character outside `[A-Za-z0-9-]` replaced by `-` (so it is
 slash- and dot-free). `scan_key` is identity and SHALL NOT be mangled: the writer SHALL
-raise `ValueError` when `scan_key` is empty or contains `.`, `/`, or `\`. Each written
-`.slp` SHALL be reloadable via `sio.load_file`.
+raise `ValueError` when `scan_key` is empty or contains any of `.` `/` `\` `:` `*` `?`
+`"` `<` `>` `|` or a control character (so the value is safe as a single path segment on
+both POSIX and Windows and preserves the `series_name = filename.split(".")[0]`
+invariant). Each written `.slp` SHALL be reloadable via `sio.load_file`.
 
 #### Scenario: Writes a reloadable named .slp per root type
 
@@ -20,7 +22,8 @@ raise `ValueError` when `scan_key` is empty or contains `.`, `/`, or `\`. Each w
 
 #### Scenario: Rejects a non-filename-safe scan_key
 
-- **WHEN** the writer is called with a `scan_key` containing `.` or a path separator
+- **WHEN** the writer is called with a `scan_key` that is empty or contains a reserved
+  character (`.`, a path separator, `:`, `*`, `?`, `"`, `<`, `>`, `|`, or a control char)
 - **THEN** it raises `ValueError` and writes no files
 
 ### Requirement: Combined per-scan manifest and provenance sidecar
@@ -29,8 +32,9 @@ The system SHALL write a single `{scan_key}.predictions.json` per scan that seri
 `PredictionManifest`: `schema_version`, `scan_key`, `plant_qr_code` (defaulting to
 `scan_key` when not given), and a list of per-root `PredictionArtifact` records. Each
 `PredictionArtifact` SHALL carry `root_type`, `model_id`, the full `ModelRef` (from
-`sleap-roots-contracts`), `slp_path` (the basename, relative to the manifest's
-directory), `checksum` (sha256 hex of the `.slp`), and `file_size` (bytes). The manifest
+`sleap-roots-contracts`), `slp_path` (the basename as a POSIX-style string via
+`Path.as_posix()`, relative to the manifest's directory), `checksum` (sha256 hex of the
+`.slp`), and `file_size` (bytes). The manifest
 SHALL also record the predict-side provenance: `predict_inference_config`,
 `predict_output_params`, `predict_code_sha`, and `predict_container_digest`. The written
 JSON SHALL reload and validate back into an equivalent `PredictionManifest`. When no root
@@ -55,7 +59,14 @@ types are resolved, `artifacts` SHALL be an empty list.
 - **WHEN** the writer runs for a scan where no root type resolved to a model
 - **THEN** it still writes `{scan_key}.predictions.json` with `artifacts` equal to `[]`
 
-### Requirement: Fail-soft build and runtime identity
+#### Scenario: Manifest JSON round-trips to an equivalent model
+
+- **WHEN** the written `{scan_key}.predictions.json` is read back and validated into a
+  `PredictionManifest`
+- **THEN** it equals the manifest the writer returned (all fields, including each
+  artifact's `ModelRef`)
+
+### Requirement: Fail-soft build identity
 
 The writer SHALL record `predict_code_sha` and `predict_container_digest` from explicit
 arguments when provided, otherwise from the environment variables `SRP_PREDICT_CODE_SHA`
@@ -86,7 +97,12 @@ plant_qr_code=None, inference_config, output_params, predict_code_sha=None,
 predict_container_digest=None)` that writes the named `.slp` files and the combined JSON
 into `out_dir` (creating it if missing) and returns the resulting `PredictionManifest`.
 It SHALL raise `ValueError` when `labels_by_root` and `refs_by_root` do not cover the same
-set of root types. It SHALL NOT import or depend on `sleap-roots` at runtime.
+set of root types. Re-running for the same `scan_key` into the same `out_dir` SHALL
+overwrite prior outputs in place (idempotent re-run). The writer SHALL use `pathlib.Path`
+for path handling and emit path strings — `slp_path` and any path passed across the
+sleap-io / sleap-roots boundary — via `Path.as_posix()` (lab convention; keeps the
+manifest portable across POSIX and Windows). It SHALL NOT import or depend on
+`sleap-roots` at runtime.
 
 #### Scenario: Writer returns a manifest and writes the artifacts
 
@@ -99,6 +115,12 @@ set of root types. It SHALL NOT import or depend on `sleap-roots` at runtime.
 
 - **WHEN** `labels_by_root` and `refs_by_root` cover different root types
 - **THEN** the writer raises `ValueError`
+
+#### Scenario: Re-running overwrites prior outputs in place
+
+- **WHEN** `write_prediction_outputs` runs into an `out_dir` that already holds a prior
+  manifest and `.slp` files for the same `scan_key`
+- **THEN** it overwrites them in place and the reloaded manifest reflects the new run
 
 ### Requirement: Batch prediction-and-write over a warm worker
 
@@ -121,20 +143,30 @@ returning one `PredictionManifest` per scan. A `ScanRequest` SHALL carry `scan_k
 - **THEN** the second scan reuses the resident `Predictor` instance loaded for the first
   (verified by object identity), rather than reloading it
 
+#### Scenario: Per-scan override is honored
+
+- **WHEN** a `ScanRequest` carries an explicit `overrides` mapping a root type to a
+  `ModelRef`
+- **THEN** that scan's manifest records the overridden `ModelRef` for that root type
+
 ### Requirement: Series-loadable output verified without mocks
 
 The produced artifacts SHALL load through the downstream consumer
-`sleap_roots.Series.load(series_name=scan_key, primary_path=…, lateral_path=…,
-crown_path=…)` without error and expose the predicted labels. This SHALL be verified by a
-real, non-mocked test that drives the warm worker over the vendored native + legacy
-models (no mocking of the sleap-nn / sleap-io boundary). `sleap-roots` SHALL be a
-test-only dependency and the test SHALL skip cleanly when it is not importable.
+`sleap_roots.Series.load(series_name=scan_key, ...)`, passing each resolved root type's
+`.slp` path (e.g. `primary_path` / `lateral_path`; `crown_path` is `None` when no crown
+model resolved) as a `Path.as_posix()` string, without error and expose the predicted
+labels for the resolved root types. This SHALL be verified by a real, non-mocked test that
+drives the warm worker over the vendored native + legacy models (no mocking of the
+sleap-nn / sleap-io boundary). `sleap-roots` SHALL be a test-only dependency and the test
+SHALL skip cleanly when it is not importable.
 
 #### Scenario: Output loads via sleap-roots Series.load
 
 - **WHEN** the writer's output for a scan is passed to `sleap_roots.Series.load` with the
-  per-root `.slp` paths
-- **THEN** the `Series` loads without error and its per-root labels are populated
+  resolved root types' `.slp` paths (primary and lateral for the vendored models;
+  `crown_path=None`)
+- **THEN** the `Series` loads without error and its `primary_labels` / `lateral_labels`
+  are populated
 
 #### Scenario: Acceptance test skips cleanly without sleap-roots
 

--- a/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
+++ b/openspec/changes/add-predict-output-contract/specs/prediction-output/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Named per-root prediction files
+
+The system SHALL write one `.slp` file per predicted root type named
+`{scan_key}.model{model_id}.root{root_type}.slp`, matching the sleap-roots `Series`
+naming convention (`load_series_from_h5s`: no underscores, `root` concatenated with the
+type). `model_id` SHALL be a filename-safe slug derived from the model's `registry_id`
+and `version` with every character outside `[A-Za-z0-9-]` replaced by `-` (so it is
+slash- and dot-free). `scan_key` is identity and SHALL NOT be mangled: the writer SHALL
+raise `ValueError` when `scan_key` is empty or contains `.`, `/`, or `\`. Each written
+`.slp` SHALL be reloadable via `sio.load_file`.
+
+#### Scenario: Writes a reloadable named .slp per root type
+
+- **WHEN** the writer runs for a scan whose worker resolved `primary` and `lateral` models
+- **THEN** it writes `{scan_key}.model{model_id}.rootprimary.slp` and
+  `{scan_key}.model{model_id}.rootlateral.slp`, each reloadable via `sio.load_file` with
+  labeled frames
+
+#### Scenario: Rejects a non-filename-safe scan_key
+
+- **WHEN** the writer is called with a `scan_key` containing `.` or a path separator
+- **THEN** it raises `ValueError` and writes no files
+
+### Requirement: Combined per-scan manifest and provenance sidecar
+
+The system SHALL write a single `{scan_key}.predictions.json` per scan that serializes a
+`PredictionManifest`: `schema_version`, `scan_key`, `plant_qr_code` (defaulting to
+`scan_key` when not given), and a list of per-root `PredictionArtifact` records. Each
+`PredictionArtifact` SHALL carry `root_type`, `model_id`, the full `ModelRef` (from
+`sleap-roots-contracts`), `slp_path` (the basename, relative to the manifest's
+directory), `checksum` (sha256 hex of the `.slp`), and `file_size` (bytes). The manifest
+SHALL also record the predict-side provenance: `predict_inference_config`,
+`predict_output_params`, `predict_code_sha`, and `predict_container_digest`. The written
+JSON SHALL reload and validate back into an equivalent `PredictionManifest`. When no root
+types are resolved, `artifacts` SHALL be an empty list.
+
+#### Scenario: Manifest maps each root type to its file, model_id, and full ModelRef
+
+- **WHEN** the writer runs for a scan with resolved `primary` and `lateral` models
+- **THEN** `{scan_key}.predictions.json` contains one artifact per root type whose
+  `slp_path` basename matches the written `.slp`, whose `model_id` matches the filename
+  slug, and whose `model` round-trips to the resolved `ModelRef`
+
+#### Scenario: Checksums and sizes match the written files
+
+- **WHEN** the manifest is reloaded and each artifact's `checksum`/`file_size` is compared
+  to the on-disk `.slp`
+- **THEN** each `checksum` equals the file's recomputed sha256 hex and each `file_size`
+  equals the file's byte length
+
+#### Scenario: Zero resolved roots yields an empty artifacts list
+
+- **WHEN** the writer runs for a scan where no root type resolved to a model
+- **THEN** it still writes `{scan_key}.predictions.json` with `artifacts` equal to `[]`
+
+### Requirement: Fail-soft build and runtime identity
+
+The writer SHALL record `predict_code_sha` and `predict_container_digest` from explicit
+arguments when provided, otherwise from the environment variables `SRP_PREDICT_CODE_SHA`
+and `SRP_PREDICT_CONTAINER_DIGEST`, otherwise the empty string. It SHALL NOT raise when
+these are absent.
+
+#### Scenario: Explicit argument takes precedence
+
+- **WHEN** `write_prediction_outputs` is called with an explicit `predict_code_sha`
+- **THEN** the manifest records that exact value regardless of the environment
+
+#### Scenario: Environment fallback
+
+- **WHEN** no `predict_container_digest` argument is given but
+  `SRP_PREDICT_CONTAINER_DIGEST` is set
+- **THEN** the manifest records the environment value
+
+#### Scenario: Absent identity records empty strings
+
+- **WHEN** neither the argument nor the environment variable is set
+- **THEN** the manifest records `""` for that field and no error is raised
+
+### Requirement: Pure per-scan writer API
+
+The system SHALL provide
+`write_prediction_outputs(labels_by_root, refs_by_root, out_dir, *, scan_key,
+plant_qr_code=None, inference_config, output_params, predict_code_sha=None,
+predict_container_digest=None)` that writes the named `.slp` files and the combined JSON
+into `out_dir` (creating it if missing) and returns the resulting `PredictionManifest`.
+It SHALL raise `ValueError` when `labels_by_root` and `refs_by_root` do not cover the same
+set of root types. It SHALL NOT import or depend on `sleap-roots` at runtime.
+
+#### Scenario: Writer returns a manifest and writes the artifacts
+
+- **WHEN** `write_prediction_outputs` is called with aligned `labels_by_root` and
+  `refs_by_root`
+- **THEN** it writes the per-root `.slp` files and `{scan_key}.predictions.json` into
+  `out_dir` and returns a `PredictionManifest` describing them
+
+#### Scenario: Mismatched label and ref root types raise
+
+- **WHEN** `labels_by_root` and `refs_by_root` cover different root types
+- **THEN** the writer raises `ValueError`
+
+### Requirement: Batch prediction-and-write over a warm worker
+
+The system SHALL provide `predict_and_write_batch(worker, requests, out_dir, *,
+predict_code_sha=None, predict_container_digest=None)` that drives a single
+`WarmModelWorker` over an iterable of `ScanRequest`s, writing one output subdirectory per
+scan (`out_dir/{scan_key}/`), reusing the worker's resident `Predictor`s across scans, and
+returning one `PredictionManifest` per scan. A `ScanRequest` SHALL carry `scan_key`,
+`video`, `params`, and optional `plant_qr_code` and `overrides`.
+
+#### Scenario: Batch writes one subdirectory of artifacts per scan
+
+- **WHEN** `predict_and_write_batch` runs over two `ScanRequest`s
+- **THEN** it creates `out_dir/{scan_key}/` for each scan containing that scan's `.slp`
+  files and `{scan_key}.predictions.json`, and returns a `PredictionManifest` per scan
+
+#### Scenario: Resident predictors are reused across scans
+
+- **WHEN** two scans in one batch resolve to the same model version
+- **THEN** the second scan reuses the resident `Predictor` instance loaded for the first
+  (verified by object identity), rather than reloading it
+
+### Requirement: Series-loadable output verified without mocks
+
+The produced artifacts SHALL load through the downstream consumer
+`sleap_roots.Series.load(series_name=scan_key, primary_path=…, lateral_path=…,
+crown_path=…)` without error and expose the predicted labels. This SHALL be verified by a
+real, non-mocked test that drives the warm worker over the vendored native + legacy
+models (no mocking of the sleap-nn / sleap-io boundary). `sleap-roots` SHALL be a
+test-only dependency and the test SHALL skip cleanly when it is not importable.
+
+#### Scenario: Output loads via sleap-roots Series.load
+
+- **WHEN** the writer's output for a scan is passed to `sleap_roots.Series.load` with the
+  per-root `.slp` paths
+- **THEN** the `Series` loads without error and its per-root labels are populated
+
+#### Scenario: Acceptance test skips cleanly without sleap-roots
+
+- **WHEN** the test suite runs in an environment where `sleap_roots` is not importable
+- **THEN** the `Series.load` test skips with a message rather than failing

--- a/openspec/changes/add-predict-output-contract/tasks.md
+++ b/openspec/changes/add-predict-output-contract/tasks.md
@@ -2,90 +2,146 @@
 
 TDD throughout: write the failing test first (red), implement the minimum to pass
 (green), then refactor. Run `/lint` + `/test` after each task. No mocks — drive the real
-warm worker over the vendored native + legacy models.
+warm worker over the vendored native + legacy models. Lab convention: use `pathlib.Path`
+for all path handling and emit path strings via `Path.as_posix()`.
 
-## 1. Test-only dependency + environment sanity
+## 1. Test-only dependency + lockfile
 
-- [ ] 1.1 Add `sleap-roots` to the `dev` extra in `pyproject.toml`. **Verify first:** run
-  `uv sync --extra dev --extra cpu` and confirm it resolves with `sleap-io==0.8.x`
-  (no downgrade of the sleap-nn pin). If it conflicts, stop and fall back to
+- [ ] 1.1 Add `sleap-roots` to the `dev` extra in `pyproject.toml` (decision: keep in
+  `dev` and run the acceptance test in CI). **Verify first:** run
+  `uv sync --extra dev --extra cpu` and confirm it resolves with `sleap-io==0.8.x` (no
+  downgrade of the sleap-nn pin, torch unchanged). If it conflicts, stop and fall back to
   `importorskip` + a documented compatible-env note (do NOT loosen the inference pin).
   - *Test:* `uv run python -c "import sleap_roots, sleap_io; print(sleap_io.__version__)"`
     imports both and prints an `0.8.x` version.
+- [ ] 1.2 Run `uv lock` and commit the updated `uv.lock`. **Review the diff:** confirm the
+  only changes are the additive `dev`-gated entries (`sleap-roots`, `scikit-image`,
+  `pywavelets`, `scikit-learn`) and that no `cpu`-closure pin moved — in particular
+  `sleap-io` stays `0.8.0` and `torch`/`torchvision` are unchanged. Push commit 1
+  (deps + lock) **alone first** so the CI matrix confirms 3-OS resolution before code is
+  built on top.
+  - *Verify:* CI green on ubuntu + windows + macos for the deps-only commit.
 
 ## 2. Schema models (`PredictionArtifact`, `PredictionManifest`)
 
 - [ ] 2.1 Add `sleap_roots_predict/output_contract.py` with the two pydantic models,
   reusing `ModelRef` from `sleap-roots-contracts`.
   - *Test (red first):* `tests/test_output_contract.py::test_manifest_round_trips`
-    constructs a `PredictionManifest` (with a real `ModelRef`), dumps to JSON, reloads,
-    and asserts equality — verifies field set, `schema_version` default, and `ModelRef`
-    round-trip.
+    constructs a `PredictionManifest` (with a real `ModelRef`), dumps to JSON, reloads via
+    the model, and asserts equality — verifies field set, `schema_version` default, and
+    `ModelRef` round-trip.
   - *Test:* `test_plant_qr_code_defaults_to_scan_key` verifies the default.
 
 ## 3. `model_id` slug + `scan_key` validation helpers
 
 - [ ] 3.1 Implement `slugify_model_id(ref)` (non-`[A-Za-z0-9-]` → `-`, dot/slash-free) and
-  `scan_key` filename-safety validation.
+  `scan_key` filename-safety validation (reject empty or any of `. / \ : * ? " < > |` or a
+  control character).
   - *Test (red first):* `test_model_id_slug_is_filename_safe` asserts a `registry_id`
     with `/` and `.` produces a slug with neither; `test_rejects_unsafe_scan_key`
-    (parametrized over `.`, `/`, `\`, empty) asserts `ValueError`.
+    (parametrized over `.`, `/`, `\`, `:`, `*`, a control char, and empty) asserts
+    `ValueError`; `test_accepts_normal_scan_key` asserts an alnum/`_`/`-` key is accepted.
 
 ## 4. Pure writer `write_prediction_outputs`
 
-- [ ] 4.1 Implement the writer: validate `set(labels_by_root) == set(refs_by_root)`;
-  create `out_dir`; per root write `{scan_key}.model{slug}.root{root_type}.slp`, compute
-  sha256 + size; build + write `{scan_key}.predictions.json`; return the manifest.
+- [ ] 4.1 Implement the writer: validate `set(labels_by_root) == set(refs_by_root)` and
+  `scan_key` safety; create `out_dir` (`Path`); per root write
+  `{scan_key}.model{slug}.root{root_type}.slp`, compute sha256 + size; build + write
+  `{scan_key}.predictions.json`; thread `predict_code_sha`/`predict_container_digest`
+  through (see task 5); store `slp_path` as a `Path.as_posix()` basename; return the
+  manifest. Re-runs overwrite in place.
   - *Test (red first):* `test_writer_writes_named_slp_and_manifest` drives the warm worker
     (`rice_source` + `video` fixtures) to real labels + refs, calls the writer, and
     asserts the named `.slp` reload via `sio.load_file` with frames and the manifest maps
     root → path/model_id/`ModelRef`.
+  - *Test:* `test_slp_path_is_relocatable_basename` asserts each `slp_path` is not absolute,
+    contains no separator, equals the bare `{scan_key}.model{slug}.root{rt}.slp`, and
+    `manifest_dir / slp_path` exists.
+  - *Test:* `test_writer_covers_all_root_types` uses a source with primary=native,
+    lateral=legacy, crown=native (reuse) so the `root{crown}` filename + manifest branch is
+    exercised (all three `RootType` literals).
+  - *Test:* `test_manifest_json_on_disk_round_trips` reloads the written JSON file and
+    validates it equals the returned manifest.
   - *Test:* `test_checksums_and_sizes_match_files` recomputes sha256/size and compares.
   - *Test:* `test_mismatched_labels_and_refs_raise` asserts `ValueError`.
   - *Test:* `test_zero_roots_writes_empty_artifacts` asserts `artifacts == []` and the JSON
     is still written.
+  - *Test:* `test_rerun_overwrites_in_place` writes once, writes again into the same
+    `out_dir`/`scan_key`, and asserts the reloaded manifest reflects the second run.
+  - *Test:* `test_writer_does_not_import_sleap_roots` imports
+    `sleap_roots_predict.output_contract` and asserts `"sleap_roots" not in sys.modules`
+    (runtime-purity guard).
+  - *Test:* `test_plant_qr_code_recorded_verbatim` asserts an explicit `plant_qr_code` is
+    stored as-is (non-default path).
 
 ## 5. Fail-soft build identity
 
 - [ ] 5.1 Implement the explicit-arg → env → `""` precedence for `predict_code_sha` /
-  `predict_container_digest`.
+  `predict_container_digest` (helper used by the writer in task 4).
   - *Test (red first):* `test_build_identity_explicit_arg_wins`,
-    `test_build_identity_env_fallback` (uses `monkeypatch.setenv`), and
+    `test_build_identity_env_fallback` (uses `monkeypatch.setenv` on
+    `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST`), and
     `test_build_identity_absent_is_empty_string` (asserts `""`, no raise).
 
 ## 6. `ScanRequest` + batch `predict_and_write_batch`
 
 - [ ] 6.1 Add the `ScanRequest` dataclass and `predict_and_write_batch` (one warm worker,
-  one subdir per scan, `resolve`+`predict`+`write` per scan, return `list[...]`).
+  one subdir per scan `out_dir/{scan_key}/`, `resolve`+`predict`+`write` per scan using the
+  worker's `inference_config()`/`output_params()`, return `list[PredictionManifest]`).
   - *Test (red first):* `test_batch_writes_per_scan_subdirs` runs two scans and asserts
     `out_dir/{scan_key}/` exists per scan with its `.slp` + `.predictions.json`.
   - *Test:* `test_batch_reuses_resident_predictors` asserts the second scan reuses the
     first scan's `Predictor` instance by object identity (warmth).
+  - *Test:* `test_batch_respects_overrides` passes a `ScanRequest.overrides` mapping a root
+    type to an explicit `ModelRef` and asserts that scan's manifest records it.
 
-## 7. Downstream acceptance — `sleap_roots.Series.load`
+## 7. Downstream acceptance — `sleap_roots.Series.load` (runs in CI)
 
 - [ ] 7.1 Add the real acceptance test loading the writer's output via `Series.load`.
+  Spike it locally first to confirm `Series.load` accepts the vendored skeleton before
+  finalizing assertions.
   - *Test (red first):* `test_output_loads_via_sleap_roots_series` uses
-    `pytest.importorskip("sleap_roots")`, writes a scan's artifacts, calls
-    `Series.load(series_name=scan_key, primary_path=…, lateral_path=…, crown_path=…)`, and
-    asserts it loads without error and the per-root labels are populated.
+    `pytest.importorskip("sleap_roots")` (belt-and-suspenders; in CI `sleap-roots` is
+    installed so it executes), writes a scan's artifacts, calls
+    `Series.load(series_name=scan_key, primary_path=<as_posix>, lateral_path=<as_posix>,
+    crown_path=None)`, and asserts it loads without error and `primary_labels` /
+    `lateral_labels` are populated. (No crown model is vendored → `crown_path=None`.)
 
-## 8. Public API + docs
+## 8. Public API + documentation
 
 - [ ] 8.1 Export `PredictionArtifact`, `PredictionManifest`, `ScanRequest`,
   `write_prediction_outputs`, `predict_and_write_batch` from
   `sleap_roots_predict/__init__.py`.
   - *Test (red first):* extend `tests/test_public_api.py` to assert the new names import
     from the package root.
-- [ ] 8.2 Update `CLAUDE.md` (module list + processing flow) and `README` if applicable to
-  describe the output contract.
+- [ ] 8.2 Documentation — explicit per-file checklist (single-source the artifact format in
+  the spec / `output_contract.py` docstrings; do NOT re-copy the filename grammar or JSON
+  field list into every doc):
+  - `CLAUDE.md`: add `output_contract.py` to the module list; add the output-contract to
+    the Processing Flow; add `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST` to the
+    "Runtime configuration (env)" section; add the 5 new names to the `__init__` export
+    list; **fix the now-stale line** ("`predict(save_dir=…)` writes raw per-root `.slp`
+    only … the `predictions.csv` manifest + scan-aware naming are a deferred
+    output-contract slice") to point at the new writer and say `predictions.json`.
+  - `README.md`: add `output_contract.py` to the Project Structure tree (one-line format
+    description only, referencing the spec/docstrings).
+  - `API.md`: document the 5 new public exports (or state the section is intentionally
+    partial and point to `__init__`).
+  - `CHANGELOG.md`: add an `### Added` entry under `[Unreleased]` (module + 5 exports + 2
+    env vars + test-only `sleap-roots` dev dep).
+  - `openspec/project.md`: surgically edit the Roadmap note (lines ~15-18) — strike the
+    "`predictions.csv` output contract + `.slp` naming" clause (done; it's `.json`), keep
+    serving/CLI, full `Provenance`/`ResultEnvelope`, and the parity harness as pending.
 
 ## 9. Gate
 
-- [ ] 9.1 `/lint` clean (black, ruff `D`, codespell) and `/test` green (default markers).
-- [ ] 9.2 Run the acceptance/`Series.load` test locally in a `dev` env with `sleap-roots`
-  installed to confirm the real downstream load passes.
-- [ ] 9.3 Mark all `tasks.md` items complete; ready `/pre-merge`.
+- [ ] 9.1 `/lint` clean (black, ruff `D`, codespell), `/test` green (default markers), and
+  `uv build` succeeds (sdist + wheel) — or confirm `/pre-merge` covers the build step.
+- [ ] 9.2 Confirm the `Series.load` acceptance test passes in a `dev` env with
+  `sleap-roots` installed (it runs in CI, and `/pre-merge` re-runs it locally).
+- [ ] 9.3 Run GPU tests locally (`uv run pytest -m gpu`) per the `/pre-merge` gate; they
+  skip cleanly with no accelerator.
+- [ ] 9.4 Mark all `tasks.md` items complete; ready `/pre-merge`.
 
 ## Post-merge (required, tracked separately)
 

--- a/openspec/changes/add-predict-output-contract/tasks.md
+++ b/openspec/changes/add-predict-output-contract/tasks.md
@@ -1,0 +1,94 @@
+# Tasks — add-predict-output-contract
+
+TDD throughout: write the failing test first (red), implement the minimum to pass
+(green), then refactor. Run `/lint` + `/test` after each task. No mocks — drive the real
+warm worker over the vendored native + legacy models.
+
+## 1. Test-only dependency + environment sanity
+
+- [ ] 1.1 Add `sleap-roots` to the `dev` extra in `pyproject.toml`. **Verify first:** run
+  `uv sync --extra dev --extra cpu` and confirm it resolves with `sleap-io==0.8.x`
+  (no downgrade of the sleap-nn pin). If it conflicts, stop and fall back to
+  `importorskip` + a documented compatible-env note (do NOT loosen the inference pin).
+  - *Test:* `uv run python -c "import sleap_roots, sleap_io; print(sleap_io.__version__)"`
+    imports both and prints an `0.8.x` version.
+
+## 2. Schema models (`PredictionArtifact`, `PredictionManifest`)
+
+- [ ] 2.1 Add `sleap_roots_predict/output_contract.py` with the two pydantic models,
+  reusing `ModelRef` from `sleap-roots-contracts`.
+  - *Test (red first):* `tests/test_output_contract.py::test_manifest_round_trips`
+    constructs a `PredictionManifest` (with a real `ModelRef`), dumps to JSON, reloads,
+    and asserts equality — verifies field set, `schema_version` default, and `ModelRef`
+    round-trip.
+  - *Test:* `test_plant_qr_code_defaults_to_scan_key` verifies the default.
+
+## 3. `model_id` slug + `scan_key` validation helpers
+
+- [ ] 3.1 Implement `slugify_model_id(ref)` (non-`[A-Za-z0-9-]` → `-`, dot/slash-free) and
+  `scan_key` filename-safety validation.
+  - *Test (red first):* `test_model_id_slug_is_filename_safe` asserts a `registry_id`
+    with `/` and `.` produces a slug with neither; `test_rejects_unsafe_scan_key`
+    (parametrized over `.`, `/`, `\`, empty) asserts `ValueError`.
+
+## 4. Pure writer `write_prediction_outputs`
+
+- [ ] 4.1 Implement the writer: validate `set(labels_by_root) == set(refs_by_root)`;
+  create `out_dir`; per root write `{scan_key}.model{slug}.root{root_type}.slp`, compute
+  sha256 + size; build + write `{scan_key}.predictions.json`; return the manifest.
+  - *Test (red first):* `test_writer_writes_named_slp_and_manifest` drives the warm worker
+    (`rice_source` + `video` fixtures) to real labels + refs, calls the writer, and
+    asserts the named `.slp` reload via `sio.load_file` with frames and the manifest maps
+    root → path/model_id/`ModelRef`.
+  - *Test:* `test_checksums_and_sizes_match_files` recomputes sha256/size and compares.
+  - *Test:* `test_mismatched_labels_and_refs_raise` asserts `ValueError`.
+  - *Test:* `test_zero_roots_writes_empty_artifacts` asserts `artifacts == []` and the JSON
+    is still written.
+
+## 5. Fail-soft build identity
+
+- [ ] 5.1 Implement the explicit-arg → env → `""` precedence for `predict_code_sha` /
+  `predict_container_digest`.
+  - *Test (red first):* `test_build_identity_explicit_arg_wins`,
+    `test_build_identity_env_fallback` (uses `monkeypatch.setenv`), and
+    `test_build_identity_absent_is_empty_string` (asserts `""`, no raise).
+
+## 6. `ScanRequest` + batch `predict_and_write_batch`
+
+- [ ] 6.1 Add the `ScanRequest` dataclass and `predict_and_write_batch` (one warm worker,
+  one subdir per scan, `resolve`+`predict`+`write` per scan, return `list[...]`).
+  - *Test (red first):* `test_batch_writes_per_scan_subdirs` runs two scans and asserts
+    `out_dir/{scan_key}/` exists per scan with its `.slp` + `.predictions.json`.
+  - *Test:* `test_batch_reuses_resident_predictors` asserts the second scan reuses the
+    first scan's `Predictor` instance by object identity (warmth).
+
+## 7. Downstream acceptance — `sleap_roots.Series.load`
+
+- [ ] 7.1 Add the real acceptance test loading the writer's output via `Series.load`.
+  - *Test (red first):* `test_output_loads_via_sleap_roots_series` uses
+    `pytest.importorskip("sleap_roots")`, writes a scan's artifacts, calls
+    `Series.load(series_name=scan_key, primary_path=…, lateral_path=…, crown_path=…)`, and
+    asserts it loads without error and the per-root labels are populated.
+
+## 8. Public API + docs
+
+- [ ] 8.1 Export `PredictionArtifact`, `PredictionManifest`, `ScanRequest`,
+  `write_prediction_outputs`, `predict_and_write_batch` from
+  `sleap_roots_predict/__init__.py`.
+  - *Test (red first):* extend `tests/test_public_api.py` to assert the new names import
+    from the package root.
+- [ ] 8.2 Update `CLAUDE.md` (module list + processing flow) and `README` if applicable to
+  describe the output contract.
+
+## 9. Gate
+
+- [ ] 9.1 `/lint` clean (black, ruff `D`, codespell) and `/test` green (default markers).
+- [ ] 9.2 Run the acceptance/`Series.load` test locally in a `dev` env with `sleap-roots`
+  installed to confirm the real downstream load passes.
+- [ ] 9.3 Mark all `tasks.md` items complete; ready `/pre-merge`.
+
+## Post-merge (required, tracked separately)
+
+- [ ] P.1 Update `sleap-roots-pipeline/docs/bloom-integration/roadmap.md` (A4 DAG): predict
+  output contract done → unblocks A3-traits input. Note the predict-local schema and its
+  future promotion to `sleap-roots-contracts`.

--- a/openspec/changes/add-predict-output-contract/tasks.md
+++ b/openspec/changes/add-predict-output-contract/tasks.md
@@ -117,12 +117,10 @@ for all path handling and emit path strings via `Path.as_posix()`.
 - [ ] 8.2 Documentation — explicit per-file checklist (single-source the artifact format in
   the spec / `output_contract.py` docstrings; do NOT re-copy the filename grammar or JSON
   field list into every doc):
-  - `CLAUDE.md`: add `output_contract.py` to the module list; add the output-contract to
-    the Processing Flow; add `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST` to the
-    "Runtime configuration (env)" section; add the 5 new names to the `__init__` export
-    list; **fix the now-stale line** ("`predict(save_dir=…)` writes raw per-root `.slp`
-    only … the `predictions.csv` manifest + scan-aware naming are a deferred
-    output-contract slice") to point at the new writer and say `predictions.json`.
+  - `CLAUDE.md`: **out of scope for this change** — deferred to
+    [talmolab/sleap-roots-predict#15](https://github.com/talmolab/sleap-roots-predict/issues/15)
+    (CLAUDE.md drifts from the OpenSpec specs; the stale `predictions.csv`/"deferred" line
+    + duplicated API list are handled holistically there, not patched piecemeal here).
   - `README.md`: add `output_contract.py` to the Project Structure tree (one-line format
     description only, referencing the spec/docstrings).
   - `API.md`: document the 5 new public exports (or state the section is intentionally

--- a/openspec/changes/add-predict-output-contract/tasks.md
+++ b/openspec/changes/add-predict-output-contract/tasks.md
@@ -7,14 +7,14 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 1. Test-only dependency + lockfile
 
-- [ ] 1.1 Add `sleap-roots` to the `dev` extra in `pyproject.toml` (decision: keep in
+- [x] 1.1 Add `sleap-roots` to the `dev` extra in `pyproject.toml` (decision: keep in
   `dev` and run the acceptance test in CI). **Verify first:** run
   `uv sync --extra dev --extra cpu` and confirm it resolves with `sleap-io==0.8.x` (no
   downgrade of the sleap-nn pin, torch unchanged). If it conflicts, stop and fall back to
   `importorskip` + a documented compatible-env note (do NOT loosen the inference pin).
   - *Test:* `uv run python -c "import sleap_roots, sleap_io; print(sleap_io.__version__)"`
     imports both and prints an `0.8.x` version.
-- [ ] 1.2 Run `uv lock` and commit the updated `uv.lock`. **Review the diff:** confirm the
+- [x] 1.2 Run `uv lock` and commit the updated `uv.lock`. **Review the diff:** confirm the
   only changes are the additive `dev`-gated entries (`sleap-roots`, `scikit-image`,
   `pywavelets`, `scikit-learn`) and that no `cpu`-closure pin moved — in particular
   `sleap-io` stays `0.8.0` and `torch`/`torchvision` are unchanged. Push commit 1
@@ -24,7 +24,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 2. Schema models (`PredictionArtifact`, `PredictionManifest`)
 
-- [ ] 2.1 Add `sleap_roots_predict/output_contract.py` with the two pydantic models,
+- [x] 2.1 Add `sleap_roots_predict/output_contract.py` with the two pydantic models,
   reusing `ModelRef` from `sleap-roots-contracts`.
   - *Test (red first):* `tests/test_output_contract.py::test_manifest_round_trips`
     constructs a `PredictionManifest` (with a real `ModelRef`), dumps to JSON, reloads via
@@ -34,7 +34,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 3. `model_id` slug + `scan_key` validation helpers
 
-- [ ] 3.1 Implement `slugify_model_id(ref)` (non-`[A-Za-z0-9-]` → `-`, dot/slash-free) and
+- [x] 3.1 Implement `slugify_model_id(ref)` (non-`[A-Za-z0-9-]` → `-`, dot/slash-free) and
   `scan_key` filename-safety validation (reject empty or any of `. / \ : * ? " < > |` or a
   control character).
   - *Test (red first):* `test_model_id_slug_is_filename_safe` asserts a `registry_id`
@@ -44,7 +44,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 4. Pure writer `write_prediction_outputs`
 
-- [ ] 4.1 Implement the writer: validate `set(labels_by_root) == set(refs_by_root)` and
+- [x] 4.1 Implement the writer: validate `set(labels_by_root) == set(refs_by_root)` and
   `scan_key` safety; create `out_dir` (`Path`); per root write
   `{scan_key}.model{slug}.root{root_type}.slp`, compute sha256 + size; build + write
   `{scan_key}.predictions.json`; thread `predict_code_sha`/`predict_container_digest`
@@ -76,7 +76,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 5. Fail-soft build identity
 
-- [ ] 5.1 Implement the explicit-arg → env → `""` precedence for `predict_code_sha` /
+- [x] 5.1 Implement the explicit-arg → env → `""` precedence for `predict_code_sha` /
   `predict_container_digest` (helper used by the writer in task 4).
   - *Test (red first):* `test_build_identity_explicit_arg_wins`,
     `test_build_identity_env_fallback` (uses `monkeypatch.setenv` on
@@ -85,7 +85,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 6. `ScanRequest` + batch `predict_and_write_batch`
 
-- [ ] 6.1 Add the `ScanRequest` dataclass and `predict_and_write_batch` (one warm worker,
+- [x] 6.1 Add the `ScanRequest` dataclass and `predict_and_write_batch` (one warm worker,
   one subdir per scan `out_dir/{scan_key}/`, `resolve`+`predict`+`write` per scan using the
   worker's `inference_config()`/`output_params()`, return `list[PredictionManifest]`).
   - *Test (red first):* `test_batch_writes_per_scan_subdirs` runs two scans and asserts
@@ -97,7 +97,7 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 7. Downstream acceptance — `sleap_roots.Series.load` (runs in CI)
 
-- [ ] 7.1 Add the real acceptance test loading the writer's output via `Series.load`.
+- [x] 7.1 Add the real acceptance test loading the writer's output via `Series.load`.
   Spike it locally first to confirm `Series.load` accepts the vendored skeleton before
   finalizing assertions.
   - *Test (red first):* `test_output_loads_via_sleap_roots_series` uses
@@ -109,12 +109,12 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 8. Public API + documentation
 
-- [ ] 8.1 Export `PredictionArtifact`, `PredictionManifest`, `ScanRequest`,
+- [x] 8.1 Export `PredictionArtifact`, `PredictionManifest`, `ScanRequest`,
   `write_prediction_outputs`, `predict_and_write_batch` from
   `sleap_roots_predict/__init__.py`.
   - *Test (red first):* extend `tests/test_public_api.py` to assert the new names import
     from the package root.
-- [ ] 8.2 Documentation — explicit per-file checklist (single-source the artifact format in
+- [x] 8.2 Documentation — explicit per-file checklist (single-source the artifact format in
   the spec / `output_contract.py` docstrings; do NOT re-copy the filename grammar or JSON
   field list into every doc):
   - `CLAUDE.md`: **out of scope for this change** — deferred to
@@ -133,13 +133,13 @@ for all path handling and emit path strings via `Path.as_posix()`.
 
 ## 9. Gate
 
-- [ ] 9.1 `/lint` clean (black, ruff `D`, codespell), `/test` green (default markers), and
+- [x] 9.1 `/lint` clean (black, ruff `D`, codespell), `/test` green (default markers), and
   `uv build` succeeds (sdist + wheel) — or confirm `/pre-merge` covers the build step.
-- [ ] 9.2 Confirm the `Series.load` acceptance test passes in a `dev` env with
+- [x] 9.2 Confirm the `Series.load` acceptance test passes in a `dev` env with
   `sleap-roots` installed (it runs in CI, and `/pre-merge` re-runs it locally).
-- [ ] 9.3 Run GPU tests locally (`uv run pytest -m gpu`) per the `/pre-merge` gate; they
+- [x] 9.3 Run GPU tests locally (`uv run pytest -m gpu`) per the `/pre-merge` gate; they
   skip cleanly with no accelerator.
-- [ ] 9.4 Mark all `tasks.md` items complete; ready `/pre-merge`.
+- [x] 9.4 Mark all `tasks.md` items complete; ready `/pre-merge`.
 
 ## Post-merge (required, tracked separately)
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -12,10 +12,12 @@ distribution artifact is a GHCR Docker image. A PyPI wheel is also published for
 importable library.
 
 > **Roadmap note:** tier **A3-predict** is landing. The inference core was rebuilt on the
-> sleap-nn 0.3.0 API (PR #6), and the warm in-memory model worker + wandb model-management
-> layer (the `model-management` capability) followed. Remaining A3/A4 work: the serving
-> protocol/CLI, the `predictions.csv` output contract + `.slp` naming, emitting
-> `Provenance`/`ResultEnvelope`, and the prediction-parity harness.
+> sleap-nn 0.3.0 API (PR #6), the warm in-memory model worker + wandb model-management
+> layer (the `model-management` capability) followed, and the predict **output contract**
+> (the `prediction-output` capability: named per-root `.slp` + a combined
+> `{scan}.predictions.json` manifest) now lands. Remaining A3/A4 work: the serving
+> protocol/CLI, emitting the full `Provenance`/`ResultEnvelope` (traits assembles these
+> from predict's manifest), and the prediction-parity harness.
 
 ## Tech Stack
 - **Python** ≥ 3.11 (CI matrix: 3.11, 3.12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ dev = [
     # (sleap_roots.Series.load). Predict does NOT runtime-depend on it (no cycle:
     # sleap-roots depends on the contract, not on predict). sleap-roots requires
     # sleap-io>=0.0.11 (open upper) and no sleap-nn, so it co-resolves with the
-    # sleap-nn 0.3.0 pin (sleap-io 0.8.x).
-    "sleap-roots",
+    # sleap-nn 0.3.0 pin (sleap-io 0.8.x). Floor-pinned so a lock refresh can't pull
+    # an incompatible release into the (default-run) Series.load acceptance test.
+    "sleap-roots>=0.1.4",
 ]
 # Platform-specific install profiles. Each pins sleap-nn 0.3.0 and selects a
 # torch build; torch/torchvision are routed to the matching PyTorch index via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dev = [
     "ruff",
     "jupyterlab>=4.4.6",
     "ipykernel>=6.30.1",
+    # Test-only: the downstream consumer, used by the output-contract acceptance test
+    # (sleap_roots.Series.load). Predict does NOT runtime-depend on it (no cycle:
+    # sleap-roots depends on the contract, not on predict). sleap-roots requires
+    # sleap-io>=0.0.11 (open upper) and no sleap-nn, so it co-resolves with the
+    # sleap-nn 0.3.0 pin (sleap-io 0.8.x).
+    "sleap-roots",
 ]
 # Platform-specific install profiles. Each pins sleap-nn 0.3.0 and selects a
 # torch build; torch/torchvision are routed to the matching PyTorch index via

--- a/sleap_roots_predict/__init__.py
+++ b/sleap_roots_predict/__init__.py
@@ -8,6 +8,10 @@ This package provides:
   fetch them from the wandb registry or a local dir (``ModelCardSource`` /
   ``WandbRegistrySource`` / ``LocalCardSource``), and keep sleap-nn predictors
   resident across scans (``WarmModelWorker``)
+- Output contract: write the per-scan artifacts the downstream traits stage reads
+  (named per-root ``.slp`` + a combined ``{scan}.predictions.json`` manifest) via
+  ``write_prediction_outputs`` / ``predict_and_write_batch`` (see the
+  ``prediction-output`` spec)
 - Timelapse experiment processing with metadata extraction (video/H5/metadata;
   prediction within this flow is currently deferred)
 """
@@ -34,6 +38,14 @@ from sleap_roots_predict.model_registry import (  # noqa: F401
 
 from sleap_roots_predict.warm_worker import WarmModelWorker  # noqa: F401
 
+from sleap_roots_predict.output_contract import (  # noqa: F401
+    PredictionArtifact,
+    PredictionManifest,
+    ScanRequest,
+    predict_and_write_batch,
+    write_prediction_outputs,
+)
+
 __all__ = [
     "process_timelapse_experiment",
     "make_predictor",
@@ -43,4 +55,9 @@ __all__ = [
     "LocalCardSource",
     "WandbRegistrySource",
     "WarmModelWorker",
+    "PredictionArtifact",
+    "PredictionManifest",
+    "ScanRequest",
+    "write_prediction_outputs",
+    "predict_and_write_batch",
 ]

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -1,0 +1,312 @@
+"""Predict output contract: the on-disk artifacts predict writes per scan.
+
+For each scan the writer emits one named ``.slp`` per predicted root type
+(``{scan_key}.model{model_id}.root{root_type}.slp`` — the sleap-roots ``Series``
+naming convention) plus a single combined ``{scan_key}.predictions.json`` that
+serializes a :class:`PredictionManifest`: the manifest (per-root paths +
+``model_id`` + ``plant_qr_code``) and the predict-side provenance (resolved
+``ModelRef``s, effective inference config, code sha / container digest, and each
+``.slp``'s checksum + file size).
+
+The schema is predict-local for now (it reuses ``ModelRef`` from
+``sleap-roots-contracts``); it is promoted to the shared contract once the traits
+stage (A3-traits) consumes it. Path strings are emitted via ``Path.as_posix()``
+(lab convention) so the manifest stays portable across POSIX and Windows.
+"""
+
+import hashlib
+import os
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import sleap_io as sio
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sleap_roots_contracts import ModelRef, ResolvedParams, RootType
+
+if TYPE_CHECKING:
+    from sleap_roots_predict.warm_worker import WarmModelWorker
+
+# Data containers, immutable. ``protected_namespaces=()`` disables pydantic's
+# ``model_``-prefix guard so the spec'd field ``model_id`` (and the ``model``
+# ModelRef field) validate without a namespace warning.
+_FROZEN = ConfigDict(frozen=True, protected_namespaces=())
+
+
+class PredictionArtifact(BaseModel):
+    """One predicted root type's ``.slp`` file plus its identity + integrity.
+
+    Attributes:
+        root_type: The root type this artifact carries.
+        model_id: Filename-safe slug of the model (a discovery label; the full
+            identity is ``model``).
+        model: The resolved ``ModelRef`` that produced this ``.slp``.
+        slp_path: Basename of the ``.slp`` (POSIX-style), relative to the
+            manifest's directory.
+        checksum: sha256 hex digest of the ``.slp`` file.
+        file_size: Size of the ``.slp`` file in bytes.
+    """
+
+    model_config = _FROZEN
+
+    root_type: RootType
+    model_id: str
+    model: ModelRef
+    slp_path: str
+    checksum: str
+    file_size: int
+
+
+class PredictionManifest(BaseModel):
+    """Per-scan output contract: manifest + predict-side provenance.
+
+    Attributes:
+        schema_version: Version of this predict-local manifest shape.
+        scan_key: Producer-side scan identifier (also the ``.slp`` filename stem).
+        plant_qr_code: Cross-scan plant key; defaults to ``scan_key`` when unset.
+        artifacts: One :class:`PredictionArtifact` per predicted root type (may be
+            empty when no root type resolved to a model).
+        predict_inference_config: Full effective inference config (audit).
+        predict_output_params: Output-defining subset of the inference config.
+        predict_code_sha: Git sha of the predict code (``""`` when unknown).
+        predict_container_digest: Image digest of the predict container (``""``
+            when unknown).
+    """
+
+    model_config = _FROZEN
+
+    schema_version: str = "1"
+    scan_key: str
+    plant_qr_code: str = ""
+    artifacts: list[PredictionArtifact] = Field(default_factory=list)
+    predict_inference_config: dict[str, Any] = Field(default_factory=dict)
+    predict_output_params: dict[str, Any] = Field(default_factory=dict)
+    predict_code_sha: str = ""
+    predict_container_digest: str = ""
+
+    @model_validator(mode="after")
+    def _default_plant_qr_code(self) -> "PredictionManifest":
+        """Default ``plant_qr_code`` to ``scan_key`` when not provided."""
+        if not self.plant_qr_code:
+            object.__setattr__(self, "plant_qr_code", self.scan_key)
+        return self
+
+
+# --- filename helpers -------------------------------------------------------
+
+_SLUG_UNSAFE = re.compile(r"[^A-Za-z0-9-]")
+
+# Characters that break a single path segment on POSIX and/or Windows, plus `.`
+# (which would break the ``series_name = filename.split(".")[0]`` invariant that
+# sleap-roots relies on).
+_SCAN_KEY_FORBIDDEN = frozenset('./\\:*?"<>|')
+
+
+def slugify_model_id(ref: ModelRef) -> str:
+    """Return a filename-safe, dot/slash-free slug for a model ref.
+
+    Combines ``registry_id`` and ``version`` and replaces every character outside
+    ``[A-Za-z0-9-]`` with ``-`` (the ``registry_id`` is a slash path, so it is not
+    itself a valid filename). The slug is a discovery label; the full identity is
+    recorded as the artifact's ``ModelRef``.
+
+    Args:
+        ref: The resolved model reference.
+
+    Returns:
+        A slug safe to embed in a ``.slp`` filename.
+    """
+    return _SLUG_UNSAFE.sub("-", f"{ref.registry_id}_{ref.version}")
+
+
+def _validate_scan_key(scan_key: str) -> None:
+    r"""Raise ``ValueError`` if ``scan_key`` is unsafe as a single path segment.
+
+    ``scan_key`` is identity and must not be mangled, so an empty value or one
+    containing ``. / \ : * ? " < > |`` or a control character is rejected rather
+    than rewritten.
+
+    Args:
+        scan_key: The producer-side scan identifier.
+
+    Raises:
+        ValueError: If ``scan_key`` is empty or contains a reserved character.
+    """
+    if not scan_key:
+        raise ValueError("scan_key must be a non-empty string")
+    bad = {c for c in scan_key if c in _SCAN_KEY_FORBIDDEN or ord(c) < 32}
+    if bad:
+        raise ValueError(
+            f"scan_key {scan_key!r} contains reserved character(s) {sorted(bad)!r}; "
+            "it must be safe as a single path segment"
+        )
+
+
+def _resolve_identity(explicit: str | None, env_var: str) -> str:
+    """Return the explicit value, else the environment value, else ``""``."""
+    if explicit is not None:
+        return explicit
+    return os.environ.get(env_var, "")
+
+
+# --- writer -----------------------------------------------------------------
+
+
+def write_prediction_outputs(
+    labels_by_root: dict[str, "sio.Labels"],
+    refs_by_root: dict[str, ModelRef],
+    out_dir: str | Path,
+    *,
+    scan_key: str,
+    plant_qr_code: str | None = None,
+    inference_config: dict[str, Any],
+    output_params: dict[str, Any],
+    predict_code_sha: str | None = None,
+    predict_container_digest: str | None = None,
+) -> PredictionManifest:
+    """Write the per-scan output contract into ``out_dir``.
+
+    For each resolved root type this writes
+    ``{scan_key}.model{model_id}.root{root_type}.slp`` (the sleap-roots ``Series``
+    naming convention) and then a single combined ``{scan_key}.predictions.json``
+    serializing a :class:`PredictionManifest`. Re-running for the same ``scan_key``
+    into the same ``out_dir`` overwrites the prior outputs in place. Path strings
+    are emitted via ``Path.as_posix()``. Does not import ``sleap-roots``.
+
+    Args:
+        labels_by_root: Predicted ``sio.Labels`` per root type (from the worker's
+            ``predict``).
+        refs_by_root: The resolved ``ModelRef`` per root type (from the worker's
+            ``resolve``); must cover the same root types as ``labels_by_root``.
+        out_dir: Directory to write into (created if missing).
+        scan_key: Producer-side scan identifier and ``.slp`` filename stem; must be
+            safe as a single path segment.
+        plant_qr_code: Cross-scan plant key; defaults to ``scan_key`` when ``None``.
+        inference_config: Full effective inference config (``worker.inference_config()``).
+        output_params: Output-defining subset (``worker.output_params()``).
+        predict_code_sha: Explicit predict git sha; falls back to
+            ``SRP_PREDICT_CODE_SHA`` then ``""``.
+        predict_container_digest: Explicit container digest; falls back to
+            ``SRP_PREDICT_CONTAINER_DIGEST`` then ``""``.
+
+    Returns:
+        The written :class:`PredictionManifest`.
+
+    Raises:
+        ValueError: If ``scan_key`` is unsafe, or ``labels_by_root`` and
+            ``refs_by_root`` cover different root types.
+    """
+    _validate_scan_key(scan_key)
+    if set(labels_by_root) != set(refs_by_root):
+        raise ValueError(
+            f"labels_by_root root types {sorted(labels_by_root)} do not match "
+            f"refs_by_root root types {sorted(refs_by_root)}"
+        )
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    artifacts: list[PredictionArtifact] = []
+    for root_type in sorted(refs_by_root):
+        ref = refs_by_root[root_type]
+        slug = slugify_model_id(ref)
+        filename = f"{scan_key}.model{slug}.root{root_type}.slp"
+        slp_path = out / filename
+        sio.save_file(labels_by_root[root_type], slp_path.as_posix())
+        data = slp_path.read_bytes()
+        artifacts.append(
+            PredictionArtifact(
+                root_type=root_type,
+                model_id=slug,
+                model=ref,
+                slp_path=Path(filename).as_posix(),
+                checksum=hashlib.sha256(data).hexdigest(),
+                file_size=len(data),
+            )
+        )
+
+    manifest = PredictionManifest(
+        scan_key=scan_key,
+        plant_qr_code=plant_qr_code or scan_key,
+        artifacts=artifacts,
+        predict_inference_config=dict(inference_config),
+        predict_output_params=dict(output_params),
+        predict_code_sha=_resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA"),
+        predict_container_digest=_resolve_identity(
+            predict_container_digest, "SRP_PREDICT_CONTAINER_DIGEST"
+        ),
+    )
+    (out / f"{scan_key}.predictions.json").write_text(
+        manifest.model_dump_json(indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# --- batch ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScanRequest:
+    """One scan's inputs for :func:`predict_and_write_batch`.
+
+    Attributes:
+        scan_key: Producer-side scan identifier (and ``.slp`` filename stem).
+        video: The ``sio.Video`` to predict on.
+        params: Resolved scan params (species/mode/age).
+        plant_qr_code: Optional cross-scan plant key (defaults to ``scan_key``).
+        overrides: Optional explicit ``ModelRef`` per root type.
+    """
+
+    scan_key: str
+    video: "sio.Video"
+    params: ResolvedParams
+    plant_qr_code: str | None = None
+    overrides: dict[str, ModelRef] | None = None
+
+
+def predict_and_write_batch(
+    worker: "WarmModelWorker",
+    requests: "Iterable[ScanRequest]",
+    out_dir: str | Path,
+    *,
+    predict_code_sha: str | None = None,
+    predict_container_digest: str | None = None,
+) -> list[PredictionManifest]:
+    """Drive one warm worker over N scans, writing one subdirectory per scan.
+
+    The worker's resident ``Predictor``s are reused across scans (models loaded
+    once), so a batch amortizes model-load cost. Each scan is written into
+    ``out_dir/{scan_key}/`` via :func:`write_prediction_outputs`.
+
+    Args:
+        worker: A ``WarmModelWorker`` kept resident across the batch.
+        requests: The scans to predict and write.
+        out_dir: Parent directory; each scan gets an ``out_dir/{scan_key}/`` subdir.
+        predict_code_sha: Passed through to each scan's manifest.
+        predict_container_digest: Passed through to each scan's manifest.
+
+    Returns:
+        One :class:`PredictionManifest` per scan, in request order.
+    """
+    out = Path(out_dir)
+    inference_config = worker.inference_config()
+    output_params = worker.output_params()
+    manifests: list[PredictionManifest] = []
+    for req in requests:
+        refs = worker.resolve(req.params, req.overrides)
+        labels = worker.predict(req.params, req.video, overrides=req.overrides)
+        manifests.append(
+            write_prediction_outputs(
+                labels,
+                refs,
+                out / req.scan_key,
+                scan_key=req.scan_key,
+                plant_qr_code=req.plant_qr_code,
+                inference_config=inference_config,
+                output_params=output_params,
+                predict_code_sha=predict_code_sha,
+                predict_container_digest=predict_container_digest,
+            )
+        )
+    return manifests

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -136,6 +136,11 @@ def _validate_scan_key(scan_key: str) -> None:
     """
     if not scan_key:
         raise ValueError("scan_key must be a non-empty string")
+    if scan_key != scan_key.strip():
+        raise ValueError(
+            f"scan_key {scan_key!r} has leading/trailing whitespace; it must be a "
+            "clean single path segment (Windows trims trailing spaces/dots)"
+        )
     bad = {c for c in scan_key if c in _SCAN_KEY_FORBIDDEN or ord(c) < 32}
     if bad:
         raise ValueError(
@@ -170,10 +175,12 @@ def write_prediction_outputs(
 
     For each resolved root type this writes
     ``{scan_key}.model{model_id}.root{root_type}.slp`` (the sleap-roots ``Series``
-    naming convention) and then a single combined ``{scan_key}.predictions.json``
+    filename convention; loaded downstream via ``Series.load`` with the manifest's
+    explicit paths) and then a single combined ``{scan_key}.predictions.json``
     serializing a :class:`PredictionManifest`. Re-running for the same ``scan_key``
-    into the same ``out_dir`` overwrites the prior outputs in place. Path strings
-    are emitted via ``Path.as_posix()``. Does not import ``sleap-roots``.
+    into the same ``out_dir`` overwrites the prior outputs in place, first removing
+    any stale ``.slp`` for that scan (so a changed model slug does not orphan files).
+    Path strings are emitted via ``Path.as_posix()``. Does not import ``sleap-roots``.
 
     Args:
         labels_by_root: Predicted ``sio.Labels`` per root type (from the worker's
@@ -206,6 +213,16 @@ def write_prediction_outputs(
         )
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
+
+    # Idempotent re-run: remove this scan's prior `.slp` artifacts first. Their
+    # filenames embed the model slug, so a model/version/override change would
+    # otherwise orphan the old files (unreferenced by the new manifest, yet matched
+    # by glob-based consumers). Scoped by the validated (separator-free) scan_key
+    # prefix, so other scans in the same directory are untouched.
+    slp_prefix = f"{scan_key}.model"
+    for stale in list(out.iterdir()):
+        if stale.name.startswith(slp_prefix) and stale.name.endswith(".slp"):
+            stale.unlink()
 
     artifacts: list[PredictionArtifact] = []
     for root_type in sorted(refs_by_root):
@@ -288,12 +305,24 @@ def predict_and_write_batch(
 
     Returns:
         One :class:`PredictionManifest` per scan, in request order.
+
+    Raises:
+        ValueError: If two requests share a ``scan_key`` (which would otherwise
+            silently overwrite a scan's subdirectory).
     """
     out = Path(out_dir)
+    reqs = list(requests)
+    keys = [r.scan_key for r in reqs]
+    dups = sorted({k for k in keys if keys.count(k) > 1})
+    if dups:
+        raise ValueError(
+            f"duplicate scan_key(s) in batch: {dups}; each scan must be unique "
+            "(a repeat would silently overwrite an earlier scan's subdirectory)"
+        )
     inference_config = worker.inference_config()
     output_params = worker.output_params()
     manifests: list[PredictionManifest] = []
-    for req in requests:
+    for req in reqs:
         refs = worker.resolve(req.params, req.overrides)
         labels = worker.predict(req.params, req.video, overrides=req.overrides)
         manifests.append(

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -1,0 +1,394 @@
+"""Real, no-mock tests for the predict output contract.
+
+The writer is driven by the real warm worker over the vendored native + legacy
+models (reusing the `rice_source` / `video` fixtures pattern from
+``test_warm_worker.py``); no sleap-nn / sleap-io boundary is mocked.
+"""
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import sleap_io as sio
+from sleap_roots_contracts import ModelCard, ModelRef, ResolvedParams
+
+from sleap_roots_predict.model_registry import LocalCardSource
+from sleap_roots_predict.output_contract import (
+    PredictionArtifact,
+    PredictionManifest,
+    ScanRequest,
+    _validate_scan_key,
+    predict_and_write_batch,
+    slugify_model_id,
+    write_prediction_outputs,
+)
+from sleap_roots_predict.video_utils import make_video_from_images
+from sleap_roots_predict.warm_worker import WarmModelWorker
+
+
+def _card(
+    root_type, registry_id, *, species="rice", version="v1", age_min=2, age_max=5
+):
+    return ModelCard(
+        species=species,
+        mode="cylinder",
+        age_min=age_min,
+        age_max=age_max,
+        root_type=root_type,
+        registry_id=registry_id,
+        version=version,
+    )
+
+
+def _params(species="rice", age=3):
+    return ResolvedParams(values={"species": species, "mode": "cylinder", "age": age})
+
+
+@pytest.fixture(scope="module")
+def video(centered_pair_image_dir: Path):
+    """An 8-frame greyscale video built from the vendored frames."""
+    files = sorted(centered_pair_image_dir.glob("*.png"))
+    return make_video_from_images(files, greyscale=True)
+
+
+@pytest.fixture
+def rice_source(native_model_dir: Path, legacy_model_dir: Path) -> LocalCardSource:
+    """A source: primary=native model, lateral=legacy model, both for rice."""
+    return LocalCardSource(
+        [
+            (_card("primary", "reg/rice-primary"), native_model_dir),
+            (_card("lateral", "reg/rice-lateral"), legacy_model_dir),
+        ]
+    )
+
+
+@pytest.fixture
+def all_roots_source(native_model_dir: Path, legacy_model_dir: Path) -> LocalCardSource:
+    """A source covering all three root types (crown reuses the native model)."""
+    return LocalCardSource(
+        [
+            (_card("primary", "reg/rice-primary"), native_model_dir),
+            (_card("lateral", "reg/rice-lateral"), legacy_model_dir),
+            (_card("crown", "reg/rice-crown"), native_model_dir),
+        ]
+    )
+
+
+def _ref(root_type="primary", registry_id="reg/rice-primary", version="v1"):
+    return ModelRef(
+        registry_id=registry_id,
+        version=version,
+        sleap_nn_version="0.3.0",
+        root_type=root_type,
+    )
+
+
+# --- Task 2: schema models --------------------------------------------------
+
+
+def test_manifest_round_trips():
+    """A manifest with a real ModelRef dumps to JSON and reloads equal."""
+    artifact = PredictionArtifact(
+        root_type="primary",
+        model_id="reg-rice-primary-v1",
+        model=_ref(),
+        slp_path="s1.modelreg-rice-primary-v1.rootprimary.slp",
+        checksum="abc123",
+        file_size=42,
+    )
+    manifest = PredictionManifest(
+        scan_key="s1",
+        plant_qr_code="s1",
+        artifacts=[artifact],
+        predict_inference_config={"device": "cpu", "peak_threshold": 0.2},
+        predict_output_params={"peak_threshold": 0.2},
+    )
+    reloaded = PredictionManifest.model_validate_json(manifest.model_dump_json())
+    assert reloaded == manifest
+    assert reloaded.schema_version == "1"
+    assert reloaded.artifacts[0].model == _ref()
+
+
+def test_plant_qr_code_defaults_to_scan_key():
+    """An unset plant_qr_code defaults to scan_key."""
+    manifest = PredictionManifest(scan_key="scan0731")
+    assert manifest.plant_qr_code == "scan0731"
+
+
+# --- Task 3: slug + scan_key validation -------------------------------------
+
+
+def test_model_id_slug_is_filename_safe():
+    """A registry_id with a slash and a dot yields a slash/dot-free slug."""
+    slug = slugify_model_id(_ref(registry_id="reg/rice.primary", version="v1"))
+    assert "/" not in slug and "." not in slug
+    assert slug == "reg-rice-primary-v1"
+
+
+@pytest.mark.parametrize("bad", [".", "/", "\\", ":", "*", "\x00", ""])
+def test_rejects_unsafe_scan_key(bad):
+    """Empty or reserved-character scan keys are rejected (not mangled)."""
+    key = f"scan{bad}1" if bad else ""
+    with pytest.raises(ValueError):
+        _validate_scan_key(key)
+
+
+def test_accepts_normal_scan_key():
+    """An alphanumeric key with `_`/`-` is accepted."""
+    _validate_scan_key("scan_0731-A")  # no raise
+
+
+# --- Task 4: pure writer (real inference, no mocks) -------------------------
+
+
+def test_writer_writes_named_slp_and_manifest(rice_source, video, tmp_path):
+    """Real inference -> named .slp per root + a manifest mapping each root."""
+    worker = WarmModelWorker(rice_source)
+    refs = worker.resolve(_params())
+    labels = worker.predict(_params(), video)
+    manifest = write_prediction_outputs(
+        labels,
+        refs,
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    assert {a.root_type for a in manifest.artifacts} == {"primary", "lateral"}
+    for art in manifest.artifacts:
+        slp = tmp_path / art.slp_path
+        assert slp.exists()
+        assert len(sio.load_file(slp.as_posix())) > 0
+        assert art.model_id == slugify_model_id(refs[art.root_type])
+        assert art.model == refs[art.root_type]
+
+
+def test_slp_path_is_relocatable_basename(rice_source, video, tmp_path):
+    """slp_path is a bare POSIX basename (no dir), so the scan dir is relocatable."""
+    worker = WarmModelWorker(rice_source)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    for art in manifest.artifacts:
+        assert not Path(art.slp_path).is_absolute()
+        assert "/" not in art.slp_path and "\\" not in art.slp_path
+        assert art.slp_path == (
+            f"scan0731.model{slugify_model_id(art.model)}.root{art.root_type}.slp"
+        )
+        assert (tmp_path / art.slp_path).exists()
+
+
+def test_writer_covers_all_root_types(all_roots_source, video, tmp_path):
+    """All three RootType literals (incl. crown) produce named .slp + artifacts."""
+    worker = WarmModelWorker(all_roots_source)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    assert {a.root_type for a in manifest.artifacts} == {"primary", "lateral", "crown"}
+    assert (
+        tmp_path / f"scan0731.model{slugify_model_id(_ref('crown', 'reg/rice-crown'))}"
+        ".rootcrown.slp"
+    ).exists()
+
+
+def test_manifest_json_on_disk_round_trips(rice_source, video, tmp_path):
+    """The written JSON file reloads into a manifest equal to the returned one."""
+    worker = WarmModelWorker(rice_source)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    on_disk = (tmp_path / "scan0731.predictions.json").read_text(encoding="utf-8")
+    assert PredictionManifest.model_validate_json(on_disk) == manifest
+
+
+def test_checksums_and_sizes_match_files(rice_source, video, tmp_path):
+    """Each artifact's checksum/file_size match the on-disk .slp."""
+    worker = WarmModelWorker(rice_source)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    for art in manifest.artifacts:
+        data = (tmp_path / art.slp_path).read_bytes()
+        assert art.checksum == hashlib.sha256(data).hexdigest()
+        assert art.file_size == len(data)
+
+
+def test_mismatched_labels_and_refs_raise(tmp_path):
+    """Label root types not matching ref root types raise ValueError."""
+    with pytest.raises(ValueError):
+        write_prediction_outputs(
+            {"primary": sio.Labels()},
+            {"lateral": _ref("lateral", "reg/rice-lateral")},
+            tmp_path,
+            scan_key="s1",
+            inference_config={},
+            output_params={},
+        )
+
+
+def test_writer_rejects_unsafe_scan_key(tmp_path):
+    """The writer rejects an unsafe scan_key and writes nothing."""
+    with pytest.raises(ValueError):
+        write_prediction_outputs(
+            {}, {}, tmp_path, scan_key="scan.1", inference_config={}, output_params={}
+        )
+    assert not list(tmp_path.iterdir())
+
+
+def test_zero_roots_writes_empty_artifacts(tmp_path):
+    """A scan with no resolved roots still writes a manifest with artifacts=[]."""
+    manifest = write_prediction_outputs(
+        {}, {}, tmp_path, scan_key="scan0", inference_config={}, output_params={}
+    )
+    assert manifest.artifacts == []
+    assert (tmp_path / "scan0.predictions.json").exists()
+
+
+def test_rerun_overwrites_in_place(rice_source, video, tmp_path):
+    """Re-running the same scan into the same dir overwrites in place."""
+    worker = WarmModelWorker(rice_source)
+    kwargs = dict(
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    write_prediction_outputs(
+        worker.predict(_params(), video), worker.resolve(_params()), tmp_path, **kwargs
+    )
+    second = write_prediction_outputs(
+        worker.predict(_params(), video), worker.resolve(_params()), tmp_path, **kwargs
+    )
+    on_disk = (tmp_path / "scan0731.predictions.json").read_text(encoding="utf-8")
+    assert PredictionManifest.model_validate_json(on_disk) == second
+
+
+def test_plant_qr_code_recorded_verbatim(tmp_path):
+    """An explicit plant_qr_code is stored as-is (non-default path)."""
+    manifest = write_prediction_outputs(
+        {},
+        {},
+        tmp_path,
+        scan_key="scan0",
+        plant_qr_code="QR-123",
+        inference_config={},
+        output_params={},
+    )
+    assert manifest.plant_qr_code == "QR-123"
+
+
+def test_writer_does_not_import_sleap_roots():
+    """Importing the writer module must not pull in the sleap-roots runtime dep."""
+    code = (
+        "import sys, sleap_roots_predict.output_contract; "
+        "assert 'sleap_roots' not in sys.modules"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# --- Task 5: fail-soft build identity ---------------------------------------
+
+
+def test_build_identity_explicit_arg_wins(tmp_path, monkeypatch):
+    """An explicit predict_code_sha overrides the environment."""
+    monkeypatch.setenv("SRP_PREDICT_CODE_SHA", "from-env")
+    manifest = write_prediction_outputs(
+        {},
+        {},
+        tmp_path,
+        scan_key="s",
+        inference_config={},
+        output_params={},
+        predict_code_sha="explicit",
+    )
+    assert manifest.predict_code_sha == "explicit"
+
+
+def test_build_identity_env_fallback(tmp_path, monkeypatch):
+    """With no argument, the environment variable is used."""
+    monkeypatch.setenv("SRP_PREDICT_CONTAINER_DIGEST", "sha256:env")
+    manifest = write_prediction_outputs(
+        {}, {}, tmp_path, scan_key="s", inference_config={}, output_params={}
+    )
+    assert manifest.predict_container_digest == "sha256:env"
+
+
+def test_build_identity_absent_is_empty_string(tmp_path, monkeypatch):
+    """Absent argument and environment record the empty string without error."""
+    monkeypatch.delenv("SRP_PREDICT_CODE_SHA", raising=False)
+    monkeypatch.delenv("SRP_PREDICT_CONTAINER_DIGEST", raising=False)
+    manifest = write_prediction_outputs(
+        {}, {}, tmp_path, scan_key="s", inference_config={}, output_params={}
+    )
+    assert manifest.predict_code_sha == ""
+    assert manifest.predict_container_digest == ""
+
+
+# --- Task 6: ScanRequest + batch --------------------------------------------
+
+
+def test_batch_writes_per_scan_subdirs(rice_source, video, tmp_path):
+    """Batch writes one subdirectory of artifacts per scan."""
+    worker = WarmModelWorker(rice_source)
+    requests = [
+        ScanRequest(scan_key="s1", video=video, params=_params()),
+        ScanRequest(scan_key="s2", video=video, params=_params()),
+    ]
+    manifests = predict_and_write_batch(worker, requests, tmp_path)
+    assert len(manifests) == 2
+    for scan_key in ("s1", "s2"):
+        scan_dir = tmp_path / scan_key
+        assert (scan_dir / f"{scan_key}.predictions.json").exists()
+        assert list(scan_dir.glob("*.rootprimary.slp"))
+        assert list(scan_dir.glob("*.rootlateral.slp"))
+
+
+def test_batch_reuses_resident_predictors(rice_source, video, tmp_path):
+    """The second scan reuses the resident Predictor loaded for the first."""
+    worker = WarmModelWorker(rice_source)
+    predict_and_write_batch(worker, [ScanRequest("s1", video, _params())], tmp_path)
+    primary = worker._predictors[("reg/rice-primary", "v1")]
+    predict_and_write_batch(worker, [ScanRequest("s2", video, _params())], tmp_path)
+    assert worker._predictors[("reg/rice-primary", "v1")] is primary
+
+
+def test_batch_respects_overrides(rice_source, video, tmp_path):
+    """A per-scan override reaches resolution and is recorded in the manifest."""
+    override = ModelRef(
+        registry_id="reg/rice-lateral",
+        version="v1",
+        sleap_nn_version="0.3.0",
+        root_type="primary",
+    )
+    worker = WarmModelWorker(rice_source)
+    manifests = predict_and_write_batch(
+        worker,
+        [ScanRequest("s1", video, _params(), overrides={"primary": override})],
+        tmp_path,
+    )
+    primary_art = next(a for a in manifests[0].artifacts if a.root_type == "primary")
+    assert primary_art.model == override

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -16,6 +16,7 @@ from sleap_roots_contracts import ModelCard, ModelRef, ResolvedParams
 
 from sleap_roots_predict.model_registry import LocalCardSource
 from sleap_roots_predict.output_contract import (
+    _SCAN_KEY_FORBIDDEN,
     PredictionArtifact,
     PredictionManifest,
     ScanRequest,
@@ -127,10 +128,24 @@ def test_model_id_slug_is_filename_safe():
     assert slug == "reg-rice-primary-v1"
 
 
-@pytest.mark.parametrize("bad", [".", "/", "\\", ":", "*", "\x00", ""])
-def test_rejects_unsafe_scan_key(bad):
-    """Empty or reserved-character scan keys are rejected (not mangled)."""
-    key = f"scan{bad}1" if bad else ""
+@pytest.mark.parametrize(
+    "bad", sorted(_SCAN_KEY_FORBIDDEN) + ["\x00", "\n", "\t", "\r"]
+)
+def test_rejects_reserved_and_control_chars_in_scan_key(bad):
+    """Every reserved char + control chars are rejected (not mangled)."""
+    with pytest.raises(ValueError):
+        _validate_scan_key(f"scan{bad}1")
+
+
+def test_rejects_empty_scan_key():
+    """An empty scan_key is rejected."""
+    with pytest.raises(ValueError):
+        _validate_scan_key("")
+
+
+@pytest.mark.parametrize("key", [" ", "   ", "scan ", " scan"])
+def test_rejects_whitespace_scan_key(key):
+    """Leading/trailing/all-whitespace keys are rejected (Windows-mangle-prone)."""
     with pytest.raises(ValueError):
         _validate_scan_key(key)
 
@@ -284,6 +299,53 @@ def test_rerun_overwrites_in_place(rice_source, video, tmp_path):
     assert PredictionManifest.model_validate_json(on_disk) == second
 
 
+def test_rerun_with_changed_model_prunes_stale_slp(rice_source, video, tmp_path):
+    """Re-running with a different model for a root type removes the stale .slp."""
+    worker = WarmModelWorker(rice_source)
+    kwargs = dict(
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    # Run 1: primary -> reg/rice-primary (native model, one slug).
+    write_prediction_outputs(
+        worker.predict(_params(), video), worker.resolve(_params()), tmp_path, **kwargs
+    )
+    # Run 2: override primary -> reg/rice-lateral (a different slug/filename).
+    override = {
+        "primary": ModelRef(
+            registry_id="reg/rice-lateral",
+            version="v1",
+            sleap_nn_version="0.3.0",
+            root_type="primary",
+        )
+    }
+    write_prediction_outputs(
+        worker.predict(_params(), video, overrides=override),
+        worker.resolve(_params(), override),
+        tmp_path,
+        **kwargs,
+    )
+    # The stale run-1 primary .slp was pruned: exactly one remains.
+    assert len(list(tmp_path.glob("*.rootprimary.slp"))) == 1
+
+
+def test_manifest_records_worker_provenance(rice_source, video, tmp_path):
+    """The writer stores the worker's inference config + output params verbatim."""
+    worker = WarmModelWorker(rice_source, peak_threshold=0.15)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    assert manifest.predict_inference_config == worker.inference_config()
+    assert manifest.predict_output_params == worker.output_params()
+    assert manifest.predict_output_params == {"peak_threshold": 0.15}
+
+
 def test_plant_qr_code_recorded_verbatim(tmp_path):
     """An explicit plant_qr_code is stored as-is (non-default path)."""
     manifest = write_prediction_outputs(
@@ -392,6 +454,17 @@ def test_batch_respects_overrides(rice_source, video, tmp_path):
     )
     primary_art = next(a for a in manifests[0].artifacts if a.root_type == "primary")
     assert primary_art.model == override
+
+
+def test_batch_rejects_duplicate_scan_keys(rice_source, video, tmp_path):
+    """Two requests sharing a scan_key raise rather than silently clobber."""
+    worker = WarmModelWorker(rice_source)
+    reqs = [
+        ScanRequest("dup", video, _params()),
+        ScanRequest("dup", video, _params()),
+    ]
+    with pytest.raises(ValueError):
+        predict_and_write_batch(worker, reqs, tmp_path)
 
 
 # --- Task 7: downstream acceptance (sleap_roots.Series.load) -----------------

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -392,3 +392,32 @@ def test_batch_respects_overrides(rice_source, video, tmp_path):
     )
     primary_art = next(a for a in manifests[0].artifacts if a.root_type == "primary")
     assert primary_art.model == override
+
+
+# --- Task 7: downstream acceptance (sleap_roots.Series.load) -----------------
+
+
+def test_output_loads_via_sleap_roots_series(rice_source, video, tmp_path):
+    """The writer's output loads cleanly via the downstream sleap_roots.Series."""
+    sleap_roots = pytest.importorskip("sleap_roots")
+    worker = WarmModelWorker(rice_source)
+    manifest = write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    # Resolve each root type's .slp path (POSIX) from the manifest; no crown here.
+    paths = {
+        a.root_type: (tmp_path / a.slp_path).as_posix() for a in manifest.artifacts
+    }
+    series = sleap_roots.Series.load(
+        series_name="scan0731",
+        primary_path=paths.get("primary"),
+        lateral_path=paths.get("lateral"),
+        crown_path=None,
+    )
+    assert series.primary_labels is not None
+    assert series.lateral_labels is not None

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -16,5 +16,10 @@ def test_public_surface_importable_without_credentials(monkeypatch):
         "make_predictor",
         "predict_on_video",
         "process_timelapse_experiment",
+        "PredictionArtifact",
+        "PredictionManifest",
+        "ScanRequest",
+        "write_prediction_outputs",
+        "predict_and_write_batch",
     ):
         assert hasattr(pkg, name), name

--- a/uv.lock
+++ b/uv.lock
@@ -3713,6 +3713,73 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-linux-cuda') or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-macos') or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-windows-cuda') or (extra == 'extra-19-sleap-roots-predict-linux-cuda' and extra == 'extra-19-sleap-roots-predict-macos') or (extra == 'extra-19-sleap-roots-predict-linux-cuda' and extra == 'extra-19-sleap-roots-predict-windows-cuda') or (extra == 'extra-19-sleap-roots-predict-macos' and extra == 'extra-19-sleap-roots-predict-windows-cuda')" },
+    { name = "tifffile", version = "2026.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-linux-cuda') or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-macos') or (extra == 'extra-19-sleap-roots-predict-cpu' and extra == 'extra-19-sleap-roots-predict-windows-cuda') or (extra == 'extra-19-sleap-roots-predict-linux-cuda' and extra == 'extra-19-sleap-roots-predict-macos') or (extra == 'extra-19-sleap-roots-predict-linux-cuda' and extra == 'extra-19-sleap-roots-predict-windows-cuda') or (extra == 'extra-19-sleap-roots-predict-macos' and extra == 'extra-19-sleap-roots-predict-windows-cuda')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/16/8a407688b607f86f81f8c649bf0d68a2a6d67375f18c2d660aba20f5b648/scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0", size = 12355510, upload-time = "2025-12-20T17:10:31.628Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/7efc088ececb6f6868fd4475e16cfafc11f242ce9ab5fc3557d78b5da0d4/scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd", size = 12056334, upload-time = "2025-12-20T17:10:34.559Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/bc7fb91fb5ff65ef42346c8b7ee8b09b04eabf89235ab7dbfdfd96cbd1ea/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953", size = 13297768, upload-time = "2025-12-20T17:10:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/e71c1a7d90e70da67b88ccc609bd6ae54798d5847369b15d3a8052232f9d/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af", size = 13711217, upload-time = "2025-12-20T17:10:40.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/59/9637ee12c23726266b91296791465218973ce1ad3e4c56fc81e4d8e7d6e1/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d", size = 14337782, upload-time = "2025-12-20T17:10:43.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5c/a3e1e0860f9294663f540c117e4bf83d55e5b47c281d475cc06227e88411/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d", size = 14805997, upload-time = "2025-12-20T17:10:45.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c6/2eeacf173da041a9e388975f54e5c49df750757fcfc3ee293cdbbae1ea0a/scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7", size = 11878486, upload-time = "2025-12-20T17:10:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a4/a852c4949b9058d585e762a66bf7e9a2cd3be4795cd940413dfbfbb0ce79/scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581", size = 11346518, upload-time = "2025-12-20T17:10:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+    { url = "https://files.pythonhosted.org/packages/51/44/6b744f92b37ae2833fd423cce8f806d2368859ec325a699dc30389e090b9/scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c", size = 12365810, upload-time = "2025-12-20T17:11:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f5/83590d9355191f86ac663420fec741b82cc547a4afe7c4c1d986bf46e4db/scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd", size = 12075717, upload-time = "2025-12-20T17:11:49.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/253e7cf5aee6190459fe136c614e2cbccc562deceb4af96e0863f1b8ee29/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab", size = 13161520, upload-time = "2025-12-20T17:11:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/cec6a3cbaadfdcc02bd6ff02f3abfe09eaa7f4d4e0a525a1e3a3f4bce49c/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505", size = 13684340, upload-time = "2025-12-20T17:11:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0d/39a776f675d24164b3a267aa0db9f677a4cb20127660d8bf4fd7fef66817/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331", size = 14203839, upload-time = "2025-12-20T17:11:55.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/2514df226bbcedfe9b2caafa1ba7bc87231a0c339066981b182b08340e06/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578", size = 14770021, upload-time = "2025-12-20T17:11:58.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/0671dc91c0c79340c3fe202f0549c7d3681eb7640fe34ab68a5f090a7c7f/scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650", size = 12023490, upload-time = "2025-12-20T17:12:00.013Z" },
+    { url = "https://files.pythonhosted.org/packages/65/08/7c4cb59f91721f3de07719085212a0b3962e3e3f2d1818cbac4eeb1ea53e/scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f", size = 11473782, upload-time = "2025-12-20T17:12:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/65c4258137acef3d73cb561ac55512eacd7b30bb4f4a11474cad526bc5db/scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1", size = 12686060, upload-time = "2025-12-20T17:12:03.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/32/76971f8727b87f1420a962406388a50e26667c31756126444baf6668f559/scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f", size = 12422628, upload-time = "2025-12-20T17:12:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0d/996febd39f757c40ee7b01cdb861867327e5c8e5f595a634e8201462d958/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59", size = 12962369, upload-time = "2025-12-20T17:12:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/612d354f946c9600e7dea012723c11d47e8d455384e530f6daaaeb9bf62c/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394", size = 13272431, upload-time = "2025-12-20T17:12:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/26c00b466e06055a086de2c6e2145fe189ccdc9a1d11ccc7de020f2591ad/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62", size = 14016362, upload-time = "2025-12-20T17:12:12.793Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/00a90402e1775634043c2a0af8a3c76ad450866d9fa444efcc43b553ba2d/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2", size = 14364151, upload-time = "2025-12-20T17:12:14.909Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ca/918d8d306bd43beacff3b835c6d96fac0ae64c0857092f068b88db531a7c/scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4", size = 12413484, upload-time = "2025-12-20T17:12:17.046Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cd/4da01329b5a8d47ff7ec3c99a2b02465a8017b186027590dc7425cee0b56/scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf", size = 11769501, upload-time = "2025-12-20T17:12:19.339Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4064,6 +4131,25 @@ torch-cuda128 = [
 ]
 
 [[package]]
+name = "sleap-roots"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "h5py" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scikit-image" },
+    { name = "seaborn" },
+    { name = "shapely" },
+    { name = "sleap-io" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/4c/70e936e37d28fb9222bb61e88410fa76b08f91d71f246686caaf0feeb973/sleap_roots-0.1.4-py3-none-any.whl", hash = "sha256:e51dc83cb879d2563dd8adbda58890e154c5fd6290dc21e8cfa3c51301a76efa", size = 45446, upload-time = "2025-05-10T00:31:45.17Z" },
+]
+
+[[package]]
 name = "sleap-roots-contracts"
 version = "0.1.0a3"
 source = { registry = "https://pypi.org/simple" }
@@ -4108,6 +4194,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "sleap-roots" },
     { name = "toml" },
     { name = "twine" },
 ]
@@ -4150,6 +4237,7 @@ requires-dist = [
     { name = "sleap-nn", extras = ["torch-cpu"], marker = "extra == 'macos'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'linux-cuda'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'windows-cuda'", specifier = "==0.3.0" },
+    { name = "sleap-roots", marker = "extra == 'dev'" },
     { name = "sleap-roots-contracts", specifier = "==0.1.0a3" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "sleap-roots-predict", extra = "cpu" } },

--- a/uv.lock
+++ b/uv.lock
@@ -4237,7 +4237,7 @@ requires-dist = [
     { name = "sleap-nn", extras = ["torch-cpu"], marker = "extra == 'macos'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'linux-cuda'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'windows-cuda'", specifier = "==0.3.0" },
-    { name = "sleap-roots", marker = "extra == 'dev'" },
+    { name = "sleap-roots", marker = "extra == 'dev'", specifier = ">=0.1.4" },
     { name = "sleap-roots-contracts", specifier = "==0.1.0a3" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "sleap-roots-predict", extra = "cpu" } },


### PR DESCRIPTION
## Summary

Adds the **predict output contract** — the on-disk artifacts predict writes per scan for the downstream sleap-roots traits stage (A3-traits) to consume. This is the deferred task 9.3 slice from the archived `add-warm-model-worker` change, and the predict→traits handoff on the A4 DAG (`images-downloader → predict(warm) → traits → write-back`).

New module `sleap_roots_predict/output_contract.py`; `WarmModelWorker` is unchanged (the writer sits on top of it).

OpenSpec change: **`add-predict-output-contract`** (new capability `prediction-output`, ADDED-only). `openspec validate --strict` passes.

## What changed

- **Schema (predict-local, reuses `ModelRef` from `sleap-roots-contracts`):** `PredictionArtifact` (per-root: `root_type`, `model_id`, full `ModelRef`, `slp_path`, sha256 `checksum`, `file_size`) and `PredictionManifest` (per-scan: manifest + predict-side provenance).
- **`write_prediction_outputs(...)`** — the pure per-scan writer: named per-root `.slp` (`{scan_key}.model{model_id}.root{root_type}.slp`, sleap-roots `Series`-compatible) + a combined `{scan_key}.predictions.json`. Fail-soft build identity (arg → `SRP_PREDICT_CODE_SHA`/`SRP_PREDICT_CONTAINER_DIGEST` → `""`); idempotent overwrite; `scan_key` filename-safety validation; `Path.as_posix()` throughout.
- **`ScanRequest` + `predict_and_write_batch(...)`** — drive one warm worker over N scans (one subdir per scan; resident predictors reused).
- **5 new public exports** from the package root.
- **Test-only dep:** `sleap-roots` added to the `dev` extra for the `Series.load` acceptance test (predict does **not** runtime-depend on it). `uv.lock` regenerated — purely additive, `sleap-io` held at 0.8.0.
- **Docs:** README structure tree, CHANGELOG `[Unreleased] → Added`, API.md Output Contract section, `openspec/project.md` roadmap note. (CLAUDE.md drift deferred to #15.)

## Artifacts written (per scan)

```
out_dir/{scan_key}/
├── {scan_key}.model{model_id}.rootprimary.slp
├── {scan_key}.model{model_id}.rootlateral.slp
└── {scan_key}.predictions.json   # manifest + predict-side provenance
```

## Verification

`[x]` verified · `[~]` N/A or partial · `[ ]` not done

- [x] `black --check` / `ruff` / `codespell` clean
- [x] CPU tests: **175 passed** (29 new, real inference over vendored native+legacy models, no mocks)
- [x] GPU subset (`-m gpu`): **3 passed** on real CUDA (local; CI has no GPU runner)
- [x] Downstream acceptance: output loads cleanly via `sleap_roots.Series.load` (primary/lateral labels populated)
- [x] `uv build` — sdist + wheel
- [x] Runtime-purity guard: importing the writer does not import `sleap_roots`
- [x] `openspec validate add-predict-output-contract --strict`
- [~] 3-OS CI resolution of the new `dev` dep — confirmed locally on Windows; ubuntu/macos confirmed by this PR's CI run
- [~] `docker build` — N/A (runtime image unaffected; uses `--extra cpu`, never `dev`)

## Notes

- **Schema is predict-local for now** and promoted to `sleap-roots-contracts` once A3-traits consumes it (design decision).
- **Out of scope:** BlobRef upload locations (A4 step G), full `Provenance`/`ResultEnvelope` (traits), serving entrypoint, Dockerfile build-stamp wiring.
- **Post-merge:** update the pipeline roadmap (tasks.md P.1); CLAUDE.md spec-drift cleanup tracked in #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)