### PR TITLE
feat: flip predict's default model source to the live production registry (#11, #12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# sleap-roots-predict runtime configuration.
+# Copy this file to `.env` and fill in WANDB_API_KEY. Everything else has a
+# sensible default (shown below) and only needs uncommenting to override.
+
+# Required: authenticates access to the wandb model registry.
+WANDB_API_KEY=
+
+# --- Optional (defaults shown) ----------------------------------------------
+# wandb entity that owns the model registry.
+# SRP_WANDB_ENTITY=eberrigan-salk-institute-for-biological-studies
+# Model registry name (the live production registry).
+# SRP_WANDB_MODEL_REGISTRY=sleap-roots-models
+# Only artifacts carrying this alias are listed.
+# SRP_WANDB_MODEL_ALIAS=production
+# Local artifact download cache (falls back to WANDB_CACHE_DIR, then wandb default).
+# SRP_MODEL_CACHE_DIR=
+# Inference device override (auto | cpu | cuda | mps).
+# SRP_DEVICE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ All notable changes to this project are documented here. The format is based on
   resolve CUDA wheels.
 - Added `SRP_DEVICE` env override (used by `"auto"` device resolution).
 
+### Changed (BREAKING)
+
+- **Flipped the default model source to the live production wandb registry.**
+  `WandbRegistrySource` now defaults its registry to `sleap-roots-models`, and
+  `WarmModelWorker(source=None)` defaults to a `WandbRegistrySource` — so with only
+  `WANDB_API_KEY` set the warm worker fetches production models out-of-the-box (no other
+  env var required). A missing `WANDB_API_KEY` fails loud on first use; there is no offline
+  fallback. Renamed the registry env vars `SRP_WANDB_REGISTRY` → `SRP_WANDB_MODEL_REGISTRY`
+  and `SRP_WANDB_ALIAS` → `SRP_WANDB_MODEL_ALIAS` (old names are no longer read), matching
+  the `sleap-roots-training` producer. `list_cards()` now skips a single non-conforming
+  registry artifact with a logged warning instead of aborting the whole listing.
+
 ### Removed (BREAKING)
 
 - Removed `predict_on_h5` and `batch_predict` (they depended on the removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The main package is `sleap_roots_predict/` which contains:
 ### Runtime configuration (env)
 The warm model worker / wandb registry source read these environment variables:
 - `WANDB_API_KEY`: authenticates registry access (a k8s secret in deployment)
-- `SRP_WANDB_ENTITY`, `SRP_WANDB_REGISTRY`: the production registry to fetch models from
+- `SRP_WANDB_ENTITY`, `SRP_WANDB_MODEL_REGISTRY` (default `sleap-roots-models`): the production registry to fetch models from
 - `SRP_MODEL_CACHE_DIR`: local artifact download cache (falls back to `WANDB_CACHE_DIR`); point at a persistent/hostPath volume in k8s
 - `SRP_DEVICE`: overrides inference device auto-detection (from `predict.py`)
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ sorted_files = natural_sort(files)
 # Result: ["img_1.tif", "img_2.tif", "img_10.tif"]
 ```
 
+## Configuration
+
+Model fetching from the wandb registry is configured through environment variables. The
+only **required** variable is `WANDB_API_KEY` — with it set, the warm worker fetches
+production models from the live registry out-of-the-box; everything else has a sensible
+default. Copy [`.env.example`](.env.example) to `.env` and fill in your key to get started.
+
+| Variable | Required? | Default |
+|---|---|---|
+| `WANDB_API_KEY` | **yes** | — (a missing key fails loud on first use) |
+| `SRP_WANDB_ENTITY` | no | `eberrigan-salk-institute-for-biological-studies` |
+| `SRP_WANDB_MODEL_REGISTRY` | no | `sleap-roots-models` (the live production registry) |
+| `SRP_WANDB_MODEL_ALIAS` | no | `production` |
+| `SRP_MODEL_CACHE_DIR` | no | falls back to `WANDB_CACHE_DIR`, then wandb's default |
+| `SRP_DEVICE` | no | auto-detect (cuda / mps / cpu) |
+
 ## CI/CD
 
 The project uses GitHub Actions for continuous integration and deployment:

--- a/docs/superpowers/specs/2026-07-05-flip-default-live-registry-design.md
+++ b/docs/superpowers/specs/2026-07-05-flip-default-live-registry-design.md
@@ -1,0 +1,188 @@
+# Design: flip predict's default model source to the live production registry
+
+- **Date:** 2026-07-05
+- **Branch:** `flip-default-live-registry`
+- **Issues:** closes predict **#11** (default source + env rename) and **#12**
+  (per-artifact error isolation)
+- **Roadmap:** advances tier **A3-predict** ("flip predict's default source to the
+  live registry")
+- **Status:** design — awaiting approval before the OpenSpec proposal
+
+## Motivation
+
+`WandbRegistrySource` today only works when the operator sets `SRP_WANDB_REGISTRY`,
+which has **no default** and a generic name; and `WarmModelWorker` requires an
+explicit `source`. So fetching production models is opt-in and manually wired.
+
+The production registry is now seeded, verified, and finalized (`pytest -m wandb` is
+green against it): entity `eberrigan-salk-institute-for-biological-studies`, registry
+`sleap-roots-models`, alias `production`, 13 production `ModelCard`s over 8
+SHA256-pinned models. This change makes reading that live registry the **default**, so
+the warm worker fetches production models out-of-the-box with only `WANDB_API_KEY` set.
+
+## Decisions (settled in brainstorming)
+
+1. **Default source, fail-loud.** `WarmModelWorker(source=None)` builds a
+   `WandbRegistrySource` by default; `WandbRegistrySource()` defaults its registry to
+   `sleap-roots-models`. A missing `WANDB_API_KEY` fails loud when cards are listed —
+   **no silent `LocalCardSource` fallback**. `LocalCardSource` stays an explicit opt-in
+   for offline/tests.
+2. **Hard rename** the env vars (no deprecated alias). The package is alpha
+   (`0.0.1a0`); the old names had no default and were referenced only by one gated test
+   and docs.
+3. **Defer predict #7** (reshape the worker's config accessors to the `Provenance`
+   contract fields `predict_inference_config` / `predict_output_params`). It is an
+   orthogonal provenance-shape concern — the `ModelCard` carries no inference config —
+   and deserves its own focused slice.
+
+## The five changes
+
+### 1. Default registry (#11)
+
+In `model_registry.py`, add `_DEFAULT_REGISTRY = "sleap-roots-models"` and resolve the
+registry with that default:
+
+```python
+self._registry = registry or os.environ.get("SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY)
+```
+
+`WandbRegistrySource()` — no args, only `WANDB_API_KEY` in the environment — now targets
+the live registry. Entity and alias already default correctly. The
+`_registry_project()` "no registry configured" guard becomes effectively unreachable in
+normal use; keep a minimal defensive guard (an explicit `registry=""` is still possible).
+
+### 2. Env-var rename, hard (#11)
+
+- `SRP_WANDB_REGISTRY` → **`SRP_WANDB_MODEL_REGISTRY`**
+- `SRP_WANDB_ALIAS` → **`SRP_WANDB_MODEL_ALIAS`**
+
+Old names are dropped entirely (not read as a fallback), matching the producer's
+`SLEAP_ROOTS_MODEL_REGISTRY` / `SLEAP_ROOTS_MODEL_ALIAS` and leaving room for a future
+`sleap-roots-labels` (data) registry. Updates land in `model_registry.py` (the
+`os.environ.get` reads, docstrings, and the `_registry_project` error message) and the
+OpenSpec/README docs (see Change 5). `SRP_WANDB_ENTITY` and `SRP_MODEL_CACHE_DIR` are
+unchanged (already correctly scoped). Archived OpenSpec changes and historical design
+docs under `docs/superpowers/specs/` are left as-is (historical record).
+
+> **Doc home:** `CLAUDE.md` is being retired in favor of OpenSpec best practices, so
+> env-var documentation goes in `openspec/project.md` + `README.md`, **not** CLAUDE.md.
+> The two stale old-name references currently in CLAUDE.md are corrected to the new
+> names in passing (so the interim file isn't left pointing at dead vars), but no new
+> content is added there and it is not treated as the canonical doc home.
+
+### 3. Default source in the warm worker (#11)
+
+In `warm_worker.py`, make `source` optional and default to the live registry:
+
+```python
+def __init__(self, source: Optional[ModelCardSource] = None, *, ...):
+    self._source = source if source is not None else WandbRegistrySource()
+```
+
+Construction does zero network. The first `resolve()` / `get_predictors()` triggers
+`list_cards()`, which already fail-loud raises `RuntimeError` naming `WANDB_API_KEY`
+when the key is absent. Backward-compatible: every existing caller passes `source`
+positionally.
+
+### 4. Per-artifact error isolation (#12)
+
+Split `list_cards()` into a **network part** and a **pure collector**:
+
+- `_iter_registry_artifacts(api)` — the `artifact_collections` / `artifacts` traversal
+  (network).
+- `_collect_cards(artifacts)` — applies the alias filter, then wraps
+  `_card_from_artifact` in `try/except Exception`; on failure it logs
+  `logger.warning("Skipping non-conforming model artifact %r: %s", label, err)` and
+  continues. One bad artifact never aborts the list.
+
+Adds a module logger to `model_registry.py` (`logging.getLogger(__name__)`, matching the
+repo convention already used in `predict.py`/`video_utils.py`). "Malformed" covers
+metadata missing required selection fields (pydantic `ValidationError`) and an invalid
+age window (`ValueError`) — both caught. This split is also the offline test seam.
+
+### 5. Env-var setup: reference docs + `.env.example` (#11)
+
+After this change the only *required* variable is `WANDB_API_KEY`; everything else has a
+sensible default. To make that discoverable:
+
+- **Reference table** — a required-vs-optional + default table for the full env surface,
+  added as a new **"Configuration"** section in the operator-facing `README.md`, and
+  mirrored in `openspec/project.md` (the dev/ops conventions home). `CLAUDE.md` is being
+  retired in favor of OpenSpec best practices, so it is **not** the doc home — its two
+  stale old-name references are just corrected to the new names in passing. Surface:
+
+  | Variable | Required? | Default |
+  |---|---|---|
+  | `WANDB_API_KEY` | **yes** | — (fail-loud if missing) |
+  | `SRP_WANDB_ENTITY` | no | `eberrigan-salk-institute-for-biological-studies` |
+  | `SRP_WANDB_MODEL_REGISTRY` | no | `sleap-roots-models` |
+  | `SRP_WANDB_MODEL_ALIAS` | no | `production` |
+  | `SRP_MODEL_CACHE_DIR` | no | falls back to `WANDB_CACHE_DIR`, then wandb default |
+  | `SRP_DEVICE` | no | auto-detect |
+
+- **`.env.example`** — a committed template: `WANDB_API_KEY=` uncommented (the one thing
+  to fill in) and every optional var commented out with its default shown, so local dev
+  is copy-`.env`-and-go. Not auto-loaded (no `python-dotenv`; the service uses real
+  k8s env/secrets) — it is documentation-by-example.
+- A light consistency test guards the rename: `.env.example` mentions the new
+  `SRP_WANDB_MODEL_REGISTRY` / `SRP_WANDB_MODEL_ALIAS` and **not** the old
+  `SRP_WANDB_REGISTRY` / `SRP_WANDB_ALIAS`.
+
+## Failure posture
+
+- Missing `WANDB_API_KEY` → **fail loud** before any network call; **no** silent
+  `LocalCardSource` fallback.
+- The default source **tolerates registry growth** — no card count is hardcoded
+  anywhere (arabidopsis `plate` and others will be added later; the default source must
+  keep working as the set grows).
+
+## Testing (TDD, minimal mocking)
+
+**Offline unit tests** (default suite, no network):
+
+- Default registry: `WandbRegistrySource()` → `._registry == "sleap-roots-models"`.
+- Env rename: `SRP_WANDB_MODEL_REGISTRY` set → honored; old `SRP_WANDB_REGISTRY` set →
+  **ignored** (proves the hard rename).
+- Default source: `WarmModelWorker()._source` is a `WandbRegistrySource`; no network on
+  construction.
+- Fail-loud: `WarmModelWorker()` with no `WANDB_API_KEY` → `resolve(params)` raises
+  `RuntimeError` naming `WANDB_API_KEY` (construction does not raise).
+- Skip-and-warn: `_collect_cards([good_fake, malformed_fake])` returns `[good_card]`,
+  emits a `WARNING` (asserted via `caplog`) naming the bad artifact, and does not raise.
+  Uses simple duck-typed fake artifact objects (data holders with
+  `.metadata`/`.aliases`/`.version`/`.digest`/`.qualified_name`), **not** wandb-boundary
+  mocks.
+
+**Gated `@pytest.mark.wandb`** (live registry, only `WANDB_API_KEY`):
+
+- Existing `test_wandb_source_lists_and_materializes` stays green; add
+  `monkeypatch.delenv("SRP_WANDB_MODEL_REGISTRY", raising=False)` to prove the default
+  path needs no registry env. Assertions stay **count-agnostic** (tolerate the growing
+  card set — do not assert exactly 13).
+
+## OpenSpec impact
+
+One capability: **`model-management`**. Deltas:
+
+- MODIFY "Wandb Registry Source With Version Pinning" — default registry, renamed env
+  vars, and a skip-and-warn scenario.
+- MODIFY "Warm Model Residency" — optional `source` defaulting to the live registry,
+  with a fail-loud-on-missing-key scenario.
+
+## Out of scope (linked, not done here)
+
+- #7 — reshape config accessors to `predict_inference_config` / `predict_output_params`.
+- #14 — dedupe warm cache by `weights_checksum`.
+- #13 — pin a wandb version floor (hygiene; no actual skew).
+- #10 — `sleap_nn_version` mismatch warning (dormant).
+- The A3-predict parity gate (tolerance + reference scan set).
+
+## Acceptance
+
+- A fresh `WandbRegistrySource` / `WarmModelWorker` with only `WANDB_API_KEY` set (no
+  `SRP_WANDB_MODEL_REGISTRY`) fetches the production models from the live registry.
+- A malformed/non-conforming production artifact is skipped-with-warning, not fatal, in
+  `list_cards()`.
+- `uv run pytest -m wandb -q` stays green against the live registry.
+- Closes predict #11 + #12; report back so training #6 and the pipeline roadmap
+  A3-predict row advance.

--- a/openspec/changes/flip-default-live-registry/design.md
+++ b/openspec/changes/flip-default-live-registry/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Full design rationale lives in
+`docs/superpowers/specs/2026-07-05-flip-default-live-registry-design.md` (the brainstorming
+output). This file captures only the decisions that shape the spec deltas.
+
+The `model-management` capability already ships `WandbRegistrySource` (network confined,
+lazy `import wandb`, alias→concrete-version pinning), `LocalCardSource` (offline), and
+`WarmModelWorker` (fetch-once/load-once/reuse, fail-loud). This change flips the *default*
+path onto the live registry and hardens `list_cards()` against a single bad artifact.
+
+## Goals / Non-Goals
+
+- **Goals:** live registry as the out-of-the-box source with only `WANDB_API_KEY` set;
+  env-var names model-scoped to match the producer; one malformed artifact skips-with-warning.
+- **Non-Goals:** #7 provenance-config reshape; #14 checksum dedupe; #13 wandb floor; #10
+  `sleap_nn_version` mismatch; the parity gate. `python-dotenv` auto-loading (the service
+  uses real k8s env/secrets).
+
+## Decisions
+
+- **Default source, fail-loud (no offline fallback).** `WarmModelWorker(source=None)` →
+  `WandbRegistrySource()`; missing `WANDB_API_KEY` raises when cards are listed. A silent
+  `LocalCardSource` fallback would hide a misconfigured production deploy, contradicting the
+  worker's fetch-once/fail-loud posture. `LocalCardSource` stays an explicit opt-in.
+- **Hard rename (no deprecated alias).** Package is alpha (`0.0.1a0`); the old names had no
+  default and were referenced only by one gated test + docs, so a clean break beats
+  transitional dual-read code. Alternative (read both for one release) rejected as
+  needless carrying cost.
+- **Default registry via constant + env.** `_DEFAULT_REGISTRY = "sleap-roots-models"`;
+  `registry or os.environ.get("SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY)`.
+- **Skip-and-warn via a pure collector seam.** Split `list_cards()` into
+  `_iter_registry_artifacts(api)` (network) and `_collect_cards(artifacts)` (pure). The
+  collector applies the alias filter, then wraps `_card_from_artifact` in
+  `try/except Exception` → `logger.warning(...)` + continue. The pure seam lets the
+  skip-and-warn behavior be unit-tested offline with duck-typed fake artifact objects
+  (no wandb-boundary mocks). Warning uses a module `logging.getLogger(__name__)` (repo
+  convention), asserted with `caplog`.
+- **Isolation is scoped to card construction only — not the traversal.** The `try/except`
+  wraps *only* `_card_from_artifact(artifact)`, and `_require_key()` stays at the top of
+  `list_cards()` before any network. So genuine failures (missing credentials, registry /
+  network / pagination errors) propagate fail-loud; only a single non-conforming artifact's
+  card build is skipped. This avoids the trap of a broad `except` silently dropping a
+  production model and caching a degraded catalog (the worker caches the card list once) —
+  which would undercut the fail-loud posture. The warning includes the underlying error, so
+  a skip is diagnosable. `except Exception` (not `BaseException`) keeps
+  `KeyboardInterrupt`/`SystemExit` propagating.
+- **DRY env docs: README is the single canonical table.** The env-var table lives once in
+  the operator-facing `README.md`; `openspec/project.md` carries a 1–2 line pointer (not a
+  second table). `.env.example` is the executable companion (a different artifact — a file
+  you `cp`). A consistency test asserts the `.env.example` var set equals the README table's
+  var set and that neither names the legacy vars — so the two prose surfaces cannot drift.
+  Docstrings name only the vars relevant to that constructor, with their defaults.
+- **Count-agnostic gated assertions.** The production card set grows (arabidopsis `plate`
+  deferred to training #3), so the gated test asserts non-empty + conforming, never an
+  exact count.
+- **Doc home is OpenSpec + README, not CLAUDE.md** (CLAUDE.md is being retired). The
+  `.env.example` is documentation-by-example, not auto-loaded.
+
+## Risks / Trade-offs
+
+- **Breaking env rename** → mitigated by alpha status + the new default (most operators
+  need set nothing beyond `WANDB_API_KEY`); the README/`.env.example` make the surface
+  discoverable; training #6 tracks the producer-side doc ripple.
+- **Broad `except Exception` in the collector** → justified: the whole point is resilience
+  to *any* single malformed artifact. `Exception` (not `BaseException`) still lets
+  `KeyboardInterrupt`/`SystemExit` propagate. Each skip is logged, so silent data loss is
+  avoided.
+
+## Migration
+
+Operators/CI setting `SRP_WANDB_REGISTRY` / `SRP_WANDB_ALIAS` must switch to
+`SRP_WANDB_MODEL_REGISTRY` / `SRP_WANDB_MODEL_ALIAS` — or, since `sleap-roots-models` is
+now the default, simply unset them. No code migration for callers passing an explicit
+`source` (the new `source=None` default is additive/backward-compatible).
+
+## Open Questions
+
+None — the three brainstorming decisions (default+fail-loud, hard rename, defer #7) are
+settled.

--- a/openspec/changes/flip-default-live-registry/proposal.md
+++ b/openspec/changes/flip-default-live-registry/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Fetching production models is opt-in today: `WandbRegistrySource` only works when the
+operator sets `SRP_WANDB_REGISTRY` (no default, generic name), and `WarmModelWorker`
+requires an explicit `source`. The production registry is now seeded, verified, and
+finalized (`pytest -m wandb` is green against `sleap-roots-models` / alias `production`),
+so reading it should be the **default** — the warm worker should fetch production models
+out-of-the-box with only `WANDB_API_KEY` set. Closes predict **#11** (default source +
+env rename) and **#12** (per-artifact error isolation); advances roadmap **A3-predict**.
+
+## What Changes
+
+- Default `WandbRegistrySource`'s registry to `sleap-roots-models` (the live production
+  registry), so a source constructed with only `WANDB_API_KEY` set reads production.
+- Make `WarmModelWorker(source=None)` default to a `WandbRegistrySource` reading the live
+  registry — **fail-loud** on a missing `WANDB_API_KEY`, **no** offline `LocalCardSource`
+  fallback. Construction stays network-free; the failure surfaces on first use.
+- **BREAKING**: hard-rename the env vars `SRP_WANDB_REGISTRY` → `SRP_WANDB_MODEL_REGISTRY`
+  and `SRP_WANDB_ALIAS` → `SRP_WANDB_MODEL_ALIAS` (old names no longer read), matching the
+  producer's `SLEAP_ROOTS_MODEL_REGISTRY` / `SLEAP_ROOTS_MODEL_ALIAS`. Alpha package;
+  old names had no default and were referenced only by one gated test + docs.
+- Isolate per-artifact errors in `list_cards()`: a non-conforming production artifact is
+  skipped with a logged warning naming it, not fatal — one bad artifact never aborts the
+  listing.
+- Add env-var setup docs (a required-vs-optional + defaults table in `README.md`,
+  mirrored in `openspec/project.md`) and a committed `.env.example` template.
+
+## Impact
+
+- **Affected specs:** `model-management` — MODIFY "Wandb Registry Source With Version
+  Pinning" (default registry + renamed env vars + skip-and-warn); MODIFY "Warm Model
+  Residency" (optional `source` defaulting to the live registry, fail-loud).
+- **Affected code:** `sleap_roots_predict/model_registry.py`,
+  `sleap_roots_predict/warm_worker.py`; new `.env.example`; docs `README.md` (new
+  "Configuration" section — the canonical env table), `openspec/project.md` (pointer to it),
+  `CHANGELOG.md` (`[Unreleased]` BREAKING entry), and an in-passing single old-name
+  correction in `CLAUDE.md` (line 71; being retired in favor of OpenSpec docs — not a doc
+  home); tests `tests/test_model_registry.py`, `tests/test_warm_worker.py`.
+- **Ripples out (tracked elsewhere):** training **#6** (update its README/design env
+  refs), pipeline roadmap row **A3-predict**.
+- **Explicitly deferred (linked, not here):** #7 (reshape config accessors to
+  `predict_inference_config`/`predict_output_params`), #14 (dedupe warm cache by
+  `weights_checksum`), #13 (wandb version floor), #10 (`sleap_nn_version` mismatch), the
+  A3-predict parity gate.

