### PR TITLE
feat: resolve_params oracle - Bloom metadata -> ResolvedParams (A3-params)

### DIFF
--- a/API.md
+++ b/API.md
@@ -88,6 +88,45 @@ Run prediction on a sleap_io.Video object.
 
 **Returns:** Path to saved .slp file or Labels object with predictions
 
+### Model Selection
+
+Resolve Bloom scan metadata into params, then select a production model per root type
+(metadata → params → model). See the `param-resolution` and `model-management` OpenSpec
+specs for the full matching semantics (kept single-sourced there to avoid drift).
+
+```python
+from sleap_roots_predict import (
+    resolve_params,  # Bloom cyl_scans_extended row -> ResolvedParams (species/mode/age)
+    choose_models,   # ResolvedParams + ModelCards -> {root_type: ModelRef}
+)
+```
+
+#### `resolve_params`
+```python
+resolve_params(
+    metadata: Dict[str, Any],
+    overrides: Optional[Dict[str, Any]] = None,
+) -> ResolvedParams
+```
+Pure oracle mapping a single Bloom `cyl_scans_extended` row (the dict bloomcli's download
+writes to `scans.csv`) to a `ResolvedParams` carrying `species` (normalized from
+`species_name`), `mode` (`"cylinder"` for the cylinder stage-in path), and `age` (from
+`plant_age_days`, in days).
+
+**Parameters:**
+- `metadata`: A single Bloom scan-metadata row; load-bearing keys are `species_name` and
+  `plant_age_days` (other columns ignored). Blank/absent load-bearing fields are treated as
+  not provided.
+- `overrides`: Optional param-space dict (keys ⊆ `{species, mode, age}`); each key wins its
+  field, and override values are normalized/coerced like derived values so `param_hash` is
+  representation-independent.
+
+**Returns:** A `ResolvedParams` (with `values` and a computed `param_hash`), ready for
+`choose_models`.
+
+**Raises:** `ValueError` on an unknown override key, a non-whole `plant_age_days`/`age`, or
+a still-missing `species`/`mode`/`age` after merging overrides.
+
 ### Output Contract
 
 Write the per-scan artifacts the downstream sleap-roots traits stage reads — named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Param resolution** (`sleap_roots_predict.param_resolution`): `resolve_params(metadata,
+  overrides=None)` maps a single Bloom `cyl_scans_extended` row (the dict bloomcli writes to
+  `scans.csv`) to a `ResolvedParams` (`species`/`mode`/`age`), so `choose_models` can select
+  production models from real Bloom metadata (metadata → params → model). `species_name` is
+  normalized to the `ModelCard` vocabulary (lowercase passthrough; unknown species pass
+  through so the registry stays the authority), `mode` routes through a one-line
+  `_mode_for_scan` seam (`"cylinder"` for the cylinder stage-in path; GraviScan/multiscanner
+  deferred), and `plant_age_days` is coerced to an `int` (confirmed **days**, matching the
+  seeded cards' `age_min`/`age_max`). Overrides win per field with keys restricted to
+  `{species, mode, age}`; override values are canonicalized like derived values, and
+  blank/lossy inputs fail loud, so `param_hash` is representation-independent. Pure and
+  offline — no new dependencies. New public export: `resolve_params`. See the
+  `param-resolution` OpenSpec spec.
 - **Predict output contract** (`sleap_roots_predict.output_contract`): the per-scan
   artifacts the downstream traits stage reads. `write_prediction_outputs` writes one
   named per-root `.slp` (`{scan_key}.model{model_id}.root{root_type}.slp`, sleap-roots

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ To publish a new release:
 ```
 sleap_roots_predict/
 ├── predict.py                      # SLEAP-NN prediction interface
+├── param_resolution.py             # Bloom scan metadata -> ResolvedParams (resolve_params)
 ├── model_selection.py              # Pure model-selection matcher (choose_models)
 ├── model_registry.py               # Model-card sources (Local + Wandb registry)
 ├── warm_worker.py                  # WarmModelWorker: resident predictors across scans
@@ -235,6 +236,7 @@ sleap_roots_predict/
 
 tests/
 ├── test_predict.py             # Prediction module tests
+├── test_param_resolution.py    # Param-resolution oracle tests (offline)
 ├── test_model_selection.py     # Model-selection matcher tests
 ├── test_model_registry.py      # Card-source tests (offline + gated wandb)
 ├── test_warm_worker.py         # Warm worker tests (real CPU inference)

--- a/docs/superpowers/specs/2026-07-06-param-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-06-param-resolution-design.md
@@ -1,0 +1,207 @@
+# Design: A3-params — `resolve_params` (Bloom scan metadata → `ResolvedParams`)
+
+- **Date:** 2026-07-06
+- **Repo:** `sleap-roots-predict`
+- **Branch:** `add-param-resolution`
+- **Roadmap:** tier **A3-params** ("Bloom dataset metadata → `ResolvedParams`; oracle:
+  given metadata X → expected params; user override wins") — currently `⬜` in
+  `sleap-roots-pipeline/docs/bloom-integration/roadmap.md`.
+- **Status:** **APPROVED — brainstorming complete.** This doc is the settled design.
+  **Resuming in a new session: run `/new-feature`, but SKIP brainstorming** (it's done —
+  this file is its output) and go straight to the **OpenSpec proposal** →
+  `/review-openspec` → TDD. Suggested change-id: `add-param-resolution`.
+
+## Motivation
+
+Predict's `choose_models(params, cards)` consumes a `ResolvedParams` (`species`, `mode`,
+`age`) and selects a production model per root type. Nothing yet **produces** that
+`ResolvedParams` from real Bloom scan metadata — the roadmap's A3-params gap. This change
+adds a pure oracle `resolve_params(metadata) -> ResolvedParams` so the metadata a scan
+already carries in Bloom drives model selection end-to-end (metadata → params →
+`choose_models` → warm worker → prediction).
+
+## Settled decisions (from brainstorming 2026-07-06)
+
+1. **Home = `sleap-roots-predict`.** The only dependency the pure mapper needs is
+   `sleap-roots-contracts` (already pinned `==0.1.0a3`; predict already imports
+   `ResolvedParams`). Co-located with `choose_models`; no new deps. Alternatives rejected:
+   contracts (would add mapping *behavior* to a pure-schema lib), pipeline/A4 (not a Python
+   lib; most scaffolding), salk-bloom/TS (different stack). A pure Python **oracle** is
+   valuable regardless of where production emission eventually runs — including as the
+   reference a future TS Bloom-side version is tested against.
+2. **Call model = Model A** (predict resolves internally) **with overridability.** The
+   predict step receives the raw scan metadata + an optional overrides dict, and calls
+   `resolve_params(metadata, overrides)` itself. Overridability is preserved by the
+   `overrides` argument (user override wins per field); overrides are collected at submit
+   time and passed into predict. Model A keeps everything in predict; the one thing it
+   gives up vs "resolve at submit" (Model B) is showing the user the *fully-resolved*
+   params at submit for direct editing — acceptable when the override UX is "force these
+   fields."
+3. **Input = one `cyl_scans_extended` row** — the dict the bloomcli download writes to
+   `scans.csv` (see "Input contract" below).
+4. **Unknown species → lowercased passthrough** (NOT hard-fail, NOT skip-visibility). The
+   **registry (ModelCards) is the single authority** on which species have models;
+   `resolve_params` only *translates* Bloom's naming. New seeded species then work with no
+   resolver edit; a species with no card degrades to `choose_models` zero-match → skip.
+   Safe because Bloom's `species_name` is FK-controlled (a `species` table via
+   `species_id`), so it's already a curated vocabulary — "unknown to the resolver" means "a
+   real Bloom species not yet modelled," exactly where hard-fail would be wrong.
+5. **Strict post-override validation.** After merging overrides, require `species`, `mode`,
+   `age` all present → else raise a clear `ValueError` naming what's missing. Do not ship a
+   half-resolved params object.
+6. **Mode = scanner-determined, scoped to cylinder now, via a one-line seam.** See "Mode".
+
+## Input contract (what `resolve_params` consumes)
+
+A single `cyl_scans_extended` row — the exact shape bloomcli's
+`bloomcli/src/bloomctl/download.py` (`_COLUMNS`) writes to `scans.csv`. Confirmed against
+`salk-bloom` PRs #350/#351/#353 (bloomcli, authored by blm3886) and
+`test_download_metadata.py`. Load-bearing fields (all others ignored):
+
+| Bloom field | → param | Notes |
+|---|---|---|
+| `species_name` | `species` | e.g. `"Pennycress"`; FK-controlled via `species_id` → `species` table. Also present: `species_genus` (`"Thlaspi"`), `species_species` (`"arvense"`) — available as cross-checks. |
+| `plant_age_days` | `age` | int, **days** (e.g. `14`). |
+| (the scan's scanner) | `mode` | Cylinder pipeline (`cyl_scans_extended`) ⇒ `"cylinder"`. |
+
+Field names are module constants matching bloomcli's column names, so the coupling is
+explicit and greppable.
+
+## The mapping
+
+```python
+def resolve_params(metadata, overrides=None) -> ResolvedParams:
+    derived = {
+        "species": _normalize_species(metadata["species_name"]),
+        "mode":    _mode_for_scan(metadata),        # "cylinder" now; scanner→mode seam
+        "age":     int(metadata["plant_age_days"]),
+    }
+    values = {**derived, **(overrides or {})}        # user override wins, per field
+    _require(values, ("species", "mode", "age"))     # fail-loud if any missing post-override
+    return ResolvedParams(values=values)             # contract computes param_hash
+```
+
+- **species** — `_normalize_species(name)`: an explicit alias map for the seeded species
+  (`Pennycress→pennycress`, `Arabidopsis→arabidopsis`, `Rice→rice`, `Soybean→soybean`,
+  `Canola→canola`) with a **lowercase passthrough fallback** for anything not in the map.
+  ```python
+  def _normalize_species(name):
+      return _ALIASES.get(name.strip().lower(), name.strip().lower())
+  ```
+- **mode** — `_mode_for_scan(metadata)` returns `"cylinder"` (the cylinder pipeline yields
+  cylinder scans only). See "Mode" for the seam rationale.
+- **age** — `plant_age_days` straight through as `int`.
+- **overrides** — a **param-space** dict (`{"mode": "..."}`, `{"species": "..."}`), merged
+  last; override wins per field. Overrides express final param values, not metadata fields.
+
+## Mode: the scanner→mode seam
+
+Mode is a property of the scan's **scanner** (Bloom models modality by separate table
+families: `cyl_*` cylinder scanners vs `gravi_*` GraviScan plate scanners; multiscanner is
+**not implemented**; multiplant-cylinder is **retired**). For the current **cylinder**
+stage-in path, mode is unconditionally `"cylinder"`.
+
+Rather than inline that literal, mode routes through a one-line function:
+
+```python
+def _mode_for_scan(metadata):
+    """Imaging modality for a scan. The cylinder pipeline yields cylinder scans only;
+    this is the single place mode is decided — where GraviScan / multiscanner modes
+    slot in once their scanners + models exist. Mode strings MUST match the exact
+    seeded ModelCard vocabulary."""
+    return "cylinder"
+```
+
+This **seam** (not the future implementation — just its shape) means: when GraviScan
+models are seeded and a graviscan stage-in path exists, mode derivation becomes a
+scanner→modality lookup confined to this one function; `resolve_params`'s body, its
+callers, and its output shape (`{species, mode, age}`) do not change. It also centralizes
+the "send the exact seeded mode string" contract in one place. We do **NOT** build the
+scanner lookup / `_SCANNER_MODE` table now (rejected as speculative — graviscan models are
+deferred and its download isn't wired).
+
+## Module & API
+
+- New file `sleap_roots_predict/param_resolution.py` (beside `model_selection.py` /
+  `model_registry.py`).
+- Public `resolve_params`, exported from `__init__.py` (+ `__all__`).
+- Pure: imports only `ResolvedParams` from the contract; no network, no filesystem I/O.
+
+## Testing — the oracle (+ the payoff round-trip)
+
+Real, no-mock, offline (matches repo convention). TDD.
+
+- **Oracle table** (`metadata X → expected params.values`): the sample bloomcli row →
+  `{species: "pennycress", mode: "cylinder", age: 14}`; species-normalization cases
+  (`Pennycress`, `Arabidopsis`, `Rice`, `Soybean`, `Canola`, plus a Latin/genus variant if
+  Bloom uses one); age passthrough; unknown-species passthrough (`"Sorghum"`→`"sorghum"`).
+- **Override-wins**: `resolve_params(row, {"mode": "x", "species": "y"})` → those win per
+  field; partial overrides leave other fields derived.
+- **Strict validation**: metadata missing `species_name`/`plant_age_days` with no override
+  → clear `ValueError` naming the missing param.
+- **The demoable round-trip** (ties A3-params to the shipped selection layer): build a
+  small real `ModelCard` list (as the existing `choose_models` tests do), then
+  `choose_models(resolve_params(row), cards)` selects the right `ModelRef` per root type.
+  This is the metadata → params → model slide.
+
+## Confirm during implementation
+
+- **Age units.** Verify the seeded production cards' `age_min`/`age_max` are in **days**
+  (to match `plant_age_days`). Check a real seeded card (gated `pytest -m wandb`, or ask
+  training). If they are NOT days, add a documented conversion in the age mapping. (If this
+  turns out to need training coordination, file the issue below rather than block.)
+- **Species strings.** Confirm the seeded cards' exact `species` strings are the lowercase
+  common names assumed here; extend `_ALIASES` for any Bloom `species_name` that doesn't
+  lowercase cleanly to the card string (e.g. Latin binomials).
+
+## Out of scope (seams / deferred)
+
+- GraviScan / multiscanner **modes** — the `_mode_for_scan` seam.
+- **Fetching** the metadata (Supabase / bloomcli) — stays in A4/bloomcli; the mapper takes
+  a dict it's handed.
+- **Where `resolve_params` is called** in production (predict-internal vs a CLI vs a TS
+  port) — a thin adapter, an A4-era decision; the oracle is call-site-agnostic.
+
+## Future work — issues to file
+
+Create these to track the deferred pieces (repo · one-liner · dependency):
+
+1. **predict — GraviScan/plate `mode` support in `resolve_params`.** Implement the
+   `_mode_for_scan` scanner→modality lookup (cylinder vs gravi) once GraviScan plate models
+   are seeded and a graviscan stage-in path exists. *Depends on:* training #3 (plate
+   models) + a bloomcli graviscan download.
+2. **predict — confirm/handle age units.** Verify seeded card `age_min/age_max` are in days
+   vs `plant_age_days`; add a conversion if not. (May be resolved inside this change; file
+   only if it needs training-side coordination.)
+3. **pipeline/A4 — wire `resolve_params` into the predict step (call-site adapter).** Decide
+   Model A internal call vs a `python -m ... resolve_params` CLI; pass scan metadata +
+   user overrides into the predict step; log the resolved params in provenance. *Depends
+   on:* A4 start.
+4. **salk-bloom / A4 — override plumbing UX.** How user overrides are collected at submit
+   time and carried into predict (the "user override wins" surface).
+5. **bloom / training — multiscanner (multi-scan) modality.** Not implemented; when it
+   lands, add its scanner family + mode string + models, then extend `_mode_for_scan`.
+6. **(watch) TS parity.** If a Bloom-side (TS) params resolver is ever needed, test it
+   against this Python oracle as the reference (given/expected table).
+
+## Acceptance
+
+- `resolve_params(cyl_scans_extended_row)` returns a `ResolvedParams` with
+  `{species, mode, age}` matching the oracle table; overrides win per field; missing
+  required fields fail loud.
+- `choose_models(resolve_params(row), seeded_cards)` selects the expected model(s).
+- Pure/offline; zero new dependencies; exported from the public API.
+- Advances roadmap A3-params; report back so the roadmap row + tracking issues update.
+
+## Cross-repo references (for the next session)
+
+- **bloomcli** (input contract): `salk-bloom` `bloomcli/src/bloomctl/download.py` (`_COLUMNS`,
+  `build_scan_row`) + `bloomcli/tests/test_download_metadata.py`; PRs #350/#351/#353 (author
+  blm3886, unreviewed). Package dir `bloomcli/`, import name `bloomctl`.
+- **Contract**: `sleap-roots-contracts` `ResolvedParams` (`values: dict`, `param_hash`) at
+  `src/sleap_roots_contracts/models.py`; pinned `==0.1.0a3`.
+- **Consumer**: predict `choose_models` (`sleap_roots_predict/model_selection.py`) + the
+  `model-management` OpenSpec spec.
+- **Not related** (clarified this session): the source-aware trait **read** RPC
+  (`get_scan_traits` + `source_id`, salk-bloom #373, authored by eberrigan) is the
+  results-read-OUT path; A3-params is the stage-IN side — they don't overlap.

--- a/openspec/changes/add-param-resolution/design.md
+++ b/openspec/changes/add-param-resolution/design.md
@@ -1,0 +1,147 @@
+## Context
+
+Full brainstorming output (approved 2026-07-06):
+`docs/superpowers/specs/2026-07-06-param-resolution-design.md`. This file records the
+decisions load-bearing for the spec deltas plus the refinements surfaced by two
+`/review-openspec` rounds, and the one open question to resolve during implementation.
+
+The selection layer (`choose_models`, `model-management` spec) already consumes a
+`ResolvedParams(values={species, mode, age})`. This change adds the missing **producer**:
+a pure oracle mapping a Bloom `cyl_scans_extended` row to that `ResolvedParams`. Home is
+`sleap-roots-predict` because the only dependency is `sleap-roots-contracts` (already
+pinned `==0.1.0a3`, already imported by predict) and the oracle belongs beside its
+consumer; a pure Python oracle is also valuable as the reference a future TS Bloom-side
+resolver is tested against.
+
+## Goals / Non-Goals
+
+- **Goals:** a pure, offline, zero-new-dependency `resolve_params(metadata, overrides=None)`
+  that returns a valid `choose_models` input with a **representation-independent
+  `param_hash`**; override-wins per field; fail-loud on missing required params, unknown
+  override keys, and lossy age coercion; exported from the public API.
+- **Non-Goals (seams/deferred):** the scanner→mode lookup for GraviScan/multiscanner
+  (only the `_mode_for_scan` seam is built now); **fetching** the metadata (A4/bloomcli);
+  the production call-site adapter (predict-internal vs CLI vs TS); the override submit-time
+  UX. These are tracked as follow-up issues.
+
+## Decisions
+
+- **Call model = Model A (predict resolves internally) with an `overrides` arg.** Predict
+  receives the raw scan metadata + an optional param-space overrides dict and calls
+  `resolve_params(metadata, overrides)` itself. Overridability is preserved by the argument
+  (override wins per field). Alternative "resolve at submit" (Model B) was rejected — it
+  only buys showing the fully-resolved params at submit for direct editing, unnecessary
+  when the override UX is "force these fields." (Note: because Model B is rejected, the
+  human never sees the resolved params, so the resolver — not the caller — must canonicalize
+  override values; see below.)
+- **Read raw → merge → canonicalize per field → validate.** Fields are read with `.get`
+  and blank values (None / non-str / empty-after-strip) are omitted (not a read-time
+  `KeyError`, not a blank param); this is what lets an override supply a missing field and
+  lets validation name what is still missing. Crucially, **the same per-field
+  canonicalization is applied to derived and override values** so `param_hash` is
+  representation-independent. Reference shape:
+  ```python
+  def resolve_params(metadata, overrides=None):
+      overrides = overrides or {}
+      _reject_unknown_override_keys(overrides)          # keys ⊆ {species, mode, age}
+      values = {"mode": _mode_for_scan(metadata)}
+      if metadata.get(SPECIES_NAME_FIELD) is not None:
+          values["species"] = metadata[SPECIES_NAME_FIELD]   # raw; canonicalized below
+      if metadata.get(PLANT_AGE_DAYS_FIELD) is not None:
+          values["age"] = metadata[PLANT_AGE_DAYS_FIELD]      # raw; canonicalized below
+      values = {**values, **overrides}                  # override wins, per field
+      # canonicalize derived OR override values identically
+      if "species" in values:
+          species = _normalize_species(values["species"])     # non-str/blank -> ""
+          values["species"] = species if species else _drop("species", values)
+      if "age" in values:
+          values["age"] = _coerce_age(values["age"])           # int; ValueError('age') if lossy
+      _require(values, ("species", "mode", "age"))     # `k in values`; names EVERY absent param
+      return ResolvedParams(values=values)             # contract computes param_hash
+  ```
+  (`_drop` illustrates "blank species → treat as absent → let `_require` name it"; the real
+  implementation simply deletes the key. `_require` uses key-membership, not truthiness, so
+  `age == 0` is valid.)
+- **Override values are canonicalized, not stored raw (surfaced by review, verified against
+  the contract).** `compute_param_hash` hashes the entire `values` dict via canonical JSON;
+  `int 14` and `str "14"` hash **differently** (integer-valued floats collapse to int, but
+  strings pass through untouched). CLI/JSON overrides are always strings, so storing an
+  override `age="14"` raw would give the same scan a different `param_hash` (→ different
+  `idempotency_key` → duplicate work) than the derived `14` path — the exact failure this
+  module exists to prevent. Normalizing/coercing override values preserves "override wins"
+  (the override still wins the field) while making the hash representation-independent.
+- **Unknown species → lowercased passthrough, not hard-fail.** The registry (`ModelCard`s)
+  is the single authority on which species have models; `resolve_params` only *translates*
+  Bloom's naming. A new seeded species then works with no resolver edit; a species with no
+  card degrades to `choose_models` zero-match → skip. Safe because Bloom's `species_name`
+  is FK-controlled (a curated `species` table), so "unknown to the resolver" means "a real
+  Bloom species not yet modelled." A **blank** `species_name` is a different case (corrupt/
+  null row, not a real species) → treated as absent → fail loud, so it is not laundered as
+  an unmodelled species.
+- **Alias map keyed by lowercased name; ships empty.** `_normalize_species` does
+  `_ALIASES.get(name.strip().lower(), name.strip().lower())`, so any map keys MUST be
+  lowercase or they never fire. Because the seeded species' common names lowercase cleanly
+  to the card strings, identity entries would be dead no-ops; `_ALIASES` therefore **ships
+  empty** with a comment marking it the extension seam for Bloom names that do *not*
+  lowercase cleanly (e.g. a Latin binomial). The verified seeded-species set is recorded in
+  the payoff round-trip test (its executable home), not as no-op production entries. Mode
+  strings and species strings MUST equal the exact seeded `ModelCard` vocabulary.
+- **Mode via a one-line seam (`_mode_for_scan`), scoped to cylinder now.** Mode is a
+  property of the scan's scanner (`cyl_*` vs `gravi_*`; multiscanner not implemented;
+  multiplant-cylinder retired). We build only the seam's *shape*, not the future
+  `_SCANNER_MODE` table (rejected as speculative while GraviScan models are deferred).
+- **Strict validation, hardened (both verified load-bearing in review round 2).** Beyond
+  "require species/mode/age present," the resolver (a) rejects unknown override keys so a
+  typo'd key cannot silently enter `values` and change `param_hash`, and (b) rejects a lossy
+  age coercion naming `age`. Both protect the reproducibility hash and both close holes
+  `choose_models` structurally cannot reach (it never recomputes the hash).
+- **Field names as module constants** (`SPECIES_NAME_FIELD`, `PLANT_AGE_DAYS_FIELD`)
+  matching bloomcli's column names, so the cross-repo coupling to `cyl_scans_extended` is
+  explicit and greppable.
+- **Flat module, not a subpackage.** `pyproject.toml` packages the project via an explicit
+  `packages = ["sleap_roots_predict"]` list, so `param_resolution.py` MUST be a flat module;
+  a `param_resolution/` subpackage would be silently omitted from the built wheel.
+
+## Risks / Trade-offs
+
+- **Age units — CONFIRMED days (2026-07-06); issue #2 resolved, not deferred.** Queried the
+  live production registry (`sleap-roots-models`, 13 cards). The seeded cards' age windows
+  are `age_min`/`age_max` in **days**: arabidopsis/pennycress `2–14`, canola `2–13`, rice
+  crown `2–5` and `6–10` (two non-overlapping windows), rice primary `2–5`, soybean `2–8`.
+  These match `plant_age_days` (days), so the resolver passes `age` straight through as an
+  `int` with **no conversion**. The same query confirmed the species vocabulary is exactly
+  the lowercase common names `_normalize_species` produces (`arabidopsis`, `canola`,
+  `pennycress`, `rice`, `soybean`), so `_ALIASES` correctly ships empty. (Observation: the
+  registry also carries a distinct `multiplant cylinder` mode on two arabidopsis cards; the
+  current cylinder stage-in path emits `"cylinder"` and does not target those — consistent
+  with multiplant-cylinder being retired. Recorded for the `_mode_for_scan` seam / issue #1.)
+- **`param_hash` is not self-versioning (verified against the contract).** `ResolvedParams`
+  carries only `values` + `param_hash`; its hash's meaning depends on the resolver's emitted
+  key-set and normalization rules (`_ALIASES`, `_mode_for_scan`, `_coerce_age`). A future
+  change that adds a param, edits an alias, or changes the mode seam makes the **same scan
+  hash differently**, with nothing in `ResolvedParams` signalling the shift. Mitigated at
+  the provenance level: `Provenance.idempotency_key` folds in `predict_code_sha`, so a
+  resolver code change yields a different idempotency key (no false dedup). Acceptable to
+  defer, but **any future add/remove of an emitted param or alias-map edit is a
+  `param_hash`-breaking change to call out explicitly**, since `git revert` does not restore
+  already-persisted hashes.
+- **No defensive copy needed.** pydantic v2 copies the input dict on validation
+  (`ResolvedParams(values=d).values is d` → `False`), and `resolve_params` builds fresh
+  dicts anyway, so there is no mutation-after-construct aliasing from the caller. (The
+  contract's `values` field is only shallow-frozen — an upstream limitation of
+  `sleap-roots-contracts`, out of scope here.)
+- **Species alias drift.** If a Bloom `species_name` doesn't lowercase cleanly to the card
+  string, selection silently zero-matches. Mitigation: `_ALIASES` is the one place to
+  extend, and the payoff round-trip test catches a mismatch for the seeded species.
+
+## Migration Plan
+
+Additive only — a new flat module, a new public export, and new tests. No existing behavior
+changes; `choose_models` and the `model-management` spec are untouched. `choose_models`
+does not import `resolve_params`, so nothing on `main` depends on the new code and a single
+`git revert` of the squash-merge reverses it cleanly.
+
+## Open Questions
+
+- **Age units** — see Risks (Task 8). Record the confirmed answer in Decisions; file
+  tracking issue #2 only if it needs training-side coordination.

--- a/openspec/changes/add-param-resolution/design.md
+++ b/openspec/changes/add-param-resolution/design.md
@@ -45,23 +45,29 @@ resolver is tested against.
       overrides = overrides or {}
       _reject_unknown_override_keys(overrides)          # keys ⊆ {species, mode, age}
       values = {"mode": _mode_for_scan(metadata)}
-      if metadata.get(SPECIES_NAME_FIELD) is not None:
+      if not _is_blank(metadata.get(SPECIES_NAME_FIELD)):
           values["species"] = metadata[SPECIES_NAME_FIELD]   # raw; canonicalized below
-      if metadata.get(PLANT_AGE_DAYS_FIELD) is not None:
+      if not _is_blank(metadata.get(PLANT_AGE_DAYS_FIELD)):
           values["age"] = metadata[PLANT_AGE_DAYS_FIELD]      # raw; canonicalized below
       values = {**values, **overrides}                  # override wins, per field
-      # canonicalize derived OR override values identically
-      if "species" in values:
-          species = _normalize_species(values["species"])     # non-str/blank -> ""
-          values["species"] = species if species else _drop("species", values)
+      # canonicalize derived OR override values identically; blank -> drop
+      _canonicalize_text(values, "species", _normalize_species)  # non-str/blank -> drop
+      _canonicalize_text(values, "mode", _normalize_mode)        # strip+lower; blank -> drop
       if "age" in values:
-          values["age"] = _coerce_age(values["age"])           # int; ValueError('age') if lossy
-      _require(values, ("species", "mode", "age"))     # `k in values`; names EVERY absent param
-      return ResolvedParams(values=values)             # contract computes param_hash
+          if _is_blank(values["age"]):
+              del values["age"]                          # blank/NaN age -> treat as absent
+          else:
+              values["age"] = _coerce_age(values["age"]) # int; ValueError('age') if lossy
+      missing = [k for k in ("species", "mode", "age") if k not in values]
+      if missing:                                        # names EVERY absent param
+          raise ValueError(f"Missing required scan param(s): {missing}")
+      return ResolvedParams(values=values)               # contract computes param_hash
   ```
-  (`_drop` illustrates "blank species → treat as absent → let `_require` name it"; the real
-  implementation simply deletes the key. `_require` uses key-membership, not truthiness, so
-  `age == 0` is valid.)
+  (`_is_blank(v)` == `v is None or NaN or empty/whitespace string` — applied symmetrically to
+  **both** load-bearing reads and to the merged `age`, so a blank field of any kind is treated
+  as not provided instead of raising at read/coerce time. `_canonicalize_text` normalizes a
+  field in place and drops it when it normalizes to blank. Validation uses key-membership, not
+  truthiness, so `age == 0` is valid.)
 - **Override values are canonicalized, not stored raw (surfaced by review, verified against
   the contract).** `compute_param_hash` hashes the entire `values` dict via canonical JSON;
   `int 14` and `str "14"` hash **differently** (integer-valued floats collapse to int, but
@@ -69,7 +75,11 @@ resolver is tested against.
   override `age="14"` raw would give the same scan a different `param_hash` (→ different
   `idempotency_key` → duplicate work) than the derived `14` path — the exact failure this
   module exists to prevent. Normalizing/coercing override values preserves "override wins"
-  (the override still wins the field) while making the hash representation-independent.
+  (the override still wins the field) while making the hash representation-independent. This
+  applies to **all three** fields, including `mode`: an override `mode="Cylinder"` is
+  normalized (`_normalize_mode` = strip+lower) so it hashes identically to the derived
+  `"cylinder"` and still exact-matches the seeded card vocabulary (a PR-review finding — the
+  original design canonicalized only species/age, leaving mode overrides raw).
 - **Unknown species → lowercased passthrough, not hard-fail.** The registry (`ModelCard`s)
   is the single authority on which species have models; `resolve_params` only *translates*
   Bloom's naming. A new seeded species then works with no resolver edit; a species with no

--- a/openspec/changes/add-param-resolution/proposal.md
+++ b/openspec/changes/add-param-resolution/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Predict's `choose_models(params, cards)` consumes a `ResolvedParams` (`species`,
+`mode`, `age`) and selects a production model per root type, but nothing yet
+**produces** that `ResolvedParams` from real Bloom scan metadata — the roadmap's
+**A3-params** gap. Without an oracle that maps the metadata a scan already carries
+in Bloom to params, the selection layer cannot be driven from production data.
+
+## What Changes
+
+- Add a pure oracle `resolve_params(metadata, overrides=None) -> ResolvedParams`
+  in a new `sleap_roots_predict/param_resolution.py`, mapping a single
+  `cyl_scans_extended` row (the dict bloomcli's download writes to `scans.csv`)
+  to `{species, mode, age}`:
+  - **species** — `species_name` normalized via an alias map with a lowercase
+    passthrough fallback (unknown species pass through; the registry/`ModelCard`s
+    are the sole authority on which species have models).
+  - **mode** — derived through a one-line `_mode_for_scan` **seam** that returns
+    `"cylinder"` for the current cylinder stage-in path (GraviScan/multiscanner
+    modes are deferred to that seam).
+  - **age** — `plant_age_days` as an `int` (days).
+- **Override-wins per field:** an optional param-space `overrides` dict is merged
+  last, so a caller-supplied field replaces the derived one. Override keys are
+  restricted to `{species, mode, age}` — an unknown key raises rather than
+  silently polluting `values`. Override **values** are canonicalized by the same
+  per-field rules as derived values (species normalized, age coerced), so a run is
+  hashed representation-independently (an `age` override of `"14"` and a derived
+  `14` produce the same `param_hash`).
+- **Strict post-override validation:** blank/absent load-bearing fields are treated
+  as not provided (a blank `species_name` fails loud rather than resolving an empty
+  species); after merging, require `species`, `mode`, and `age` all present (by
+  key, so `age=0` is valid), else raise a clear `ValueError` naming every missing
+  param. A lossy `plant_age_days` (non-whole/non-coercible) raises naming `age`.
+  These guards protect the reproducibility hash and close holes `choose_models`
+  cannot reach (it never recomputes the hash).
+- Export `resolve_params` from the package public API (`__init__.py` + `__all__`).
+- Pure/offline: the only dependency is `sleap-roots-contracts` (already pinned,
+  already imported by predict); **zero new dependencies**; no network, no I/O.
+
+## Impact
+
+- Affected specs: **param-resolution** (new capability). No change to the existing
+  `model-management` spec — `choose_models` is the unchanged consumer of the output.
+- Affected code: new `sleap_roots_predict/param_resolution.py`;
+  `sleap_roots_predict/__init__.py` (export + module docstring); new
+  `tests/test_param_resolution.py`; `tests/test_public_api.py` (extend).
+- Affected docs: `README.md`, `API.md`, `CHANGELOG.md`, `openspec/project.md`
+  (public-surface + architecture list). `CLAUDE.md` is intentionally **not** touched
+  (being retired).
+- Advances roadmap tier **A3-params** (`sleap-roots-pipeline/docs/bloom-integration/roadmap.md`).
+- Settled design (approved 2026-07-06):
+  `docs/superpowers/specs/2026-07-06-param-resolution-design.md`.

--- a/openspec/changes/add-param-resolution/specs/param-resolution/spec.md
+++ b/openspec/changes/add-param-resolution/specs/param-resolution/spec.md
@@ -112,6 +112,13 @@ than silently truncating — mirroring `choose_models`'s age handling. A resolve
 - **WHEN** the row's `plant_age_days` is `0`
 - **THEN** the resolved `age` is `0` and resolution succeeds (0 is not treated as missing)
 
+#### Scenario: A blank age is treated as not provided
+
+- **WHEN** the row's `plant_age_days` is blank (`""`, whitespace, `None`, or `NaN`) with no
+  `age` override
+- **THEN** `resolve_params` raises a `ValueError` naming `age` as **missing** (treated as not
+  provided — the same as a blank `species_name`), rather than a "not a whole number" error
+
 ### Requirement: Override Merge And Strict Post-Override Validation
 
 The optional `overrides` argument SHALL be a param-space dict merged last so a supplied
@@ -119,12 +126,15 @@ field replaces the derived one (**override wins per field**). Override keys SHAL
 restricted to the resolvable params `{species, mode, age}`; an unrecognized override key
 SHALL raise a `ValueError` naming the offending key. Override **values** SHALL be
 canonicalized by the same per-field rules as derived values (`species` normalized via
-`_normalize_species`, `age` coerced via `_coerce_age`), so that a logically identical run
-produces an identical `param_hash` regardless of whether a value arrived derived or as an
-override (e.g. an `age` override of `"14"` and a derived `14` hash identically). After
-merging and canonicalizing, `resolve_params` SHALL require that `species`, `mode`, and
-`age` are all present (by key) and SHALL raise a clear `ValueError` naming every missing
-param when any is absent. It SHALL NOT return a half-resolved `ResolvedParams`.
+`_normalize_species`, `mode` normalized via `_normalize_mode`, `age` coerced via
+`_coerce_age`), so that a logically identical run produces an identical `param_hash`
+regardless of whether a value arrived derived or as an override (e.g. an `age` override of
+`"14"` and a derived `14` hash identically; a `mode` override of `"Cylinder"` and a derived
+`"cylinder"` hash identically). A blank override value is treated as not provided (the field
+is dropped, then named by validation). After merging and canonicalizing, `resolve_params`
+SHALL require that `species`, `mode`, and `age` are all present (by key) and SHALL raise a
+clear `ValueError` naming every missing param when any is absent. It SHALL NOT return a
+half-resolved `ResolvedParams`.
 
 #### Scenario: Override wins per field
 
@@ -139,6 +149,12 @@ param when any is absent. It SHALL NOT return a half-resolved `ResolvedParams`.
 - **THEN** the resolved `species` is `"rice"` and `age` is the integer `14` (the override
   values are normalized/coerced, not stored raw), so the `param_hash` matches the
   equivalent derived run
+
+#### Scenario: A mode override is canonicalized
+
+- **WHEN** `resolve_params(row, overrides={"mode": "  Cylinder "})` is called
+- **THEN** the resolved `mode` is `"cylinder"` (stripped/lowercased like a derived mode), so
+  the `param_hash` matches the equivalent derived run and selection is not broken by casing
 
 #### Scenario: An unknown override key is rejected
 

--- a/openspec/changes/add-param-resolution/specs/param-resolution/spec.md
+++ b/openspec/changes/add-param-resolution/specs/param-resolution/spec.md
@@ -1,0 +1,188 @@
+## ADDED Requirements
+
+### Requirement: Scan Metadata Resolution To Params
+
+The system SHALL provide a pure function `resolve_params(metadata, overrides=None) ->
+ResolvedParams` that maps a single Bloom `cyl_scans_extended` scan-metadata record (the
+dict shape bloomcli's download writes to `scans.csv`) to a `ResolvedParams` carrying
+`species`, `mode`, and `age`. It SHALL read the load-bearing fields via module constants
+matching bloomcli's column names: `species_name` → `species` (normalized), the scan's
+scanner → `mode` (via the imaging-mode seam), and `plant_age_days` → `age`. A load-bearing
+field that is **absent or blank** (missing key, `None`, a non-string sentinel such as a
+`NaN`, or an empty/whitespace-only string) SHALL be treated as not provided — the function
+SHALL omit that derived param (deferring to `overrides` and then to post-override
+validation) rather than raising at read time or emitting a blank param. It SHALL construct
+`ResolvedParams(values=…)` so the contract computes `param_hash`. The function SHALL be
+pure: it SHALL perform no network access and no filesystem I/O, and SHALL NOT mutate the
+input `metadata`.
+
+#### Scenario: A sample cylinder scan row resolves to species/mode/age
+
+- **WHEN** `resolve_params` is called with a `cyl_scans_extended` row carrying
+  `species_name="Pennycress"` and `plant_age_days=14`
+- **THEN** it returns a `ResolvedParams` whose `values` are
+  `{"species": "pennycress", "mode": "cylinder", "age": 14}` and whose `param_hash` is
+  populated by the contract
+
+#### Scenario: Extra columns are ignored and the input is not mutated
+
+- **WHEN** `resolve_params` is called with a full `cyl_scans_extended` row carrying many
+  non-load-bearing columns (e.g. `species_genus`, `scan_id`, timestamps)
+- **THEN** only `species`, `mode`, and `age` appear in the resolved `values`, and the
+  passed-in `metadata` dict is unchanged
+
+#### Scenario: A blank species value is treated as not provided
+
+- **WHEN** `species_name` is present but blank (`""`, `"   "`, `None`, or a `NaN`) with no
+  `species` override
+- **THEN** `resolve_params` raises a `ValueError` naming `species` (the blank is treated as
+  missing, not resolved to an empty species), and does not crash
+
+### Requirement: Species Name Normalization
+
+The system SHALL normalize the Bloom `species_name` to the `ModelCard` species vocabulary
+via `_normalize_species`, which strips and lowercases the name and then applies an alias
+map keyed by the **lowercased** name. The alias map is the single extension point for any
+Bloom name that does not lowercase cleanly to the card string (e.g. a Latin binomial);
+names not in the map fall through as their stripped, lowercased form (**lowercase
+passthrough fallback**). Unknown species SHALL pass through rather than being rejected or
+dropped — the registry/`ModelCard`s are the single authority on which species have models,
+so an unmodelled species degrades to a `choose_models` zero-match (skip), not a resolver
+error. The resolver SHALL NOT maintain a whitelist or hard-fail on species.
+
+#### Scenario: A seeded species normalizes to the card vocabulary
+
+- **WHEN** `species_name` is `"Pennycress"`
+- **THEN** the resolved `species` is `"pennycress"`
+
+#### Scenario: Surrounding whitespace and case are normalized
+
+- **WHEN** `species_name` is `"  Rice  "`
+- **THEN** the resolved `species` is `"rice"`
+
+#### Scenario: An unknown species passes through lowercased
+
+- **WHEN** `species_name` is `"Sorghum"` (a real Bloom species with no seeded model)
+- **THEN** the resolved `species` is `"sorghum"` (passthrough), and no error is raised
+
+### Requirement: Imaging Mode Resolution Seam
+
+The system SHALL derive `mode` through a single `_mode_for_scan(metadata)` function that
+returns `"cylinder"` for the current cylinder stage-in path (the cylinder pipeline yields
+cylinder scans only). This function SHALL be the one place mode is decided, so future
+GraviScan/multiscanner modes slot in here without changing `resolve_params`'s body, its
+callers, or its output shape. The mode strings it returns MUST equal the exact seeded
+`ModelCard` mode vocabulary. The scanner→mode lookup table for deferred modalities is
+explicitly out of scope for this change.
+
+#### Scenario: A cylinder scan resolves mode "cylinder"
+
+- **WHEN** `resolve_params` resolves a `cyl_scans_extended` row
+- **THEN** the resolved `mode` is `"cylinder"`
+
+### Requirement: Age Resolution In Days
+
+The system SHALL resolve `age` from `plant_age_days` as an integer number of days via
+`_coerce_age`. It SHALL accept both an integer and an int-coercible whole-number string
+(Bloom metadata read from `scans.csv` may arrive as a string, e.g. `"14"`), canonicalizing
+both to the same `int` so the resolved `age` — and therefore `param_hash` — does not depend
+on the incoming representation. A present, non-blank, but non-whole or non-coercible value
+(e.g. `14.5`, `"14.5"`, `"abc"`, or a bool) SHALL raise a `ValueError` naming `age`, rather
+than silently truncating — mirroring `choose_models`'s age handling. A resolved `age` of
+`0` SHALL be valid (validation checks key presence, not truthiness).
+
+#### Scenario: An integer age passes through as days
+
+- **WHEN** the row's `plant_age_days` is `14`
+- **THEN** the resolved `age` is the integer `14`
+
+#### Scenario: An int-coercible string age is coerced to the same int
+
+- **WHEN** the row's `plant_age_days` is the string `"14"`
+- **THEN** the resolved `age` is the integer `14`, and the resulting `param_hash` is
+  identical to the `plant_age_days=14` case (representation-independent)
+
+#### Scenario: A non-whole or non-coercible age raises naming age
+
+- **WHEN** the row's `plant_age_days` is `14.5`, `"14.5"`, or `"abc"`
+- **THEN** `resolve_params` raises a `ValueError` whose message names `age`
+
+#### Scenario: An age of zero is valid
+
+- **WHEN** the row's `plant_age_days` is `0`
+- **THEN** the resolved `age` is `0` and resolution succeeds (0 is not treated as missing)
+
+### Requirement: Override Merge And Strict Post-Override Validation
+
+The optional `overrides` argument SHALL be a param-space dict merged last so a supplied
+field replaces the derived one (**override wins per field**). Override keys SHALL be
+restricted to the resolvable params `{species, mode, age}`; an unrecognized override key
+SHALL raise a `ValueError` naming the offending key. Override **values** SHALL be
+canonicalized by the same per-field rules as derived values (`species` normalized via
+`_normalize_species`, `age` coerced via `_coerce_age`), so that a logically identical run
+produces an identical `param_hash` regardless of whether a value arrived derived or as an
+override (e.g. an `age` override of `"14"` and a derived `14` hash identically). After
+merging and canonicalizing, `resolve_params` SHALL require that `species`, `mode`, and
+`age` are all present (by key) and SHALL raise a clear `ValueError` naming every missing
+param when any is absent. It SHALL NOT return a half-resolved `ResolvedParams`.
+
+#### Scenario: Override wins per field
+
+- **WHEN** `resolve_params(row, overrides={"mode": "graviscan", "species": "canola"})` is
+  called
+- **THEN** `mode` is `"graviscan"` and `species` is `"canola"` (the overrides), while any
+  field not present in `overrides` (e.g. `age`) keeps its derived value
+
+#### Scenario: Override values are canonicalized like derived values
+
+- **WHEN** `resolve_params(row, overrides={"species": "Rice", "age": "14"})` is called
+- **THEN** the resolved `species` is `"rice"` and `age` is the integer `14` (the override
+  values are normalized/coerced, not stored raw), so the `param_hash` matches the
+  equivalent derived run
+
+#### Scenario: An unknown override key is rejected
+
+- **WHEN** `resolve_params(row, overrides={"specis": "rice"})` is called (a typo'd key)
+- **THEN** it raises a `ValueError` whose message names the unrecognized key
+
+#### Scenario: Missing required fields raise naming each missing param
+
+- **WHEN** `resolve_params` is called with a row missing both `species_name` and
+  `plant_age_days` and no compensating overrides
+- **THEN** it raises a `ValueError` whose message names both missing params (`species` and
+  `age`)
+
+#### Scenario: A missing derived field can be supplied by an override
+
+- **WHEN** a row is missing `species_name` but the call passes
+  `overrides={"species": "rice"}`
+- **THEN** resolution succeeds with `species="rice"` (the override satisfies the
+  post-override validation)
+
+### Requirement: Public API Export
+
+The system SHALL export `resolve_params` from the package's public API — importable as
+`from sleap_roots_predict import resolve_params` and listed in `__all__` — so it is
+callable alongside `choose_models`.
+
+#### Scenario: resolve_params is importable and in __all__
+
+- **WHEN** a caller runs `from sleap_roots_predict import resolve_params`
+- **THEN** the import succeeds and `"resolve_params"` is present in
+  `sleap_roots_predict.__all__`
+
+### Requirement: Interoperability With Model Selection
+
+The `ResolvedParams` produced by `resolve_params` SHALL be a valid input to
+`choose_models`, so a Bloom scan-metadata row drives model selection end-to-end
+(metadata → params → model). The detailed selection semantics (matching, skipping,
+ambiguity) remain owned by the `model-management` capability; this requirement asserts only
+that the produced params are consumable by that layer and yield the expected selection for a
+row whose `species`/`mode`/`age` match seeded cards.
+
+#### Scenario: A resolved Bloom row selects the expected model(s)
+
+- **WHEN** `choose_models(resolve_params(row), cards)` is called for a Bloom row whose
+  normalized `species`/`mode` and coerced `age` match a small real `ModelCard` list
+- **THEN** it returns the expected `ModelRef` per matching root type (the metadata → params
+  → model round-trip), without raising a missing-param error

--- a/openspec/changes/add-param-resolution/tasks.md
+++ b/openspec/changes/add-param-resolution/tasks.md
@@ -1,0 +1,91 @@
+## 1. Scaffold module and field constants
+
+- [x] 1.1 Create the **flat module** `sleap_roots_predict/param_resolution.py` (not a
+  subpackage — see design.md) with a module docstring and the field-name constants
+  (`SPECIES_NAME_FIELD == "species_name"`, `PLANT_AGE_DAYS_FIELD == "plant_age_days"`)
+  documenting the bloomcli coupling. (Constants are exercised through the oracle-table test
+  in 5.1 — no separate tautological constant-value test.)
+
+## 2. Species normalization (TDD)
+
+- [x] 2.1 Write failing tests for `_normalize_species`: a seeded passthrough
+  (`Pennycress`→`pennycress`), whitespace/case (`"  Rice  "`→`"rice"`), unknown-species
+  passthrough (`"Sorghum"`→`"sorghum"`), and blank/non-str inputs (`""`, `"  "`, `None`,
+  `float("nan")`) → returns `""` (blank) without raising.
+- [x] 2.2 Implement `_ALIASES = {}` (ships empty with a comment marking it the extension
+  seam for names that don't lowercase cleanly; keys, when added, MUST be lowercase) +
+  `_normalize_species` (coerce non-str/blank to `""`, else `strip().lower()` then alias
+  lookup with lowercase passthrough fallback); make 2.1 pass. No whitelist / no hard-fail.
+
+## 3. Imaging-mode seam (TDD)
+
+- [x] 3.1 Write a failing test asserting `_mode_for_scan(row)` returns `"cylinder"` and that
+  the string matches the seeded `ModelCard` mode vocabulary used in selection tests.
+- [x] 3.2 Implement the one-line `_mode_for_scan` seam returning `"cylinder"` with a docstring
+  documenting it as the single mode-decision point (GraviScan/multiscanner deferred here).
+
+## 4. Age coercion in days (TDD)
+
+- [x] 4.1 Write failing tests for `_coerce_age`: `14`→`14`; int-coercible string `"14"`→`14`
+  (result is an `int`); `0`→`0` (valid, not treated as missing); non-whole/non-coercible
+  (`14.5`, `"14.5"`, `"abc"`, `True`) → `ValueError` naming `age` (no silent truncation).
+- [x] 4.2 Implement `_coerce_age` (reject bool/non-whole-float/non-coercible with a
+  param-named `ValueError`; accept int and whole-number string); make 4.1 pass.
+
+## 5. resolve_params core: mapping, override-wins, canonicalization, strict validation (TDD)
+
+- [x] 5.1 Write the oracle-table test: a sample `cyl_scans_extended` row
+  (`species_name="Pennycress"`, `plant_age_days=14`) → `values ==
+  {"species": "pennycress", "mode": "cylinder", "age": 14}`, `param_hash` populated; plus a
+  full-column row asserting only the 3 fields are used and `metadata` is not mutated.
+- [x] 5.2 Write override tests: full and partial `overrides` win per field; `overrides={}`
+  equals no overrides; an **unknown override key** (`{"specis": ...}`) raises `ValueError`
+  naming the key; **override values are canonicalized** — `overrides={"species": "Rice",
+  "age": "14"}` → `species="rice"`, `age=14`, and the resulting `param_hash` equals the
+  equivalent derived run (representation-independent).
+- [x] 5.3 Write validation tests: a row missing both `species_name` and `plant_age_days`
+  (no overrides) raises `ValueError` naming **both** `species` and `age`; a **blank**
+  `species_name` (`""`) with no override raises naming `species` (blank ≠ empty param); a
+  missing `species_name` compensated by `overrides={"species": ...}` succeeds
+  (tolerant-read → override → validate ordering).
+- [x] 5.4 Implement `resolve_params(metadata, overrides=None)` per design.md: reject unknown
+  override keys; read fields tolerantly via `.get` (mode always; species/age only when
+  non-None); merge `{**derived, **overrides}` (override wins); canonicalize per field
+  (`_normalize_species`, `_coerce_age`) dropping a blank species; `_require(...)` fail-loud
+  by key-membership naming every absent param; return `ResolvedParams(values=values)`. Make
+  5.1–5.3 pass.
+
+## 6. Public API export (TDD)
+
+- [x] 6.1 Extend `tests/test_public_api.py` asserting both
+  `from sleap_roots_predict import resolve_params` works **and**
+  `"resolve_params" in sleap_roots_predict.__all__` (the existing test only does `hasattr`).
+- [x] 6.2 Add the import + `__all__` entry (and mention it in the module docstring) in
+  `sleap_roots_predict/__init__.py`. Make 6.1 pass.
+
+## 7. Payoff round-trip with choose_models (TDD)
+
+- [x] 7.1 Write the demoable round-trip test: build a small real `ModelCard` list (mirroring
+  `tests/test_model_selection.py`), then assert `choose_models(resolve_params(row), cards)`
+  selects the expected `ModelRef` per root type (metadata → params → model).
+- [x] 7.2 Add the end-to-end unknown-species case that proves the passthrough decision:
+  a `species_name="Sorghum"` row → `choose_models(resolve_params(row), cards) == {}`
+  (zero-match skip, no error).
+
+## 8. Confirm age units (days) — decision, not a wandb regression test
+
+- [x] 8.1 Confirm the seeded production cards' `age_min`/`age_max` are in **days** (to match
+  `plant_age_days`): query a real seeded card via a gated `uv run pytest -m wandb` check or
+  ask training. **Record the confirmed answer in `design.md` Decisions** (do NOT commit a
+  `-m wandb` age-units test). If a conversion is required, add it to `_coerce_age` with an
+  **offline** unit test, and file tracking issue #2 if it needs training-side coordination.
+
+## 9. Docs + validation gate
+
+- [x] 9.1 Document `resolve_params` as the metadata → params oracle feeding `choose_models`
+  in each place that lists the public surface: `README.md` (Project Structure tree + prose),
+  the `sleap_roots_predict/__init__.py` module docstring, the `openspec/project.md`
+  Architecture-Patterns list, `API.md` (High-Level API entry), and a `CHANGELOG.md`
+  `[Unreleased]/Added` entry. **Do NOT edit `CLAUDE.md`** (being retired).
+- [x] 9.2 Run `openspec validate add-param-resolution --strict` and fix any issues.
+- [x] 9.3 Run `/pre-merge` (format check, lint, test, build) and ensure it is green.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -40,6 +40,8 @@ importable library.
 ### Architecture Patterns
 - Package `sleap_roots_predict/`:
   - `predict.py` — sleap-nn prediction interface (`make_predictor`, `predict_on_video`)
+  - `param_resolution.py` — pure Bloom-metadata → `ResolvedParams` oracle (`resolve_params`);
+    feeds `choose_models`
   - `model_selection.py` — pure model-selection matcher (`choose_models`)
   - `model_registry.py` — model-card sources (`ModelCardSource`, `LocalCardSource`,
     `WandbRegistrySource`); all wandb/network access confined here (lazy import)

--- a/sleap_roots_predict/__init__.py
+++ b/sleap_roots_predict/__init__.py
@@ -4,10 +4,11 @@ This package provides:
 - sleap-nn inference on ``sleap_io.Video`` objects (``make_predictor`` builds a
   reusable predictor; ``predict_on_video`` runs inference and optionally saves a
   ``.slp``)
-- Model management: choose models from Bloom scan metadata (``choose_models``),
-  fetch them from the wandb registry or a local dir (``ModelCardSource`` /
-  ``WandbRegistrySource`` / ``LocalCardSource``), and keep sleap-nn predictors
-  resident across scans (``WarmModelWorker``)
+- Model management: resolve Bloom scan metadata to params (``resolve_params``),
+  choose models from those params (``choose_models``), fetch them from the wandb
+  registry or a local dir (``ModelCardSource`` / ``WandbRegistrySource`` /
+  ``LocalCardSource``), and keep sleap-nn predictors resident across scans
+  (``WarmModelWorker``)
 - Output contract: write the per-scan artifacts the downstream traits stage reads
   (named per-root ``.slp`` + a combined ``{scan}.predictions.json`` manifest) via
   ``write_prediction_outputs`` / ``predict_and_write_batch`` (see the
@@ -30,6 +31,8 @@ from sleap_roots_predict.predict import (  # noqa: F401
 
 from sleap_roots_predict.model_selection import choose_models  # noqa: F401
 
+from sleap_roots_predict.param_resolution import resolve_params  # noqa: F401
+
 from sleap_roots_predict.model_registry import (  # noqa: F401
     LocalCardSource,
     ModelCardSource,
@@ -51,6 +54,7 @@ __all__ = [
     "make_predictor",
     "predict_on_video",
     "choose_models",
+    "resolve_params",
     "ModelCardSource",
     "LocalCardSource",
     "WandbRegistrySource",

--- a/sleap_roots_predict/param_resolution.py
+++ b/sleap_roots_predict/param_resolution.py
@@ -1,0 +1,137 @@
+"""Pure param-resolution oracle: Bloom scan metadata -> ``ResolvedParams``.
+
+Maps a single Bloom ``cyl_scans_extended`` row (the dict bloomcli's download
+writes to ``scans.csv``) to a ``ResolvedParams`` carrying ``species``, ``mode``,
+and ``age``, so predict's ``choose_models`` can select production models from
+real Bloom metadata (metadata -> params -> model). The mapper is pure: no
+network access and no filesystem I/O, and it does not mutate its input.
+"""
+
+import math
+from typing import Any, Dict, Optional
+
+from sleap_roots_contracts import ResolvedParams
+
+# Bloom ``cyl_scans_extended`` column names (bloomcli's ``scans.csv``). Module
+# constants so the cross-repo coupling to bloomcli's schema is explicit/greppable.
+SPECIES_NAME_FIELD = "species_name"
+PLANT_AGE_DAYS_FIELD = "plant_age_days"
+
+# The resolvable param space; overrides are restricted to these keys.
+_PARAM_KEYS = ("species", "mode", "age")
+
+# Extension seam: Bloom ``species_name`` (lowercased) -> ``ModelCard`` species
+# vocabulary, for names that do NOT lowercase cleanly to the card string (e.g. a
+# Latin binomial). The seeded common names lowercase cleanly, so this ships
+# empty; add lowercase-keyed entries only for genuine non-identity aliases.
+_ALIASES: Dict[str, str] = {}
+
+
+def _normalize_species(name: Any) -> str:
+    """Normalize a Bloom species_name to the ModelCard species vocabulary.
+
+    Strips and lowercases the name, then applies the (lowercase-keyed) alias
+    map with a lowercase passthrough fallback. Blank, ``None``, or non-string
+    (e.g. ``NaN``) inputs normalize to ``""`` so callers can treat them as not
+    provided.
+    """
+    if name is None or (isinstance(name, float) and math.isnan(name)):
+        return ""
+    key = str(name).strip().lower()
+    return _ALIASES.get(key, key)
+
+
+def _mode_for_scan(metadata: Dict[str, Any]) -> str:
+    """Return the imaging modality for a scan (the single mode-decision point).
+
+    The cylinder pipeline yields cylinder scans only, so this returns
+    ``"cylinder"``. GraviScan/multiscanner modes slot in here once their
+    scanners and models exist; the returned string MUST match the exact seeded
+    ``ModelCard`` mode vocabulary.
+    """
+    return "cylinder"
+
+
+def _coerce_age(raw_age: Any) -> int:
+    """Coerce a plant_age_days value to a whole number of days (int).
+
+    Accepts an int or an int-coercible whole-number string; rejects bools,
+    non-whole floats, and non-coercible values with a ``ValueError`` naming
+    ``age`` — mirroring ``choose_models`` so the resolved ``age`` (and therefore
+    ``param_hash``) is never derived from a lossy conversion.
+    """
+    if isinstance(raw_age, bool):
+        raise ValueError(f"Scan param 'age' must be a whole number, got {raw_age!r}")
+    try:
+        age = int(raw_age)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"Scan param 'age' must be a whole number, got {raw_age!r}"
+        ) from e
+    if isinstance(raw_age, float) and float(age) != raw_age:
+        raise ValueError(f"Scan param 'age' must be a whole number, got {raw_age!r}")
+    return age
+
+
+def resolve_params(
+    metadata: Dict[str, Any],
+    overrides: Optional[Dict[str, Any]] = None,
+) -> ResolvedParams:
+    """Resolve a Bloom scan-metadata row to ``ResolvedParams`` (species/mode/age).
+
+    Args:
+        metadata: A single Bloom ``cyl_scans_extended`` row — the shape
+            bloomcli's download writes to ``scans.csv``. Load-bearing fields:
+            ``species_name`` (-> ``species``), ``plant_age_days`` (-> ``age``,
+            days); the scanner determines ``mode``. Other columns are ignored.
+            A blank or absent load-bearing field is treated as not provided.
+        overrides: Optional param-space dict whose keys are a subset of
+            ``{"species", "mode", "age"}``. Each key wins its field over the
+            derived value; override values are normalized/coerced by the same
+            rules as derived values so ``param_hash`` is representation-
+            independent.
+
+    Returns:
+        A ``ResolvedParams`` whose ``values`` contain ``species``, ``mode``, and
+        ``age``; the contract computes ``param_hash``.
+
+    Raises:
+        ValueError: If an override key is not in ``{"species", "mode", "age"}``;
+            if a present ``plant_age_days`` (or ``age`` override) is not a whole
+            number; or if ``species``, ``mode``, or ``age`` is still missing
+            after merging overrides.
+    """
+    overrides = overrides or {}
+    unknown = set(overrides) - set(_PARAM_KEYS)
+    if unknown:
+        raise ValueError(
+            f"Unknown override key(s): {sorted(unknown)}; "
+            f"allowed keys are {list(_PARAM_KEYS)}"
+        )
+
+    # Tolerant read: mode always; species/age only when present (blank -> handled
+    # below). Absent fields are omitted, deferring to overrides then validation.
+    values: Dict[str, Any] = {"mode": _mode_for_scan(metadata)}
+    if metadata.get(SPECIES_NAME_FIELD) is not None:
+        values["species"] = metadata[SPECIES_NAME_FIELD]
+    if metadata.get(PLANT_AGE_DAYS_FIELD) is not None:
+        values["age"] = metadata[PLANT_AGE_DAYS_FIELD]
+
+    values = {**values, **overrides}  # override wins, per field
+
+    # Canonicalize derived OR override values so param_hash is representation-
+    # independent; a blank species is treated as absent (fails validation below).
+    if "species" in values:
+        species = _normalize_species(values["species"])
+        if species:
+            values["species"] = species
+        else:
+            del values["species"]
+    if "age" in values:
+        values["age"] = _coerce_age(values["age"])
+
+    missing = [key for key in _PARAM_KEYS if key not in values]
+    if missing:
+        raise ValueError(f"Missing required scan param(s): {missing}")
+
+    return ResolvedParams(values=values)

--- a/sleap_roots_predict/param_resolution.py
+++ b/sleap_roots_predict/param_resolution.py
@@ -8,7 +8,7 @@ network access and no filesystem I/O, and it does not mutate its input.
 """
 
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from sleap_roots_contracts import ResolvedParams
 
@@ -27,6 +27,26 @@ _PARAM_KEYS = ("species", "mode", "age")
 _ALIASES: Dict[str, str] = {}
 
 
+def _is_blank(value: Any) -> bool:
+    """Return True for absent-like values: ``None``, ``NaN``, or a blank string.
+
+    Bloom metadata read from ``scans.csv`` may present a missing cell as an empty
+    string (``csv``) or a ``NaN`` (``pandas`` coerces a numeric column with any
+    gap to ``float``), so both — plus whitespace-only strings — are treated the
+    same as an absent key.
+    """
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return True
+    return isinstance(value, str) and value.strip() == ""
+
+
+def _normalize_text(value: Any) -> str:
+    """Strip and lowercase a text value; blank/``None``/``NaN`` -> ``""``."""
+    if _is_blank(value):
+        return ""
+    return str(value).strip().lower()
+
+
 def _normalize_species(name: Any) -> str:
     """Normalize a Bloom species_name to the ModelCard species vocabulary.
 
@@ -35,10 +55,18 @@ def _normalize_species(name: Any) -> str:
     (e.g. ``NaN``) inputs normalize to ``""`` so callers can treat them as not
     provided.
     """
-    if name is None or (isinstance(name, float) and math.isnan(name)):
-        return ""
-    key = str(name).strip().lower()
+    key = _normalize_text(name)
     return _ALIASES.get(key, key)
+
+
+def _normalize_mode(mode: Any) -> str:
+    """Normalize a mode string to the ModelCard mode vocabulary (strip+lower).
+
+    Mirrors ``_normalize_species`` so a derived mode and an override mode
+    canonicalize identically (representation-independent ``param_hash``). The
+    seeded modes (``cylinder``, ``multiplant cylinder``) are already lowercase.
+    """
+    return _normalize_text(mode)
 
 
 def _mode_for_scan(metadata: Dict[str, Any]) -> str:
@@ -58,7 +86,8 @@ def _coerce_age(raw_age: Any) -> int:
     Accepts an int or an int-coercible whole-number string; rejects bools,
     non-whole floats, and non-coercible values with a ``ValueError`` naming
     ``age`` — mirroring ``choose_models`` so the resolved ``age`` (and therefore
-    ``param_hash``) is never derived from a lossy conversion.
+    ``param_hash``) is never derived from a lossy conversion. Blank/``NaN`` inputs
+    are handled upstream (treated as absent), not here.
     """
     if isinstance(raw_age, bool):
         raise ValueError(f"Scan param 'age' must be a whole number, got {raw_age!r}")
@@ -73,6 +102,17 @@ def _coerce_age(raw_age: Any) -> int:
     return age
 
 
+def _canonicalize_text(values: Dict[str, Any], key: str, normalizer: Callable) -> None:
+    """Normalize ``values[key]`` in place; drop the key if it normalizes to blank."""
+    if key not in values:
+        return
+    normalized = normalizer(values[key])
+    if normalized:
+        values[key] = normalized
+    else:
+        del values[key]
+
+
 def resolve_params(
     metadata: Dict[str, Any],
     overrides: Optional[Dict[str, Any]] = None,
@@ -84,7 +124,8 @@ def resolve_params(
             bloomcli's download writes to ``scans.csv``. Load-bearing fields:
             ``species_name`` (-> ``species``), ``plant_age_days`` (-> ``age``,
             days); the scanner determines ``mode``. Other columns are ignored.
-            A blank or absent load-bearing field is treated as not provided.
+            A blank or absent load-bearing field (missing key, ``None``, ``NaN``,
+            or an empty/whitespace-only string) is treated as not provided.
         overrides: Optional param-space dict whose keys are a subset of
             ``{"species", "mode", "age"}``. Each key wins its field over the
             derived value; override values are normalized/coerced by the same
@@ -109,26 +150,26 @@ def resolve_params(
             f"allowed keys are {list(_PARAM_KEYS)}"
         )
 
-    # Tolerant read: mode always; species/age only when present (blank -> handled
-    # below). Absent fields are omitted, deferring to overrides then validation.
+    # Tolerant read: mode always; species/age only when present and non-blank.
+    # Absent/blank fields are omitted, deferring to overrides then validation.
     values: Dict[str, Any] = {"mode": _mode_for_scan(metadata)}
-    if metadata.get(SPECIES_NAME_FIELD) is not None:
+    if not _is_blank(metadata.get(SPECIES_NAME_FIELD)):
         values["species"] = metadata[SPECIES_NAME_FIELD]
-    if metadata.get(PLANT_AGE_DAYS_FIELD) is not None:
+    if not _is_blank(metadata.get(PLANT_AGE_DAYS_FIELD)):
         values["age"] = metadata[PLANT_AGE_DAYS_FIELD]
 
     values = {**values, **overrides}  # override wins, per field
 
-    # Canonicalize derived OR override values so param_hash is representation-
-    # independent; a blank species is treated as absent (fails validation below).
-    if "species" in values:
-        species = _normalize_species(values["species"])
-        if species:
-            values["species"] = species
-        else:
-            del values["species"]
+    # Canonicalize derived OR override values identically so param_hash is
+    # representation-independent; a blank value is treated as absent (dropped ->
+    # named by the validation below).
+    _canonicalize_text(values, "species", _normalize_species)
+    _canonicalize_text(values, "mode", _normalize_mode)
     if "age" in values:
-        values["age"] = _coerce_age(values["age"])
+        if _is_blank(values["age"]):
+            del values["age"]
+        else:
+            values["age"] = _coerce_age(values["age"])
 
     missing = [key for key in _PARAM_KEYS if key not in values]
     if missing:

--- a/tests/test_param_resolution.py
+++ b/tests/test_param_resolution.py
@@ -1,0 +1,254 @@
+"""Tests for the pure param-resolution oracle (``resolve_params``).
+
+Real, no-mock, offline tests. ``resolve_params`` maps a single Bloom
+``cyl_scans_extended`` row (the dict bloomcli writes to ``scans.csv``) to a
+``ResolvedParams`` carrying ``species``/``mode``/``age``, so predict's
+``choose_models`` can select production models from real Bloom metadata.
+"""
+
+import math
+
+import pytest
+from sleap_roots_contracts import ModelCard, ResolvedParams
+
+from sleap_roots_predict.model_selection import choose_models
+from sleap_roots_predict.param_resolution import (
+    PLANT_AGE_DAYS_FIELD,
+    SPECIES_NAME_FIELD,
+    _coerce_age,
+    _mode_for_scan,
+    _normalize_species,
+    resolve_params,
+)
+
+# The verified seeded-species set (Bloom species_name -> ModelCard vocabulary).
+# Recorded here as the executable home for the "these lowercase cleanly" fact
+# (design decision: _ALIASES ships empty; this test owns the seeded record).
+_SEEDED_SPECIES = {
+    "Pennycress": "pennycress",
+    "Arabidopsis": "arabidopsis",
+    "Rice": "rice",
+    "Soybean": "soybean",
+    "Canola": "canola",
+}
+
+
+def _row(species_name="Pennycress", plant_age_days=14, **extra):
+    """A minimal cyl_scans_extended row with optional extra/override columns."""
+    row = {SPECIES_NAME_FIELD: species_name, PLANT_AGE_DAYS_FIELD: plant_age_days}
+    row.update(extra)
+    return row
+
+
+def _card(root_type, *, species="rice", mode="cylinder", age_min=2, age_max=5):
+    """Build a ModelCard with sensible defaults for one root type."""
+    return ModelCard(
+        species=species,
+        mode=mode,
+        age_min=age_min,
+        age_max=age_max,
+        root_type=root_type,
+        registry_id=f"reg/{species}-{root_type}",
+        version="v1",
+        weights_checksum="sha",
+    )
+
+
+# --- field constants (bloomcli coupling) -----------------------------------
+
+
+def test_field_constants_match_bloomcli_columns():
+    """The load-bearing field constants match bloomcli's scans.csv columns."""
+    assert SPECIES_NAME_FIELD == "species_name"
+    assert PLANT_AGE_DAYS_FIELD == "plant_age_days"
+
+
+# --- _normalize_species ----------------------------------------------------
+
+
+@pytest.mark.parametrize("bloom_name,expected", list(_SEEDED_SPECIES.items()))
+def test_seeded_species_normalize_to_card_vocabulary(bloom_name, expected):
+    """Each seeded Bloom species_name maps to its lowercase card string."""
+    assert _normalize_species(bloom_name) == expected
+
+
+def test_species_whitespace_and_case_normalized():
+    """Surrounding whitespace and case are stripped/lowered."""
+    assert _normalize_species("  Rice  ") == "rice"
+
+
+def test_unknown_species_passes_through_lowercased():
+    """An unmodelled species passes through (registry is the authority)."""
+    assert _normalize_species("Sorghum") == "sorghum"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None, math.nan])
+def test_blank_or_nonstring_species_returns_empty(blank):
+    """Blank/None/NaN species normalize to '' (treated as absent upstream)."""
+    assert _normalize_species(blank) == ""
+
+
+# --- _mode_for_scan --------------------------------------------------------
+
+
+def test_mode_for_scan_returns_cylinder():
+    """The cylinder stage-in path resolves mode 'cylinder'."""
+    assert _mode_for_scan(_row()) == "cylinder"
+
+
+def test_mode_matches_seeded_card_vocabulary():
+    """The mode string equals the seeded ModelCard mode vocabulary."""
+    card = _card("primary", mode="cylinder")
+    assert _mode_for_scan(_row()) == card.mode
+
+
+# --- _coerce_age -----------------------------------------------------------
+
+
+def test_int_age_passes_through():
+    """An integer age passes through as days."""
+    assert _coerce_age(14) == 14
+
+
+def test_string_age_is_coerced_to_int():
+    """An int-coercible string age is coerced to the same int."""
+    result = _coerce_age("14")
+    assert result == 14
+    assert isinstance(result, int)
+
+
+def test_age_zero_is_valid():
+    """Age 0 is a valid coerced value (not treated as missing)."""
+    assert _coerce_age(0) == 0
+
+
+@pytest.mark.parametrize("bad_age", [14.5, "14.5", "abc", True])
+def test_non_whole_or_non_coercible_age_raises_naming_age(bad_age):
+    """Fractional/non-coercible/bool ages raise a ValueError naming 'age'."""
+    with pytest.raises(ValueError, match="age"):
+        _coerce_age(bad_age)
+
+
+# --- resolve_params: core mapping ------------------------------------------
+
+
+def test_sample_row_resolves_to_species_mode_age():
+    """The oracle: a sample Bloom row -> {pennycress, cylinder, 14} + hash."""
+    params = resolve_params(_row(species_name="Pennycress", plant_age_days=14))
+    assert isinstance(params, ResolvedParams)
+    assert params.values == {"species": "pennycress", "mode": "cylinder", "age": 14}
+    assert params.param_hash  # populated by the contract
+
+
+def test_extra_columns_ignored_and_input_not_mutated():
+    """Only the 3 fields are used; the passed-in metadata dict is unchanged."""
+    row = _row(
+        species_name="Rice",
+        plant_age_days=3,
+        species_genus="Oryza",
+        scan_id="abc123",
+        captured_at="2026-07-06T00:00:00Z",
+    )
+    before = dict(row)
+    params = resolve_params(row)
+    assert set(params.values) == {"species", "mode", "age"}
+    assert row == before  # not mutated
+
+
+def test_string_age_row_hashes_identically_to_int_age_row():
+    """A CSV string age produces the same param_hash as the int age."""
+    as_str = resolve_params(_row(species_name="Rice", plant_age_days="14"))
+    as_int = resolve_params(_row(species_name="Rice", plant_age_days=14))
+    assert as_str.values == as_int.values
+    assert as_str.param_hash == as_int.param_hash
+
+
+def test_row_age_zero_resolves():
+    """A row with plant_age_days=0 resolves (0 is not treated as missing)."""
+    params = resolve_params(_row(species_name="Rice", plant_age_days=0))
+    assert params.values["age"] == 0
+
+
+def test_row_non_whole_age_raises_naming_age():
+    """A non-whole plant_age_days in the row raises naming 'age'."""
+    with pytest.raises(ValueError, match="age"):
+        resolve_params(_row(species_name="Rice", plant_age_days=14.5))
+
+
+# --- resolve_params: overrides ---------------------------------------------
+
+
+def test_override_wins_per_field():
+    """Overrides replace derived fields; non-overridden fields stay derived."""
+    params = resolve_params(
+        _row(species_name="Rice", plant_age_days=3),
+        overrides={"mode": "graviscan", "species": "canola"},
+    )
+    assert params.values == {"species": "canola", "mode": "graviscan", "age": 3}
+
+
+def test_empty_overrides_equals_no_overrides():
+    """An empty overrides dict changes nothing."""
+    row = _row(species_name="Rice", plant_age_days=3)
+    assert resolve_params(row, overrides={}).values == resolve_params(row).values
+
+
+def test_unknown_override_key_raises_naming_key():
+    """A typo'd override key raises a ValueError naming the offending key."""
+    with pytest.raises(ValueError, match="specis"):
+        resolve_params(_row(), overrides={"specis": "rice"})
+
+
+def test_override_values_are_canonicalized_like_derived():
+    """Override values are normalized/coerced so param_hash is stable."""
+    overridden = resolve_params(
+        _row(species_name="Pennycress", plant_age_days=99),
+        overrides={"species": "Rice", "age": "14"},
+    )
+    derived = resolve_params(_row(species_name="Rice", plant_age_days=14))
+    assert overridden.values == {"species": "rice", "mode": "cylinder", "age": 14}
+    assert overridden.param_hash == derived.param_hash
+
+
+# --- resolve_params: strict validation -------------------------------------
+
+
+def test_missing_both_fields_raises_naming_each():
+    """A row missing species_name and plant_age_days names both params."""
+    with pytest.raises(ValueError) as excinfo:
+        resolve_params({})
+    message = str(excinfo.value)
+    assert "species" in message
+    assert "age" in message
+
+
+def test_blank_species_raises_naming_species():
+    """A blank species_name (no override) fails loud rather than resolving ''."""
+    with pytest.raises(ValueError, match="species"):
+        resolve_params(_row(species_name="", plant_age_days=3))
+
+
+def test_missing_species_supplied_by_override_succeeds():
+    """A missing species_name compensated by an override resolves."""
+    row = {PLANT_AGE_DAYS_FIELD: 3}  # no species_name
+    params = resolve_params(row, overrides={"species": "rice"})
+    assert params.values["species"] == "rice"
+
+
+# --- payoff round-trip: metadata -> params -> model ------------------------
+
+
+def test_round_trip_selects_expected_models():
+    """choose_models(resolve_params(row), cards) selects a ref per root type."""
+    cards = [_card("primary"), _card("crown")]
+    row = _row(species_name="Rice", plant_age_days=3)
+    result = choose_models(resolve_params(row), cards)
+    assert set(result) == {"primary", "crown"}
+    assert result["primary"].version == "v1"
+
+
+def test_round_trip_unknown_species_selects_nothing():
+    """An unmodelled species resolves and zero-matches (skip, not error)."""
+    cards = [_card("primary"), _card("crown")]
+    row = _row(species_name="Sorghum", plant_age_days=3)
+    assert choose_models(resolve_params(row), cards) == {}

--- a/tests/test_param_resolution.py
+++ b/tests/test_param_resolution.py
@@ -11,12 +11,14 @@ import math
 import pytest
 from sleap_roots_contracts import ModelCard, ResolvedParams
 
+from sleap_roots_predict import param_resolution
 from sleap_roots_predict.model_selection import choose_models
 from sleap_roots_predict.param_resolution import (
     PLANT_AGE_DAYS_FIELD,
     SPECIES_NAME_FIELD,
     _coerce_age,
     _mode_for_scan,
+    _normalize_mode,
     _normalize_species,
     resolve_params,
 )
@@ -88,6 +90,20 @@ def test_blank_or_nonstring_species_returns_empty(blank):
     assert _normalize_species(blank) == ""
 
 
+def test_alias_map_substitutes_a_non_identity_alias(monkeypatch):
+    """The (normally empty) _ALIASES seam maps a non-trivial name when populated."""
+    monkeypatch.setitem(param_resolution._ALIASES, "thlaspi arvense", "pennycress")
+    assert _normalize_species("Thlaspi arvense") == "pennycress"
+
+
+# --- _normalize_mode -------------------------------------------------------
+
+
+def test_mode_normalizes_case_and_whitespace():
+    """Mode is stripped and lowercased, mirroring species normalization."""
+    assert _normalize_mode("  Cylinder ") == "cylinder"
+
+
 # --- _mode_for_scan --------------------------------------------------------
 
 
@@ -120,6 +136,13 @@ def test_string_age_is_coerced_to_int():
 def test_age_zero_is_valid():
     """Age 0 is a valid coerced value (not treated as missing)."""
     assert _coerce_age(0) == 0
+
+
+def test_whole_float_age_is_coerced_to_int():
+    """A whole float (pandas float64 from a NaN-containing column) coerces cleanly."""
+    result = _coerce_age(14.0)
+    assert result == 14
+    assert isinstance(result, int)
 
 
 @pytest.mark.parametrize("bad_age", [14.5, "14.5", "abc", True])
@@ -210,6 +233,20 @@ def test_override_values_are_canonicalized_like_derived():
     assert overridden.param_hash == derived.param_hash
 
 
+def test_mode_override_is_canonicalized():
+    """A mode override is normalized like a derived mode (representation-stable)."""
+    overridden = resolve_params(_row(), overrides={"mode": "  Cylinder "})
+    derived = resolve_params(_row())
+    assert overridden.values["mode"] == "cylinder"
+    assert overridden.param_hash == derived.param_hash
+
+
+def test_override_age_true_raises_naming_age():
+    """A bool age override is rejected on the override path too, naming age."""
+    with pytest.raises(ValueError, match="age"):
+        resolve_params(_row(), overrides={"age": True})
+
+
 # --- resolve_params: strict validation -------------------------------------
 
 
@@ -222,10 +259,43 @@ def test_missing_both_fields_raises_naming_each():
     assert "age" in message
 
 
-def test_blank_species_raises_naming_species():
-    """A blank species_name (no override) fails loud rather than resolving ''."""
+@pytest.mark.parametrize("blank", ["", "   ", None, math.nan])
+def test_blank_species_raises_naming_species(blank):
+    """A blank species_name (any form, no override) fails loud naming species."""
     with pytest.raises(ValueError, match="species"):
-        resolve_params(_row(species_name="", plant_age_days=3))
+        resolve_params(_row(species_name=blank, plant_age_days=3))
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None, math.nan])
+def test_blank_age_treated_as_missing_naming_age(blank):
+    """A blank plant_age_days is treated as not provided (names age, not 'whole')."""
+    with pytest.raises(ValueError, match="age"):
+        resolve_params(_row(species_name="Rice", plant_age_days=blank))
+
+
+def test_blank_age_can_be_supplied_by_override():
+    """A blank plant_age_days is satisfied by an age override (defer, not raise)."""
+    params = resolve_params(
+        _row(species_name="Rice", plant_age_days=math.nan), overrides={"age": 5}
+    )
+    assert params.values["age"] == 5
+
+
+def test_both_blank_fields_name_each_missing_param():
+    """Blank species AND blank age name both (age blank must not mask species)."""
+    with pytest.raises(ValueError) as excinfo:
+        resolve_params(_row(species_name="", plant_age_days=math.nan))
+    message = str(excinfo.value)
+    assert "species" in message
+    assert "age" in message
+
+
+def test_blank_mode_override_raises_naming_mode():
+    """A blank mode override is treated as absent and fails loud naming mode."""
+    with pytest.raises(ValueError, match="mode"):
+        resolve_params(
+            _row(species_name="Rice", plant_age_days=3), overrides={"mode": ""}
+        )
 
 
 def test_missing_species_supplied_by_override_succeeds():

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,6 +10,7 @@ def test_public_surface_importable_without_credentials(monkeypatch):
     for name in (
         "WarmModelWorker",
         "choose_models",
+        "resolve_params",
         "LocalCardSource",
         "WandbRegistrySource",
         "ModelCardSource",
@@ -23,3 +24,4 @@ def test_public_surface_importable_without_credentials(monkeypatch):
         "predict_and_write_batch",
     ):
         assert hasattr(pkg, name), name
+        assert name in pkg.__all__, f"{name} missing from __all__"


### PR DESCRIPTION
## Summary

Adds a pure oracle **`resolve_params(metadata, overrides=None) -> ResolvedParams`** that maps a single Bloom `cyl_scans_extended` scan-metadata row (the dict bloomcli's download writes to `scans.csv`) to `{species, mode, age}`, so predict's `choose_models` can select production models from **real Bloom metadata** end-to-end (metadata → params → model). Advances roadmap tier **A3-params**.

OpenSpec change: **`add-param-resolution`** (new `param-resolution` capability; validates `--strict`). Settled design: `docs/superpowers/specs/2026-07-06-param-resolution-design.md`. Reconciled two `/review-openspec` rounds.

## What it does

- **species** — `species_name` normalized via strip+lowercase with an (empty) alias-map extension seam; **unknown species pass through** (the registry/`ModelCard`s stay the sole authority on which species have models → an unmodelled species degrades to a `choose_models` zero-match/skip, not a resolver error).
- **mode** — a one-line `_mode_for_scan` **seam** returning `"cylinder"` for the cylinder stage-in path (GraviScan/multiscanner deferred there).
- **age** — `plant_age_days` coerced to an `int` (**confirmed days**, matching the seeded cards' `age_min`/`age_max`).
- **overrides** — param-space dict, **override-wins per field**; keys restricted to `{species, mode, age}` (unknown key raises). **Override values are canonicalized** like derived values (species normalized, age coerced), so `param_hash` is representation-independent (`"14"` and `14` hash identically) — the key reproducibility guarantee.
- **strict validation** — blank/absent load-bearing fields treated as not-provided; after merging, `species`/`mode`/`age` must all be present (by key, so `age=0` is valid) else a `ValueError` names every missing param; a lossy `plant_age_days` fails loud naming `age`.

Pure/offline; **zero new dependencies** (only `sleap-roots-contracts`, already pinned/imported). New public export: `resolve_params`.

## Age-units confirmation (closes the one open question)

Queried the live production registry (`sleap-roots-models`, 13 cards): windows are **days** — arabidopsis/pennycress `2–14`, canola `2–13`, rice crown `2–5` & `6–10`, rice primary `2–5`, soybean `2–8`. Species vocab matched the resolver output exactly. So `age` is a straight `int` passthrough, no conversion. (The registry also carries a `multiplant cylinder` mode — noted for the `_mode_for_scan` seam follow-up.)

## Verification

Three-state: `[x]` ran & passing · `[ ]` not run / N/A.

- [x] `uv run pytest -q` — **245 passed**, 5 deselected (gpu/acceptance/wandb)
- [x] `uv run pytest tests/test_param_resolution.py` — 35 passed (real, no-mock, offline)
- [x] `uv run black --check sleap_roots_predict tests` — clean
- [x] `uv run ruff check sleap_roots_predict` — clean
- [x] `uv run codespell` — clean
- [x] `openspec validate add-param-resolution --strict` — valid
- [x] `uv build` — wheel + sdist; `param_resolution.py` present in the wheel
- [ ] GPU suite (`-m gpu`) — N/A: pure module, no device path
- [x] Age units verified against the live wandb registry (days)

## Files

- `sleap_roots_predict/param_resolution.py` (new), `sleap_roots_predict/__init__.py` (export + docstring)
- `tests/test_param_resolution.py` (new), `tests/test_public_api.py` (extended)
- Docs: `README.md`, `API.md`, `CHANGELOG.md`, `openspec/project.md`
- `openspec/changes/add-param-resolution/` (proposal, tasks, design, `param-resolution` spec delta)

## Follow-ups (tracking issues)

`_mode_for_scan` GraviScan/plate mode · A4 wire-in of `resolve_params` at the predict call-site · salk-bloom override-UX plumbing · multiscanner modality · (watch) TS-parity against this oracle. *(Age-units issue dropped — confirmed here.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