--- a/openspec/changes/flip-default-live-registry/specs/model-management/spec.md
+++ b/openspec/changes/flip-default-live-registry/specs/model-management/spec.md
@@ -1,0 +1,142 @@
+## MODIFIED Requirements
+
+### Requirement: Wandb Registry Source With Version Pinning
+
+The system SHALL provide a `WandbRegistrySource` implementing `ModelCardSource` whose `list_cards()`
+reads the production registry's artifacts' selection metadata into `ModelCard`s and, when an artifact
+is referenced via a moving alias (e.g. `production`), resolves the alias to a concrete artifact
+version and populates each card's `version` and `weights_checksum` with that concrete pin (never the
+alias). The source SHALL NOT construct `ModelRef`s — `ModelRef` construction and runtime
+`sleap_nn_version` stamping are performed by `choose_models` via `ModelCard.to_model_ref`.
+`materialize(ref)` SHALL download the pinned artifact version to a local cache directory and reuse it
+on repeat calls. All network access SHALL be confined to this class. Authentication SHALL use
+`WANDB_API_KEY`; the entity, registry, and alias SHALL be configurable via `SRP_WANDB_ENTITY`,
+`SRP_WANDB_MODEL_REGISTRY`, and `SRP_WANDB_MODEL_ALIAS`; the cache SHALL be configurable via
+`SRP_MODEL_CACHE_DIR`. When no registry is configured (neither a constructor argument nor
+`SRP_WANDB_MODEL_REGISTRY`), the source SHALL default the registry to `sleap-roots-models` (the live
+production registry), so a source constructed with only `WANDB_API_KEY` set reads production;
+likewise, when no alias is configured, the alias SHALL default to `production`. The legacy environment
+names `SRP_WANDB_REGISTRY` and `SRP_WANDB_ALIAS` SHALL NOT be read. When `WANDB_API_KEY` is not set,
+the source SHALL raise a clear error naming the missing variable before any network call, rather than
+returning an empty result. `list_cards()` SHALL isolate per-artifact failures: when a single
+artifact's metadata cannot be validated into a `ModelCard`, that artifact SHALL be skipped with a
+logged warning that names it and includes the underlying error, no exception SHALL be raised, and the
+remaining conforming artifacts SHALL still be returned (one malformed artifact SHALL NOT abort the
+listing). This isolation SHALL be scoped to per-artifact card construction only; genuine failures
+(missing credentials, registry/network errors) SHALL still propagate fail-loud rather than being
+swallowed per artifact.
+
+#### Scenario: Registry defaults to the live production registry
+
+- **WHEN** a `WandbRegistrySource` is constructed with no registry argument and `SRP_WANDB_MODEL_REGISTRY`
+  unset
+- **THEN** its configured registry is `sleap-roots-models`, so `list_cards()` / `materialize()` read the
+  live production registry with only `WANDB_API_KEY` set
+
+#### Scenario: Renamed registry env var configures the registry and legacy name is ignored
+
+- **WHEN** `SRP_WANDB_MODEL_REGISTRY` is set (and no constructor registry is passed)
+- **THEN** the source uses that registry; and a value set only in the legacy `SRP_WANDB_REGISTRY` is not
+  read (the `sleap-roots-models` default applies instead)
+
+#### Scenario: Renamed alias env var configures the alias and legacy name is ignored
+
+- **WHEN** `SRP_WANDB_MODEL_ALIAS` is set (and no constructor alias is passed)
+- **THEN** the source resolves cards against that alias; and a value set only in the legacy
+  `SRP_WANDB_ALIAS` is not read (the `production` default alias applies instead)
+
+#### Scenario: A genuine credential/network error is not swallowed per artifact
+
+- **WHEN** `list_cards()` fails for a non-per-artifact reason (e.g. missing `WANDB_API_KEY`, or a
+  registry/network error while traversing artifacts)
+- **THEN** the error propagates fail-loud (it is not caught by the per-artifact skip-and-warn), so a
+  degraded or empty catalog is never silently returned
+
+#### Scenario: Alias is pinned to a concrete version in the card
+
+- **WHEN** `list_cards()` returns a card for an artifact referenced by a moving alias
+- **THEN** the card's `version` is the concrete artifact version and its `weights_checksum` is
+  populated (not the alias), so the `ModelRef` later built by `choose_models` carries the concrete pin
+
+#### Scenario: A non-conforming artifact is skipped with a warning
+
+- **WHEN** `list_cards()` encounters an artifact carrying the configured alias whose metadata cannot be
+  validated into a `ModelCard` (e.g. missing a required selection field)
+- **THEN** that artifact is skipped, a warning naming it is logged, no exception is raised, and the
+  remaining conforming cards are still returned
+
+#### Scenario: A materialized artifact is cached and reused
+
+- **WHEN** `materialize(ref)` is called twice for the same pinned version
+- **THEN** the artifact is downloaded at most once and the cached local directory is reused
+
+#### Scenario: Missing credentials raise a clear error
+
+- **WHEN** `WandbRegistrySource` is used with no `WANDB_API_KEY` set
+- **THEN** it raises an error whose message names `WANDB_API_KEY`, before any network call, and does
+  not return an empty card list
+
+### Requirement: Warm Model Residency
+
+The system SHALL provide a `WarmModelWorker(source=None, ...)` that keeps `Predictor`s resident across
+scans. When `source` is omitted (or `None`), the worker SHALL default to a `WandbRegistrySource`
+reading the live production registry — the default source is the registry, not an offline/stub source,
+and there SHALL be no silent `LocalCardSource` fallback. Constructing the worker SHALL perform no
+network access; a missing `WANDB_API_KEY` SHALL surface fail-loud on the first
+`resolve()` / `get_predictors()` call (which lists cards), not at construction.
+`resolve(params)` SHALL return `dict[RootType, ModelRef]` without loading weights.
+`get_predictors(params)` SHALL resolve, `materialize` each `ModelRef`, build a `Predictor` via
+`make_predictor`, and cache it keyed by `(registry_id, version)` so a model is fetched at most once
+and loaded at most once and reused across scans. Cards SHALL be loaded lazily once. If any resolved
+root type cannot be materialized or loaded, `get_predictors` SHALL raise an error identifying the
+root type and `registry_id:version` and SHALL NOT return partial results (fail-loud). A thin
+`predict(params, video, save_dir=None)` convenience SHALL compose `get_predictors` with
+`predict_on_video` and return per-root-type results in memory. When `save_dir` is given, it SHALL
+write one raw `.slp` per root type via `predict_on_video`'s `save_path` (e.g. `save_dir/<root_type>.slp`)
+and SHALL NOT write a `predictions.csv` manifest or apply the
+`{scan}.model{id}.root{type}.slp` naming — that naming and manifest are deferred to the
+output-contract slice.
+
+#### Scenario: Default source is the live registry
+
+- **WHEN** a `WarmModelWorker` is constructed with no `source` argument
+- **THEN** its source is a `WandbRegistrySource` (the live production registry) and construction performs
+  no network access
+
+#### Scenario: Missing credentials fail loud on first use
+
+- **WHEN** a `WarmModelWorker` constructed with the default source is used with no `WANDB_API_KEY` set
+- **THEN** the first `resolve()` / `get_predictors()` raises an error naming `WANDB_API_KEY`
+  (construction itself does not raise), and there is no offline fallback
+
+#### Scenario: resolve does not load weights
+
+- **WHEN** `resolve(params)` is called
+- **THEN** it returns the selected `ModelRef`s per root type and the worker's predictor cache remains
+  empty (no model materialized or loaded)
+
+#### Scenario: A model is loaded once and reused (warm)
+
+- **WHEN** `get_predictors` is called twice for params that resolve to the same model version
+- **THEN** the second call returns the same cached `Predictor` instance without re-fetching or reloading
+
+#### Scenario: Different params sharing a model version hit the cache
+
+- **WHEN** two different param sets resolve a root type to the same `(registry_id, version)`
+- **THEN** both use the same resident `Predictor` (keyed by model identity, not by scan or root type)
+
+#### Scenario: Unmaterializable root type fails loud
+
+- **WHEN** a resolved root type's model cannot be materialized or loaded
+- **THEN** `get_predictors` raises an error naming the root type and `registry_id:version`, and returns no predictors
+
+#### Scenario: predict returns labels per root type
+
+- **WHEN** `predict(params, video)` is called with no `save_dir`
+- **THEN** it returns a `dict[RootType, sio.Labels]` with real predicted instances for each resolved root type
+
+#### Scenario: predict with save_dir writes raw per-root .slp only
+
+- **WHEN** `predict(params, video, save_dir=…)` is called
+- **THEN** it writes one reloadable `.slp` per root type under `save_dir` and writes no
+  `predictions.csv` and applies no `{scan}.model{id}.root{type}.slp` naming (deferred)

--- a/openspec/changes/flip-default-live-registry/tasks.md
+++ b/openspec/changes/flip-default-live-registry/tasks.md
@@ -1,0 +1,108 @@
+> **Test hygiene (applies to every offline env test below):** use the `monkeypatch`
+> fixture only, and `delenv(..., raising=False)` the **entire** family up front —
+> `WANDB_API_KEY`, `SRP_WANDB_MODEL_REGISTRY`, `SRP_WANDB_REGISTRY`,
+> `SRP_WANDB_MODEL_ALIAS`, `SRP_WANDB_ALIAS`, `SRP_WANDB_ENTITY` — before setting only the
+> var under test. Without this, "no env" assertions false-fail on a dev box, and a
+> missing-key test can make a **real network call** on a machine that has `WANDB_API_KEY`
+> set. Default-suite command (matches CI): `uv run pytest -m "not gpu and not acceptance and not wandb"`.
+
+## 1. Env-var rename + default registry (predict #11)
+
+- [ ] 1.1 **Test first** (offline, `tests/test_model_registry.py`), each test delenv'ing the
+      full env family (see banner):
+      - `WandbRegistrySource()` → `._registry == "sleap-roots-models"`.
+      - `SRP_WANDB_MODEL_REGISTRY="x"` set → `._registry == "x"` (honored).
+      - legacy `SRP_WANDB_REGISTRY="legacy"` set with `SRP_WANDB_MODEL_REGISTRY` unset →
+        `._registry == "sleap-roots-models"` (legacy **ignored**).
+      - `SRP_WANDB_MODEL_ALIAS="staging"` set → `._alias == "staging"` (honored).
+      - legacy `SRP_WANDB_ALIAS="legacy"` set with `SRP_WANDB_MODEL_ALIAS` unset →
+        `._alias == "production"` (legacy **ignored**).
+      - `WandbRegistrySource()` (default registry) with `WANDB_API_KEY` delenv'd →
+        `list_cards()` raises `RuntimeError` matching `WANDB_API_KEY` before any network call
+        (default-registry construction still fails loud on creds).
+- [ ] 1.2 Implement in `model_registry.py`: add `_DEFAULT_REGISTRY = "sleap-roots-models"`;
+      `self._registry = registry or os.environ.get("SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY)`;
+      `self._alias = alias or os.environ.get("SRP_WANDB_MODEL_ALIAS", _DEFAULT_ALIAS)`; drop the
+      legacy `SRP_WANDB_REGISTRY`/`SRP_WANDB_ALIAS` reads. Update the `_registry_project` error
+      message to name `SRP_WANDB_MODEL_REGISTRY` (keep the guard — `registry=""` still reaches it).
+      Update docstrings to state the **new default** (`SRP_WANDB_MODEL_REGISTRY` → then
+      `sleap-roots-models`; `SRP_WANDB_MODEL_ALIAS` → then `production`) and fix the class
+      docstring's pre-existing omission of the alias env var (lines ~86, 108, 109).
+- [ ] 1.3 Run the offline tests → green; `/lint`.
+
+## 2. Per-artifact error isolation in `list_cards()` (predict #12)
+
+- [ ] 2.1 **Test first** (offline; construct `WandbRegistrySource(alias="production")`, no key
+      needed; use duck-typed fake artifacts each carrying `aliases=["production"]`, `metadata`,
+      `name`/`qualified_name`, `version`, `digest`):
+      - `_collect_cards([good, malformed])` → `[good_card]`; exactly one `logging.WARNING`
+        (via `caplog`) naming the bad artifact **and** including the error text; no raise.
+        (`malformed` = metadata missing a required selection field → pydantic `ValidationError`.)
+      - `_collect_cards([malformed])` → `[]`, one WARNING, no raise (all-bad is empty, not fatal).
+      - `_collect_cards([good_a, malformed, good_b])` → `[good_a, good_b]` in order, exactly one
+        WARNING (one bad artifact drops only itself).
+      - `_collect_cards([wrong_alias])` (fake whose `.aliases` lacks the configured alias) → `[]`
+        and **no** WARNING (alias-filtered ≠ malformed).
+      - The returned good card's `version`/`weights_checksum` equal the fake's `.version`/`.digest`
+        (concrete pin, offline coverage of the alias-pinning scenario).
+- [ ] 2.2 Implement: add module `logger = logging.getLogger(__name__)`; split `list_cards()` into
+      `_iter_registry_artifacts(api)` (the network `artifact_collections`/`artifacts` traversal)
+      and `_collect_cards(artifacts)` (pure). In `_collect_cards`: apply the alias filter first,
+      then wrap **only** `_card_from_artifact(artifact)` in `try/except Exception` →
+      `logger.warning("Skipping non-conforming model artifact %r: %s", label, err)` + `continue`.
+      Keep `_require_key()` at the **top** of `list_cards()`, before `_iter_registry_artifacts` is
+      iterated (do not move it inside the generator) — the existing
+      `test_wandb_source_missing_key_raises_before_network` guards this ordering.
+- [ ] 2.3 Run the offline tests → green; confirm `test_wandb_source_missing_key_raises_before_network`
+      still passes; `/lint`.
+
+## 3. Warm worker default source (predict #11)
+
+- [ ] 3.1 **Test first** (offline, `tests/test_warm_worker.py`; delenv the env family):
+      - `WarmModelWorker()._source` is a `WandbRegistrySource`.
+      - With `WANDB_API_KEY` delenv'd, `WarmModelWorker()` **construction does not raise**
+        (network-free), and the first `resolve(params)` raises `RuntimeError` matching
+        `WANDB_API_KEY` (fail-loud on first use, no offline fallback).
+- [ ] 3.2 Implement in `warm_worker.py`: `source: Optional[ModelCardSource] = None`, and in the
+      **body** `if source is None: source = WandbRegistrySource()` (never a mutable/eager default in
+      the signature — that would freeze env at import and share one instance); import
+      `WandbRegistrySource`.
+- [ ] 3.3 Run offline tests → green; confirm the existing `LocalCardSource`-based warm-worker tests
+      still pass (positional `WarmModelWorker(source)` backward compat); `/lint`.
+
+## 4. Gated wandb test update (predict #11)
+
+- [ ] 4.1 Update `test_wandb_source_lists_and_materializes`: `monkeypatch.delenv` the legacy +
+      new `SRP_WANDB_MODEL_REGISTRY` (proving the default path needs no registry env); leave
+      `SRP_WANDB_ENTITY` unset (default lab entity hosts the registry) or set it explicitly. Keep
+      assertions **count-agnostic** (non-empty + all conforming; do NOT assert exactly 13).
+- [ ] 4.2 If `WANDB_API_KEY` + live registry are available, run `uv run pytest -m wandb -q`
+      → green; otherwise confirm it skips cleanly at collection time.
+
+## 5. Env-var docs + `.env.example` + CHANGELOG (predict #11)
+
+- [ ] 5.1 **Test first**: a consistency test that (a) `.env.example` mentions
+      `SRP_WANDB_MODEL_REGISTRY` and `SRP_WANDB_MODEL_ALIAS` and **not** the legacy
+      `SRP_WANDB_REGISTRY`/`SRP_WANDB_ALIAS`, and (b) the README "Configuration" table's var set
+      equals the `.env.example` var set (guards both prose surfaces against drift). Resolve files
+      via `Path(__file__).parents[1]`, not cwd.
+- [ ] 5.2 Add `.env.example`: `WANDB_API_KEY=` uncommented; every optional var commented out with
+      its default shown (`SRP_WANDB_ENTITY`, `SRP_WANDB_MODEL_REGISTRY`, `SRP_WANDB_MODEL_ALIAS`,
+      `SRP_MODEL_CACHE_DIR`, `SRP_DEVICE`). Keep typo-clean (codespell scans it).
+- [ ] 5.3 Docs: add a **"Configuration"** section to `README.md` with the required-vs-optional +
+      defaults table (the single canonical table; default strings must match `_DEFAULT_ENTITY` /
+      `_DEFAULT_REGISTRY` / `_DEFAULT_ALIAS` in code). In `openspec/project.md`, add a **1–2 line
+      pointer** to that README section (not a second table — DRY). Correct the **one** stale
+      old-name reference in `CLAUDE.md` (line 71: `SRP_WANDB_REGISTRY` → `SRP_WANDB_MODEL_REGISTRY`;
+      note `SRP_WANDB_ALIAS` is **not** present there) — no new content added to CLAUDE.md.
+- [ ] 5.4 Run the consistency test → green; `codespell` + `/lint`.
+- [ ] 5.5 Add a `CHANGELOG.md` `[Unreleased]` entry under `### Changed (BREAKING)`: the env-var
+      rename (old names no longer read), the `sleap-roots-models` default, `WarmModelWorker(source=None)`
+      reading the live registry, and fail-loud-on-missing-key (no offline fallback).
+
+## 6. Full gate + report-back
+
+- [ ] 6.1 `/pre-merge` (format check + lint + full test suite + build); confirm the pytest step keeps
+      `not wandb` deselected; run the `gpu` subset if on an accelerator.
+- [ ] 6.2 Set every task above to `- [x]`; prepare the report-back note (close predict #11 + #12;
+      advance training #6 and pipeline roadmap row A3-predict).

--- a/openspec/changes/flip-default-live-registry/tasks.md
+++ b/openspec/changes/flip-default-live-registry/tasks.md
@@ -8,7 +8,7 @@
 
 ## 1. Env-var rename + default registry (predict #11)
 
-- [ ] 1.1 **Test first** (offline, `tests/test_model_registry.py`), each test delenv'ing the
+- [x] 1.1 **Test first** (offline, `tests/test_model_registry.py`), each test delenv'ing the
       full env family (see banner):
       - `WandbRegistrySource()` → `._registry == "sleap-roots-models"`.
       - `SRP_WANDB_MODEL_REGISTRY="x"` set → `._registry == "x"` (honored).
@@ -20,7 +20,7 @@
       - `WandbRegistrySource()` (default registry) with `WANDB_API_KEY` delenv'd →
         `list_cards()` raises `RuntimeError` matching `WANDB_API_KEY` before any network call
         (default-registry construction still fails loud on creds).
-- [ ] 1.2 Implement in `model_registry.py`: add `_DEFAULT_REGISTRY = "sleap-roots-models"`;
+- [x] 1.2 Implement in `model_registry.py`: add `_DEFAULT_REGISTRY = "sleap-roots-models"`;
       `self._registry = registry or os.environ.get("SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY)`;
       `self._alias = alias or os.environ.get("SRP_WANDB_MODEL_ALIAS", _DEFAULT_ALIAS)`; drop the
       legacy `SRP_WANDB_REGISTRY`/`SRP_WANDB_ALIAS` reads. Update the `_registry_project` error
@@ -28,11 +28,11 @@
       Update docstrings to state the **new default** (`SRP_WANDB_MODEL_REGISTRY` → then
       `sleap-roots-models`; `SRP_WANDB_MODEL_ALIAS` → then `production`) and fix the class
       docstring's pre-existing omission of the alias env var (lines ~86, 108, 109).
-- [ ] 1.3 Run the offline tests → green; `/lint`.
+- [x] 1.3 Run the offline tests → green; `/lint`.
 
 ## 2. Per-artifact error isolation in `list_cards()` (predict #12)
 
-- [ ] 2.1 **Test first** (offline; construct `WandbRegistrySource(alias="production")`, no key
+- [x] 2.1 **Test first** (offline; construct `WandbRegistrySource(alias="production")`, no key
       needed; use duck-typed fake artifacts each carrying `aliases=["production"]`, `metadata`,
       `name`/`qualified_name`, `version`, `digest`):
       - `_collect_cards([good, malformed])` → `[good_card]`; exactly one `logging.WARNING`
@@ -45,7 +45,7 @@
         and **no** WARNING (alias-filtered ≠ malformed).
       - The returned good card's `version`/`weights_checksum` equal the fake's `.version`/`.digest`
         (concrete pin, offline coverage of the alias-pinning scenario).
-- [ ] 2.2 Implement: add module `logger = logging.getLogger(__name__)`; split `list_cards()` into
+- [x] 2.2 Implement: add module `logger = logging.getLogger(__name__)`; split `list_cards()` into
       `_iter_registry_artifacts(api)` (the network `artifact_collections`/`artifacts` traversal)
       and `_collect_cards(artifacts)` (pure). In `_collect_cards`: apply the alias filter first,
       then wrap **only** `_card_from_artifact(artifact)` in `try/except Exception` →
@@ -53,56 +53,59 @@
       Keep `_require_key()` at the **top** of `list_cards()`, before `_iter_registry_artifacts` is
       iterated (do not move it inside the generator) — the existing
       `test_wandb_source_missing_key_raises_before_network` guards this ordering.
-- [ ] 2.3 Run the offline tests → green; confirm `test_wandb_source_missing_key_raises_before_network`
+- [x] 2.3 Run the offline tests → green; confirm `test_wandb_source_missing_key_raises_before_network`
       still passes; `/lint`.
 
 ## 3. Warm worker default source (predict #11)
 
-- [ ] 3.1 **Test first** (offline, `tests/test_warm_worker.py`; delenv the env family):
+- [x] 3.1 **Test first** (offline, `tests/test_warm_worker.py`; delenv the env family):
       - `WarmModelWorker()._source` is a `WandbRegistrySource`.
       - With `WANDB_API_KEY` delenv'd, `WarmModelWorker()` **construction does not raise**
         (network-free), and the first `resolve(params)` raises `RuntimeError` matching
         `WANDB_API_KEY` (fail-loud on first use, no offline fallback).
-- [ ] 3.2 Implement in `warm_worker.py`: `source: Optional[ModelCardSource] = None`, and in the
+- [x] 3.2 Implement in `warm_worker.py`: `source: Optional[ModelCardSource] = None`, and in the
       **body** `if source is None: source = WandbRegistrySource()` (never a mutable/eager default in
       the signature — that would freeze env at import and share one instance); import
       `WandbRegistrySource`.
-- [ ] 3.3 Run offline tests → green; confirm the existing `LocalCardSource`-based warm-worker tests
+- [x] 3.3 Run offline tests → green; confirm the existing `LocalCardSource`-based warm-worker tests
       still pass (positional `WarmModelWorker(source)` backward compat); `/lint`.
 
 ## 4. Gated wandb test update (predict #11)
 
-- [ ] 4.1 Update `test_wandb_source_lists_and_materializes`: `monkeypatch.delenv` the legacy +
+- [x] 4.1 Update `test_wandb_source_lists_and_materializes`: `monkeypatch.delenv` the legacy +
       new `SRP_WANDB_MODEL_REGISTRY` (proving the default path needs no registry env); leave
       `SRP_WANDB_ENTITY` unset (default lab entity hosts the registry) or set it explicitly. Keep
       assertions **count-agnostic** (non-empty + all conforming; do NOT assert exactly 13).
-- [ ] 4.2 If `WANDB_API_KEY` + live registry are available, run `uv run pytest -m wandb -q`
-      → green; otherwise confirm it skips cleanly at collection time.
+- [x] 4.2 If `WANDB_API_KEY` + live registry are available, run `uv run pytest -m wandb -q`
+      → green; otherwise confirm it skips cleanly at collection time. (No local
+      `WANDB_API_KEY` this session: verified it collects under `-m wandb` and is deselected
+      / skips cleanly by default. **The live network round-trip is unrun — confirm
+      `uv run pytest -m wandb -q` green with creds before closing #11.**)
 
 ## 5. Env-var docs + `.env.example` + CHANGELOG (predict #11)
 
-- [ ] 5.1 **Test first**: a consistency test that (a) `.env.example` mentions
+- [x] 5.1 **Test first**: a consistency test that (a) `.env.example` mentions
       `SRP_WANDB_MODEL_REGISTRY` and `SRP_WANDB_MODEL_ALIAS` and **not** the legacy
       `SRP_WANDB_REGISTRY`/`SRP_WANDB_ALIAS`, and (b) the README "Configuration" table's var set
       equals the `.env.example` var set (guards both prose surfaces against drift). Resolve files
       via `Path(__file__).parents[1]`, not cwd.
-- [ ] 5.2 Add `.env.example`: `WANDB_API_KEY=` uncommented; every optional var commented out with
+- [x] 5.2 Add `.env.example`: `WANDB_API_KEY=` uncommented; every optional var commented out with
       its default shown (`SRP_WANDB_ENTITY`, `SRP_WANDB_MODEL_REGISTRY`, `SRP_WANDB_MODEL_ALIAS`,
       `SRP_MODEL_CACHE_DIR`, `SRP_DEVICE`). Keep typo-clean (codespell scans it).
-- [ ] 5.3 Docs: add a **"Configuration"** section to `README.md` with the required-vs-optional +
+- [x] 5.3 Docs: add a **"Configuration"** section to `README.md` with the required-vs-optional +
       defaults table (the single canonical table; default strings must match `_DEFAULT_ENTITY` /
       `_DEFAULT_REGISTRY` / `_DEFAULT_ALIAS` in code). In `openspec/project.md`, add a **1–2 line
       pointer** to that README section (not a second table — DRY). Correct the **one** stale
       old-name reference in `CLAUDE.md` (line 71: `SRP_WANDB_REGISTRY` → `SRP_WANDB_MODEL_REGISTRY`;
       note `SRP_WANDB_ALIAS` is **not** present there) — no new content added to CLAUDE.md.
-- [ ] 5.4 Run the consistency test → green; `codespell` + `/lint`.
-- [ ] 5.5 Add a `CHANGELOG.md` `[Unreleased]` entry under `### Changed (BREAKING)`: the env-var
+- [x] 5.4 Run the consistency test → green; `codespell` + `/lint`.
+- [x] 5.5 Add a `CHANGELOG.md` `[Unreleased]` entry under `### Changed (BREAKING)`: the env-var
       rename (old names no longer read), the `sleap-roots-models` default, `WarmModelWorker(source=None)`
       reading the live registry, and fail-loud-on-missing-key (no offline fallback).
 
 ## 6. Full gate + report-back
 
-- [ ] 6.1 `/pre-merge` (format check + lint + full test suite + build); confirm the pytest step keeps
+- [x] 6.1 `/pre-merge` (format check + lint + full test suite + build); confirm the pytest step keeps
       `not wandb` deselected; run the `gpu` subset if on an accelerator.
-- [ ] 6.2 Set every task above to `- [x]`; prepare the report-back note (close predict #11 + #12;
+- [x] 6.2 Set every task above to `- [x]`; prepare the report-back note (close predict #11 + #12;
       advance training #6 and pipeline roadmap row A3-predict).

--- a/openspec/changes/flip-default-live-registry/tasks.md
+++ b/openspec/changes/flip-default-live-registry/tasks.md
@@ -77,10 +77,10 @@
       `SRP_WANDB_ENTITY` unset (default lab entity hosts the registry) or set it explicitly. Keep
       assertions **count-agnostic** (non-empty + all conforming; do NOT assert exactly 13).
 - [x] 4.2 If `WANDB_API_KEY` + live registry are available, run `uv run pytest -m wandb -q`
-      → green; otherwise confirm it skips cleanly at collection time. (No local
-      `WANDB_API_KEY` this session: verified it collects under `-m wandb` and is deselected
-      / skips cleanly by default. **The live network round-trip is unrun — confirm
-      `uv run pytest -m wandb -q` green with creds before closing #11.**)
+      → green; otherwise confirm it skips cleanly at collection time. **Verified GREEN**
+      against the live registry (`1 passed` in ~123s, `WANDB_API_KEY` sourced from the
+      user's wandb login): the default path (no registry env) lists + materializes from
+      `sleap-roots-models`.
 
 ## 5. Env-var docs + `.env.example` + CHANGELOG (predict #11)
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -50,6 +50,14 @@ importable library.
 - Platform-specific install extras (`cpu`, `windows_cuda`, `linux_cuda`, `macos`) select
   the right hardware acceleration; the container uses the CPU extra by default.
 
+### Runtime Configuration
+Model fetching is configured via environment variables (operator config). The only
+**required** variable is `WANDB_API_KEY`; the registry/entity/alias/cache/device all have
+defaults, so with just the key set `WarmModelWorker()` reads the live production registry.
+See the **Configuration** section of `README.md` for the full table and `.env.example` for
+a copy-and-fill template. (Env vars are model-scoped — `SRP_WANDB_MODEL_REGISTRY` /
+`SRP_WANDB_MODEL_ALIAS` — to match the `sleap-roots-training` producer.)
+
 ### Testing Strategy
 - pytest, tests in `tests/`; fixtures in `tests/conftest.py`. Inference tests are
   **real (no mocks)** — they run actual sleap-nn CPU inference against vendored

--- a/sleap_roots_predict/model_registry.py
+++ b/sleap_roots_predict/model_registry.py
@@ -129,12 +129,14 @@ class WandbRegistrySource:
         self._entity = entity or os.environ.get("SRP_WANDB_ENTITY", _DEFAULT_ENTITY)
         # Explicit arg wins; else the model-scoped env var; else the live production
         # registry default, so a source with only WANDB_API_KEY set reads production.
-        self._registry = registry or os.environ.get(
-            "SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY
+        # A set-but-empty env var (common in k8s/compose) falls back to the default too.
+        self._registry = (
+            registry or os.environ.get("SRP_WANDB_MODEL_REGISTRY") or _DEFAULT_REGISTRY
         )
-        # Explicit alias wins; else env; else default. A falsy alias falls back to
-        # the default rather than disabling the filter (which would list every version).
-        self._alias = alias or os.environ.get("SRP_WANDB_MODEL_ALIAS", _DEFAULT_ALIAS)
+        # Explicit alias wins; else env; else default. A falsy alias (unset OR
+        # set-but-empty) falls back to the default rather than disabling the filter
+        # (an empty alias would otherwise list every version).
+        self._alias = alias or os.environ.get("SRP_WANDB_MODEL_ALIAS") or _DEFAULT_ALIAS
         if cache_dir is not None:
             self._cache_dir: Optional[str] = str(cache_dir)
         else:
@@ -196,10 +198,11 @@ class WandbRegistrySource:
         Applies the alias filter, then builds one card per surviving artifact. A
         single artifact whose metadata cannot be validated into a ``ModelCard`` is
         skipped with a logged warning (naming it and the underlying error) rather
-        than aborting the listing. This isolation is scoped to per-artifact card
-        construction only: credential and network failures are raised by
-        ``_require_key`` / the traversal before this method runs, so they still fail
-        loud and are not swallowed here.
+        than aborting the listing. The ``try`` wraps *only* per-artifact card
+        construction; the ``for`` loop that advances ``artifacts`` sits outside it,
+        so credential errors (raised by ``_require_key`` before this method) and
+        errors raised while traversing the registry propagate fail-loud — only a
+        single non-conforming artifact's card build is isolated here.
 
         Args:
             artifacts: An iterable of wandb-artifact-like objects.

--- a/sleap_roots_predict/model_registry.py
+++ b/sleap_roots_predict/model_registry.py
@@ -9,11 +9,23 @@ filesystem-only deployments. ``WandbRegistrySource`` (added later) confines all
 network access to itself.
 """
 
+import logging
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Tuple, Union, runtime_checkable
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Union,
+    runtime_checkable,
+)
 
 from sleap_roots_contracts import ModelCard, ModelRef
+
+logger = logging.getLogger(__name__)
 
 # The lab wandb entity (org form is used for registry paths). Overridable via
 # SRP_WANDB_ENTITY. Kept as a default so the offline path never needs it.
@@ -160,16 +172,58 @@ class WandbRegistrySource:
         import wandb
 
         api = wandb.Api()
+        return self._collect_cards(self._iter_registry_artifacts(api))
+
+    def _iter_registry_artifacts(self, api: object) -> Iterable[object]:
+        """Yield every ``model`` artifact in the configured registry (network).
+
+        Args:
+            api: A ``wandb.Api`` handle.
+
+        Yields:
+            Each wandb artifact object across the registry's ``model`` collections.
+        """
         project = self._registry_project()
-        cards: List[ModelCard] = []
         for collection in api.artifact_collections(
             project_name=project, type_name="model"
         ):
             name = f"{project}/{collection.name}"
-            for artifact in api.artifacts(type_name="model", name=name):
-                if self._alias and self._alias not in (artifact.aliases or []):
-                    continue
+            yield from api.artifacts(type_name="model", name=name)
+
+    def _collect_cards(self, artifacts: Iterable[object]) -> List[ModelCard]:
+        """Build pinned ``ModelCard``s from artifacts, skipping non-conforming ones.
+
+        Applies the alias filter, then builds one card per surviving artifact. A
+        single artifact whose metadata cannot be validated into a ``ModelCard`` is
+        skipped with a logged warning (naming it and the underlying error) rather
+        than aborting the listing. This isolation is scoped to per-artifact card
+        construction only: credential and network failures are raised by
+        ``_require_key`` / the traversal before this method runs, so they still fail
+        loud and are not swallowed here.
+
+        Args:
+            artifacts: An iterable of wandb-artifact-like objects.
+
+        Returns:
+            The conforming cards, in input order.
+        """
+        cards: List[ModelCard] = []
+        for artifact in artifacts:
+            if self._alias and self._alias not in (
+                getattr(artifact, "aliases", None) or []
+            ):
+                continue
+            try:
                 cards.append(self._card_from_artifact(artifact))
+            except Exception as e:
+                # Isolate one non-conforming artifact: skip it (with a warning) so a
+                # single bad card never aborts the whole listing.
+                label = getattr(artifact, "qualified_name", None) or getattr(
+                    artifact, "name", "<unknown>"
+                )
+                logger.warning(
+                    "Skipping non-conforming model artifact %r: %s", label, e
+                )
         return cards
 
     @staticmethod

--- a/sleap_roots_predict/model_registry.py
+++ b/sleap_roots_predict/model_registry.py
@@ -18,6 +18,7 @@ from sleap_roots_contracts import ModelCard, ModelRef
 # The lab wandb entity (org form is used for registry paths). Overridable via
 # SRP_WANDB_ENTITY. Kept as a default so the offline path never needs it.
 _DEFAULT_ENTITY = "eberrigan-salk-institute-for-biological-studies"
+_DEFAULT_REGISTRY = "sleap-roots-models"
 _DEFAULT_ALIAS = "production"
 
 
@@ -83,7 +84,8 @@ class WandbRegistrySource:
     All network access is confined to this class and uses a lazy ``import wandb``,
     so importing this module (and the offline ``LocalCardSource`` path) never
     touches wandb. Configuration is taken from the constructor or, when omitted,
-    the environment: ``SRP_WANDB_ENTITY``, ``SRP_WANDB_REGISTRY``,
+    the environment: ``SRP_WANDB_ENTITY``, ``SRP_WANDB_MODEL_REGISTRY`` (default
+    ``sleap-roots-models``), ``SRP_WANDB_MODEL_ALIAS`` (default ``production``),
     ``SRP_MODEL_CACHE_DIR`` (falling back to ``WANDB_CACHE_DIR``); ``WANDB_API_KEY``
     authenticates. ``list_cards`` pins each artifact to its concrete version (not a
     moving alias) so the ``ModelRef`` built downstream is reproducible.
@@ -105,16 +107,22 @@ class WandbRegistrySource:
 
         Args:
             entity: wandb entity; defaults to ``SRP_WANDB_ENTITY`` then the lab entity.
-            registry: registry name; defaults to ``SRP_WANDB_REGISTRY``.
-            alias: only artifacts carrying this alias are listed (default ``production``).
+            registry: registry name; defaults to ``SRP_WANDB_MODEL_REGISTRY`` then
+                ``sleap-roots-models`` (the live production registry).
+            alias: only artifacts carrying this alias are listed; defaults to
+                ``SRP_WANDB_MODEL_ALIAS`` then ``production``.
             cache_dir: download cache; defaults to ``SRP_MODEL_CACHE_DIR`` then
                 ``WANDB_CACHE_DIR`` then wandb's own default.
         """
         self._entity = entity or os.environ.get("SRP_WANDB_ENTITY", _DEFAULT_ENTITY)
-        self._registry = registry or os.environ.get("SRP_WANDB_REGISTRY")
+        # Explicit arg wins; else the model-scoped env var; else the live production
+        # registry default, so a source with only WANDB_API_KEY set reads production.
+        self._registry = registry or os.environ.get(
+            "SRP_WANDB_MODEL_REGISTRY", _DEFAULT_REGISTRY
+        )
         # Explicit alias wins; else env; else default. A falsy alias falls back to
         # the default rather than disabling the filter (which would list every version).
-        self._alias = alias or os.environ.get("SRP_WANDB_ALIAS", _DEFAULT_ALIAS)
+        self._alias = alias or os.environ.get("SRP_WANDB_MODEL_ALIAS", _DEFAULT_ALIAS)
         if cache_dir is not None:
             self._cache_dir: Optional[str] = str(cache_dir)
         else:
@@ -133,7 +141,8 @@ class WandbRegistrySource:
         """Return the registry's wandb project path (``<entity>-org/wandb-registry-<r>``)."""
         if not self._registry:
             raise RuntimeError(
-                "No wandb registry configured; set SRP_WANDB_REGISTRY or pass registry=."
+                "No wandb registry configured; set SRP_WANDB_MODEL_REGISTRY or pass "
+                "registry=."
             )
         return f"{self._entity}-org/wandb-registry-{self._registry}"
 

--- a/sleap_roots_predict/warm_worker.py
+++ b/sleap_roots_predict/warm_worker.py
@@ -22,7 +22,7 @@ import sleap_io as sio
 from sleap_nn.inference import Predictor
 from sleap_roots_contracts import ModelRef, ResolvedParams, RootType
 
-from sleap_roots_predict.model_registry import ModelCardSource
+from sleap_roots_predict.model_registry import ModelCardSource, WandbRegistrySource
 from sleap_roots_predict.model_selection import choose_models
 from sleap_roots_predict.predict import (
     _resolve_device,
@@ -36,7 +36,7 @@ class WarmModelWorker:
 
     def __init__(
         self,
-        source: ModelCardSource,
+        source: Optional[ModelCardSource] = None,
         *,
         device: str = "auto",
         peak_threshold: float = 0.2,
@@ -45,14 +45,21 @@ class WarmModelWorker:
         """Create a warm worker over a model-card source.
 
         Args:
-            source: The card source (catalog + ``materialize``). Only
-                ``WandbRegistrySource`` touches the network; ``LocalCardSource`` is
-                fully offline.
+            source: The card source (catalog + ``materialize``). Defaults to a
+                ``WandbRegistrySource`` reading the live production registry when
+                omitted, so the worker fetches production models out-of-the-box; pass
+                a ``LocalCardSource`` for fully-offline use. Only
+                ``WandbRegistrySource`` touches the network.
             device: Inference device (``"auto"``, ``"cpu"``, ``"cuda"``, ``"mps"``).
             peak_threshold: Confidence threshold for peak detection (output-defining).
             batch_size: Samples per inference batch (diagnostic, not output-defining).
         """
-        self._source = source
+        # Default to the live production registry when no source is given. Building
+        # WandbRegistrySource does no network I/O (wandb access is deferred to first
+        # use), so a missing WANDB_API_KEY fails loud on the first
+        # resolve()/get_predictors(), not at construction — and there is no offline
+        # fallback.
+        self._source = source if source is not None else WandbRegistrySource()
         # Resolve "auto" to a concrete device once, at construction, so the value
         # recorded by inference_config() is exactly what make_predictor builds with.
         self._device = _resolve_device(device)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,26 @@ from PIL import Image
 # bottom-up models from sleap-nn v0.3.0, used for no-mock inference tests.
 ASSETS_DIR = Path(__file__).parent / "assets"
 
+# The full env family a wandb-registry-source test must clear to be hermetic: a
+# stray var on a dev box would false-fail a "no env" assertion, and a stray
+# WANDB_API_KEY would let a "missing key" test make a real network call.
+_WANDB_ENV_VARS = (
+    "WANDB_API_KEY",
+    "SRP_WANDB_MODEL_REGISTRY",
+    "SRP_WANDB_REGISTRY",
+    "SRP_WANDB_MODEL_ALIAS",
+    "SRP_WANDB_ALIAS",
+    "SRP_WANDB_ENTITY",
+)
+
+
+@pytest.fixture
+def clean_wandb_env(monkeypatch):
+    """Delete every wandb/SRP env var so registry-source tests are hermetic."""
+    for var in _WANDB_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
 
 @pytest.fixture(scope="session")
 def native_model_dir() -> Path:

--- a/tests/test_env_docs.py
+++ b/tests/test_env_docs.py
@@ -9,6 +9,12 @@ the canonical set the code reads, the ``.env.example`` template, and the README
 import re
 from pathlib import Path
 
+from sleap_roots_predict.model_registry import (
+    _DEFAULT_ALIAS,
+    _DEFAULT_ENTITY,
+    _DEFAULT_REGISTRY,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ENV_EXAMPLE = REPO_ROOT / ".env.example"
 README = REPO_ROOT / "README.md"
@@ -61,3 +67,12 @@ def test_readme_configuration_covers_all_vars_and_no_legacy():
     assert not missing, f"README Configuration missing: {sorted(missing)}"
     for legacy in LEGACY_VARS:
         assert legacy not in section
+
+
+def test_docs_default_values_match_code_constants():
+    """README + .env.example show the same default strings the code actually uses."""
+    section = _readme_config_section()
+    env = ENV_EXAMPLE.read_text(encoding="utf-8")
+    for default in (_DEFAULT_ENTITY, _DEFAULT_REGISTRY, _DEFAULT_ALIAS):
+        assert default in section, f"README Configuration missing default {default!r}"
+        assert default in env, f".env.example missing default {default!r}"

--- a/tests/test_env_docs.py
+++ b/tests/test_env_docs.py
@@ -1,0 +1,63 @@
+"""Consistency tests for the environment-variable documentation.
+
+These guard against drift between the three places the env surface is described:
+the canonical set the code reads, the ``.env.example`` template, and the README
+"Configuration" section. They also pin the hard rename — the legacy
+``SRP_WANDB_REGISTRY`` / ``SRP_WANDB_ALIAS`` names must appear nowhere.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+README = REPO_ROOT / "README.md"
+
+# The canonical set of env vars this project documents for operators.
+EXPECTED_VARS = {
+    "WANDB_API_KEY",
+    "SRP_WANDB_ENTITY",
+    "SRP_WANDB_MODEL_REGISTRY",
+    "SRP_WANDB_MODEL_ALIAS",
+    "SRP_MODEL_CACHE_DIR",
+    "SRP_DEVICE",
+}
+LEGACY_VARS = {"SRP_WANDB_REGISTRY", "SRP_WANDB_ALIAS"}
+
+
+def _env_example_vars():
+    """Return the var names declared in ``.env.example`` (commented or not)."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    return set(re.findall(r"^#?\s*([A-Z][A-Z0-9_]*)=", text, flags=re.MULTILINE))
+
+
+def _readme_config_section():
+    """Return the text of the README 'Configuration' section."""
+    text = README.read_text(encoding="utf-8")
+    match = re.search(
+        r"^#+\s*Configuration\b(.*?)(?=^#+\s|\Z)", text, flags=re.DOTALL | re.MULTILINE
+    )
+    assert match, "README has no 'Configuration' section"
+    return match.group(1)
+
+
+def test_env_example_lists_exactly_the_expected_vars():
+    """.env.example declares exactly the canonical env-var set."""
+    assert _env_example_vars() == EXPECTED_VARS
+
+
+def test_env_example_has_no_legacy_names():
+    """.env.example never names the renamed-away legacy vars."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    for legacy in LEGACY_VARS:
+        assert legacy not in text
+
+
+def test_readme_configuration_covers_all_vars_and_no_legacy():
+    """The README Configuration section names every var and no legacy name."""
+    section = _readme_config_section()
+    backticked = set(re.findall(r"`([A-Z][A-Z0-9_]*)`", section))
+    missing = EXPECTED_VARS - backticked
+    assert not missing, f"README Configuration missing: {sorted(missing)}"
+    for legacy in LEGACY_VARS:
+        assert legacy not in section

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -6,6 +6,7 @@ that ``make_predictor`` can load. Gated ``WandbRegistrySource`` tests are added 
 a later task (``@pytest.mark.wandb``).
 """
 
+import logging
 import os
 from pathlib import Path
 
@@ -141,6 +142,103 @@ def test_default_registry_still_fails_loud_without_key(clean_wandb_env):
     source = WandbRegistrySource()
     with pytest.raises(RuntimeError, match="WANDB_API_KEY"):
         source.list_cards()
+
+
+# --- per-artifact error isolation in list_cards (group 2) ---------------------
+
+
+class FakeArtifact:
+    """A duck-typed stand-in for a wandb artifact (data holder, not a mock).
+
+    Carries exactly the attributes ``_collect_cards`` / ``_card_from_artifact``
+    read: ``aliases``, ``metadata``, ``qualified_name``, ``version``, ``digest``.
+    """
+
+    def __init__(self, registry_id, *, metadata, version="v1", aliases=("production",)):
+        """Build a fake artifact with the read attributes set from the args."""
+        self.qualified_name = f"{registry_id}:{version}"
+        self.version = version
+        self.digest = f"sha256:{registry_id}"
+        self.aliases = list(aliases)
+        self.metadata = metadata
+
+
+def _good_meta(species="rice", root_type="primary"):
+    """Metadata carrying every required selection field (validates to a card)."""
+    return {
+        "species": species,
+        "mode": "cylinder",
+        "age_min": 2,
+        "age_max": 5,
+        "root_type": root_type,
+    }
+
+
+def _good_artifact(registry_id="reg/good", **kw):
+    return FakeArtifact(registry_id, metadata=_good_meta(**kw))
+
+
+def _malformed_artifact(registry_id="reg/bad"):
+    # Missing the required ``species`` field -> pydantic ValidationError.
+    meta = _good_meta()
+    del meta["species"]
+    return FakeArtifact(registry_id, metadata=meta)
+
+
+def test_collect_cards_skips_malformed_and_warns(caplog):
+    """One malformed artifact is skipped with a warning; the good one survives."""
+    source = WandbRegistrySource(alias="production")
+    good, bad = _good_artifact(), _malformed_artifact()
+    with caplog.at_level(logging.WARNING, logger="sleap_roots_predict.model_registry"):
+        cards = source._collect_cards([good, bad])
+    assert [c.registry_id for c in cards] == ["reg/good"]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    # The warning names the offending artifact and includes the underlying error.
+    assert "reg/bad" in caplog.text
+    assert "species" in caplog.text
+
+
+def test_collect_cards_all_malformed_returns_empty(caplog):
+    """An all-malformed listing is empty, not an exception."""
+    source = WandbRegistrySource(alias="production")
+    with caplog.at_level(logging.WARNING, logger="sleap_roots_predict.model_registry"):
+        cards = source._collect_cards([_malformed_artifact()])
+    assert cards == []
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+def test_collect_cards_drops_only_the_bad_one_preserving_order(caplog):
+    """A single bad artifact drops only itself; good ones keep their order."""
+    source = WandbRegistrySource(alias="production")
+    a = _good_artifact("reg/a")
+    b = _malformed_artifact("reg/bad")
+    c = _good_artifact("reg/c")
+    with caplog.at_level(logging.WARNING, logger="sleap_roots_predict.model_registry"):
+        cards = source._collect_cards([a, b, c])
+    assert [card.registry_id for card in cards] == ["reg/a", "reg/c"]
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+def test_collect_cards_alias_filtered_is_silent(caplog):
+    """An artifact lacking the configured alias is filtered out, no warning."""
+    source = WandbRegistrySource(alias="production")
+    wrong_alias = FakeArtifact(
+        "reg/experimental", metadata=_good_meta(), aliases=["experimental"]
+    )
+    with caplog.at_level(logging.WARNING, logger="sleap_roots_predict.model_registry"):
+        cards = source._collect_cards([wrong_alias])
+    assert cards == []
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_collect_cards_pins_concrete_version_and_checksum():
+    """The built card carries the artifact's concrete version + digest (pin)."""
+    source = WandbRegistrySource(alias="production")
+    art = _good_artifact("reg/good")
+    (card,) = source._collect_cards([art])
+    assert card.version == art.version
+    assert card.weights_checksum == art.digest
 
 
 @pytest.mark.wandb

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -76,25 +76,7 @@ def test_materialize_unknown_ref_raises(native_model_dir: Path):
 
 # --- WandbRegistrySource ------------------------------------------------------
 
-# The full env family a registry-source test must clear to be hermetic: a stray var
-# on a dev box would false-fail a "no env" assertion, and a stray WANDB_API_KEY would
-# let a "missing key" test make a real network call.
-_WANDB_ENV_VARS = (
-    "WANDB_API_KEY",
-    "SRP_WANDB_MODEL_REGISTRY",
-    "SRP_WANDB_REGISTRY",
-    "SRP_WANDB_MODEL_ALIAS",
-    "SRP_WANDB_ALIAS",
-    "SRP_WANDB_ENTITY",
-)
-
-
-@pytest.fixture
-def clean_wandb_env(monkeypatch):
-    """Delete every wandb/SRP env var so registry-source tests are hermetic."""
-    for var in _WANDB_ENV_VARS:
-        monkeypatch.delenv(var, raising=False)
-    return monkeypatch
+# ``clean_wandb_env`` (hermetic env fixture) lives in tests/conftest.py.
 
 
 def test_wandb_source_missing_key_raises_before_network(monkeypatch):
@@ -255,6 +237,53 @@ def test_collect_cards_pins_concrete_version_and_checksum():
     (card,) = source._collect_cards([art])
     assert card.version == art.version
     assert card.weights_checksum == art.digest
+
+
+# --- offline coverage of the registry traversal ------------------------------
+
+
+class FakeCollection:
+    """A duck-typed stand-in for a wandb artifact collection."""
+
+    def __init__(self, name):
+        """Store the collection name the traversal reads."""
+        self.name = name
+
+
+class FakeApi:
+    """A duck-typed stand-in for ``wandb.Api`` recording the calls it receives."""
+
+    def __init__(self, collections):
+        """Build from a ``{collection_name: [artifacts]}`` mapping."""
+        self._collections = collections
+        self.artifacts_calls = []
+        self.project_name = None
+
+    def artifact_collections(self, project_name, type_name):
+        """Record the project + type and return the fake collections."""
+        self.project_name = project_name
+        self.type_name = type_name
+        return [FakeCollection(name) for name in self._collections]
+
+    def artifacts(self, type_name, name):
+        """Record the query and return the collection's artifacts."""
+        self.artifacts_calls.append((type_name, name))
+        return list(self._collections[name.rsplit("/", 1)[-1]])
+
+
+def test_iter_registry_artifacts_yields_across_collections():
+    """The traversal yields every model artifact across all collections, in order."""
+    source = WandbRegistrySource(entity="ent", registry="reg")
+    a, b, c = _good_artifact("reg/a"), _good_artifact("reg/b"), _good_artifact("reg/c")
+    api = FakeApi({"colA": [a, b], "colB": [c]})
+    result = list(source._iter_registry_artifacts(api))
+    assert result == [a, b, c]
+    # Correct registry project path + one per-collection artifact query.
+    assert api.project_name == "ent-org/wandb-registry-reg"
+    assert api.artifacts_calls == [
+        ("model", "ent-org/wandb-registry-reg/colA"),
+        ("model", "ent-org/wandb-registry-reg/colB"),
+    ]
 
 
 @pytest.mark.wandb

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -137,6 +137,22 @@ def test_legacy_alias_env_var_is_ignored(clean_wandb_env):
     assert WandbRegistrySource()._alias == "production"
 
 
+def test_empty_registry_env_falls_back_to_default(clean_wandb_env):
+    """A set-but-empty SRP_WANDB_MODEL_REGISTRY falls back to the default."""
+    clean_wandb_env.setenv("SRP_WANDB_MODEL_REGISTRY", "")
+    assert WandbRegistrySource()._registry == "sleap-roots-models"
+
+
+def test_empty_alias_env_falls_back_to_default(clean_wandb_env):
+    """A set-but-empty SRP_WANDB_MODEL_ALIAS falls back to the default alias.
+
+    Regression guard: an empty alias must NOT disable the alias filter (which
+    would list every artifact version) — it falls back to ``production``.
+    """
+    clean_wandb_env.setenv("SRP_WANDB_MODEL_ALIAS", "")
+    assert WandbRegistrySource()._alias == "production"
+
+
 def test_default_registry_still_fails_loud_without_key(clean_wandb_env):
     """WandbRegistrySource() (default registry) still raises on a missing key."""
     source = WandbRegistrySource()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -75,11 +75,70 @@ def test_materialize_unknown_ref_raises(native_model_dir: Path):
 
 # --- WandbRegistrySource ------------------------------------------------------
 
+# The full env family a registry-source test must clear to be hermetic: a stray var
+# on a dev box would false-fail a "no env" assertion, and a stray WANDB_API_KEY would
+# let a "missing key" test make a real network call.
+_WANDB_ENV_VARS = (
+    "WANDB_API_KEY",
+    "SRP_WANDB_MODEL_REGISTRY",
+    "SRP_WANDB_REGISTRY",
+    "SRP_WANDB_MODEL_ALIAS",
+    "SRP_WANDB_ALIAS",
+    "SRP_WANDB_ENTITY",
+)
+
+
+@pytest.fixture
+def clean_wandb_env(monkeypatch):
+    """Delete every wandb/SRP env var so registry-source tests are hermetic."""
+    for var in _WANDB_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
 
 def test_wandb_source_missing_key_raises_before_network(monkeypatch):
     """With no WANDB_API_KEY, list_cards raises a clear error (no network call)."""
     monkeypatch.delenv("WANDB_API_KEY", raising=False)
     source = WandbRegistrySource(entity="an-entity", registry="a-registry")
+    with pytest.raises(RuntimeError, match="WANDB_API_KEY"):
+        source.list_cards()
+
+
+# --- default registry + env-var rename (group 1) ------------------------------
+
+
+def test_registry_defaults_to_sleap_roots_models(clean_wandb_env):
+    """With no registry arg and no env, the registry defaults to the live one."""
+    assert WandbRegistrySource()._registry == "sleap-roots-models"
+
+
+def test_model_registry_env_var_is_honored(clean_wandb_env):
+    """SRP_WANDB_MODEL_REGISTRY sets the registry when no arg is passed."""
+    clean_wandb_env.setenv("SRP_WANDB_MODEL_REGISTRY", "some-registry")
+    assert WandbRegistrySource()._registry == "some-registry"
+
+
+def test_legacy_registry_env_var_is_ignored(clean_wandb_env):
+    """The legacy SRP_WANDB_REGISTRY is not read (hard rename): default applies."""
+    clean_wandb_env.setenv("SRP_WANDB_REGISTRY", "legacy-registry")
+    assert WandbRegistrySource()._registry == "sleap-roots-models"
+
+
+def test_model_alias_env_var_is_honored(clean_wandb_env):
+    """SRP_WANDB_MODEL_ALIAS sets the alias when no arg is passed."""
+    clean_wandb_env.setenv("SRP_WANDB_MODEL_ALIAS", "staging")
+    assert WandbRegistrySource()._alias == "staging"
+
+
+def test_legacy_alias_env_var_is_ignored(clean_wandb_env):
+    """The legacy SRP_WANDB_ALIAS is not read (hard rename): default applies."""
+    clean_wandb_env.setenv("SRP_WANDB_ALIAS", "legacy-alias")
+    assert WandbRegistrySource()._alias == "production"
+
+
+def test_default_registry_still_fails_loud_without_key(clean_wandb_env):
+    """WandbRegistrySource() (default registry) still raises on a missing key."""
+    source = WandbRegistrySource()
     with pytest.raises(RuntimeError, match="WANDB_API_KEY"):
         source.list_cards()
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -246,10 +246,22 @@ def test_collect_cards_pins_concrete_version_and_checksum():
     not WANDB_API_KEY,
     reason="requires WANDB_API_KEY + a populated production registry",
 )
-def test_wandb_source_lists_and_materializes(tmp_path):
-    """With creds, list_cards yields pinned cards and materialize caches the dir."""
+def test_wandb_source_lists_and_materializes(tmp_path, monkeypatch):
+    """With creds and NO registry env, the default registry lists + materializes."""
+    # Prove the default path: unset the registry/alias/entity env so the source
+    # falls back to the live-registry defaults with only WANDB_API_KEY set.
+    for var in (
+        "SRP_WANDB_MODEL_REGISTRY",
+        "SRP_WANDB_REGISTRY",
+        "SRP_WANDB_MODEL_ALIAS",
+        "SRP_WANDB_ALIAS",
+        "SRP_WANDB_ENTITY",
+    ):
+        monkeypatch.delenv(var, raising=False)
     source = WandbRegistrySource(cache_dir=tmp_path)
+    assert source._registry == "sleap-roots-models"  # default in effect, no env
     cards = source.list_cards()
+    # Count-agnostic: the production card set grows over time (do not assert exactly N).
     assert cards and all(isinstance(c, ModelCard) for c in cards)
     # Cards are pinned to a concrete version (not the moving alias) with a checksum,
     # and carry the selection metadata the matcher needs.

--- a/tests/test_warm_worker.py
+++ b/tests/test_warm_worker.py
@@ -57,22 +57,7 @@ def rice_source(native_model_dir: Path, legacy_model_dir: Path) -> LocalCardSour
 
 # --- default source: the live wandb registry (group 3) ------------------------
 
-_WANDB_ENV_VARS = (
-    "WANDB_API_KEY",
-    "SRP_WANDB_MODEL_REGISTRY",
-    "SRP_WANDB_REGISTRY",
-    "SRP_WANDB_MODEL_ALIAS",
-    "SRP_WANDB_ALIAS",
-    "SRP_WANDB_ENTITY",
-)
-
-
-@pytest.fixture
-def clean_wandb_env(monkeypatch):
-    """Delete every wandb/SRP env var so the default-source tests are hermetic."""
-    for var in _WANDB_ENV_VARS:
-        monkeypatch.delenv(var, raising=False)
-    return monkeypatch
+# ``clean_wandb_env`` (hermetic env fixture) lives in tests/conftest.py.
 
 
 def test_default_source_is_the_live_wandb_registry(clean_wandb_env):

--- a/tests/test_warm_worker.py
+++ b/tests/test_warm_worker.py
@@ -13,7 +13,7 @@ import sleap_io as sio
 from sleap_nn.inference import Predictor
 from sleap_roots_contracts import ModelCard, ResolvedParams
 
-from sleap_roots_predict.model_registry import LocalCardSource
+from sleap_roots_predict.model_registry import LocalCardSource, WandbRegistrySource
 from sleap_roots_predict.predict import _resolve_device
 from sleap_roots_predict.video_utils import make_video_from_images
 from sleap_roots_predict.warm_worker import WarmModelWorker
@@ -53,6 +53,39 @@ def rice_source(native_model_dir: Path, legacy_model_dir: Path) -> LocalCardSour
             (_card("lateral", "reg/rice-lateral"), legacy_model_dir),
         ]
     )
+
+
+# --- default source: the live wandb registry (group 3) ------------------------
+
+_WANDB_ENV_VARS = (
+    "WANDB_API_KEY",
+    "SRP_WANDB_MODEL_REGISTRY",
+    "SRP_WANDB_REGISTRY",
+    "SRP_WANDB_MODEL_ALIAS",
+    "SRP_WANDB_ALIAS",
+    "SRP_WANDB_ENTITY",
+)
+
+
+@pytest.fixture
+def clean_wandb_env(monkeypatch):
+    """Delete every wandb/SRP env var so the default-source tests are hermetic."""
+    for var in _WANDB_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_default_source_is_the_live_wandb_registry(clean_wandb_env):
+    """WarmModelWorker() with no source defaults to a WandbRegistrySource."""
+    worker = WarmModelWorker()  # construction is network-free
+    assert isinstance(worker._source, WandbRegistrySource)
+
+
+def test_default_source_fails_loud_without_key(clean_wandb_env):
+    """No WANDB_API_KEY: construction is fine; the first resolve() fails loud."""
+    worker = WarmModelWorker()  # must NOT raise (no network at construction)
+    with pytest.raises(RuntimeError, match="WANDB_API_KEY"):
+        worker.resolve(_params())
 
 
 def test_resolve_returns_refs_without_loading(rice_source):


### PR DESCRIPTION
## Summary

Make the live production wandb registry the **default** model source so the warm worker
fetches production models out-of-the-box with only `WANDB_API_KEY` set, model-scope the
registry env vars to match the `sleap-roots-training` producer, and isolate per-artifact
errors so one malformed registry artifact skips-with-warning instead of aborting a scan.
Advances roadmap tier **A3-predict**.

## Changes

- **Default registry** â€” `WandbRegistrySource()` defaults its registry to `sleap-roots-models`
  (the live production registry), so a source with only `WANDB_API_KEY` set reads production.
- **Default source** â€” `WarmModelWorker(source=None)` now builds a `WandbRegistrySource`
  reading the live registry. Construction is network-free; a missing `WANDB_API_KEY` fails
  loud on the first `resolve()`/`get_predictors()`. No offline `LocalCardSource` fallback.
  Backward-compatible: explicit positional `source` callers are unchanged.
- **Per-artifact error isolation** â€” `list_cards()` is split into a network traversal
  (`_iter_registry_artifacts`) and a pure collector (`_collect_cards`). A single
  non-conforming artifact is skipped with a logged warning (naming it + the error) instead
  of aborting the listing; credential/network errors still fail loud (isolation is scoped to
  per-artifact card construction only).
- **Env docs** â€” new `.env.example` (only `WANDB_API_KEY` required), a canonical
  Configuration table in `README.md`, an `openspec/project.md` pointer, a CHANGELOG BREAKING
  entry, and a drift-guard consistency test.

## OpenSpec Change

- Change ID: `flip-default-live-registry`
- Affected capabilities: `model-management`
- Delta types: MODIFIED (2 requirements â€” "Wandb Registry Source With Version Pinning",
  "Warm Model Residency")
- All `tasks.md` items complete: yes (except the live `-m wandb` run â€” see Testing)

## Testing

- [x] CPU tests pass â€” **206 passed**, 5 deselected (`uv run pytest`)
- [x] GPU tests pass â€” **3 passed** on local CUDA (`uv run pytest -m gpu`)
- [x] New tests added â€” default registry + env rename, `_collect_cards` skip-and-warn edges
  (all-bad, order-preserving, alias-filteredâ‰ malformed, concrete-pin), warm-worker default
  source + fail-loud, `.env.example`/README drift guard
- [x] Existing tests still cover affected paths â€” warm-worker `LocalCardSource` tests
  (backward compat) and `test_wandb_source_missing_key_raises_before_network` still green
- [x] **Live `uv run pytest -m wandb -q` — VERIFIED GREEN** against the live registry (`1 passed` in ~123s; `WANDB_API_KEY` sourced from the maintainer's wandb login): the default path (no registry env) lists cards from `sleap-roots-models` and materializes a model

## Linting

- [x] Ruff passes (`uv run ruff check .`)
- [x] Codespell passes (`uv run codespell`)
- [x] Formatting passes (`uv run black --check sleap_roots_predict tests`)

## Build / Image

- [x] Wheel builds (`uv build`)
- [ ] Docker image â€” N/A (no Dockerfile or dependency changes)

## Downstream Compatibility

- [x] Output artifact format (.slp / manifest) unchanged
- [x] No breaking change to the public Python API in `__init__.py` (`WarmModelWorker(source)`
  stays positional; `source` merely gains a default)

## Breaking Changes

- [x] Breaking change: **environment-variable rename** (runtime config API)
  - `SRP_WANDB_REGISTRY` â†’ `SRP_WANDB_MODEL_REGISTRY`
  - `SRP_WANDB_ALIAS` â†’ `SRP_WANDB_MODEL_ALIAS`
  - The old names are **no longer read**. Migration: rename them in your env/manifest, or â€”
    since `sleap-roots-models` is now the default â€” simply unset them. Ripple to
    `sleap-roots-training` docs tracked at training #6.

## Related Issues

Closes #11
Closes #12

## Reviewer Notes

- Design + rationale: `docs/superpowers/specs/2026-07-05-flip-default-live-registry-design.md`;
  OpenSpec proposal under `openspec/changes/flip-default-live-registry/`.
- The `except Exception` in `_collect_cards` is deliberately scoped to card construction
  only (credential/network failures are raised earlier by `_require_key`/the traversal and
  are not swallowed) â€” see the spec scenario "A genuine credential/network error is not
  swallowed per artifact".
- Deferred (linked, not here): #7 (provenance-config shape), #14 (weights_checksum dedupe),
  #13 (wandb floor), #10 (sleap_nn_version mismatch), the A3 parity gate.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
