### PR TITLE
feat: consume PredictionArtifact/PredictionManifest from sleap-roots-contracts (predict#30)

### DIFF
--- a/API.md
+++ b/API.md
@@ -134,9 +134,11 @@ still-missing `species`/`mode`/`age` after merging overrides, or a malformed/sen
 
 Write the per-scan artifacts the downstream sleap-roots traits stage reads — named
 per-root `.slp` (`{scan_key}.model{model_id}.root{root_type}.slp`) plus a combined
-`{scan_key}.predictions.json` manifest. See the `prediction-output` OpenSpec spec and the
-`sleap_roots_predict.output_contract` docstrings for the full artifact grammar and manifest
-schema (kept single-sourced there to avoid drift).
+`{scan_key}.predictions.json` manifest. `PredictionArtifact`/`PredictionManifest` are
+implemented in `sleap-roots-contracts` (predict re-exports them); see that package's
+`prediction-manifest-contract` OpenSpec spec for the full schema and this repo's
+`prediction-output` OpenSpec spec for the writer behavior (kept single-sourced there to
+avoid drift).
 
 ```python
 from sleap_roots_predict import (
@@ -144,7 +146,7 @@ from sleap_roots_predict import (
     predict_and_write_batch,   # drive a warm worker over N scans (one subdir per scan)
     ScanRequest,               # a batch scan input (scan_key, video, params, ...)
     PredictionManifest,        # per-scan manifest (manifest + predict-side provenance)
-    PredictionArtifact,        # one per-root record (model_id, ModelRef, slp_path, checksum, size)
+    PredictionArtifact,        # one per-root record (kind, model_id, ModelRef, slp_path, checksum, size)
 )
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ All notable changes to this project are documented here. The format is based on
   `write_prediction_outputs`, `predict_and_write_batch`. Build identity is read from
   `SRP_PREDICT_CODE_SHA` / `SRP_PREDICT_CONTAINER_DIGEST` (fail-soft to `""`). Added
   `sleap-roots` as a test-only (`dev`) dependency for the `Series.load` acceptance test.
-  See the `prediction-output` OpenSpec spec.
+  `PredictionArtifact`/`PredictionManifest` are implemented in
+  `sleap-roots-contracts==0.1.0a5` (predict's local copies are deleted — contracts is now
+  the single source of truth, mirroring `resolve_params`); `PredictionArtifact` gains a
+  `kind` field (`BlobKind`, defaults to `"predictions_slp"`). See the `prediction-output`
+  OpenSpec spec.
 - **Predict container CLI** (`sleap_roots_predict.batch` + `__main__`): a warm-batch
   entrypoint — `sleap-roots-predict <input_scan_dir> <output_dir>` (also
   `python -m sleap_roots_predict`) and the `run_batch(...)` library function. Discovers scans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,14 @@ Install with platform-specific extras for proper hardware acceleration:
 > lists here). In brief, `sleap_roots_predict/` is: inference (`predict.py`), model
 > selection/registry/warm worker (`model_selection.py`, `model_registry.py`,
 > `warm_worker.py` — `resolve_params` is imported from `sleap-roots-contracts`, no local
-> copy), the per-scan output contract (`output_contract.py`), the warm-batch container
-> runner + CLI (`batch.py`, `__main__.py` — `python -m sleap_roots_predict <in> <out>`),
-> and image/timelapse utilities
+> copy), the per-scan output contract (`output_contract.py` — `PredictionArtifact`/
+> `PredictionManifest` are also imported from `sleap-roots-contracts`, no local copy), the
+> warm-batch container runner + CLI (`batch.py`, `__main__.py` — `python -m
+> sleap_roots_predict <in> <out>`), and image/timelapse utilities
 > (`video_utils.py`, `plates_timelapse_experiment.py`).
 
 ### Key Dependencies
-- **Core**: sleap-nn, sleap-io for pose estimation; sleap-roots-contracts for shared `ModelCard`/`ModelRef`/`ResolvedParams`; wandb for the model registry
+- **Core**: sleap-nn, sleap-io for pose estimation; sleap-roots-contracts for shared `ModelCard`/`ModelRef`/`ResolvedParams`/`PredictionArtifact`/`PredictionManifest`; wandb for the model registry
 - **Data Processing**: numpy, pandas, h5py, imageio
 - **Testing**: pytest, pytest-cov, PIL
 

--- a/docs/superpowers/specs/2026-07-22-consume-contracts-prediction-manifest-design.md
+++ b/docs/superpowers/specs/2026-07-22-consume-contracts-prediction-manifest-design.md
@@ -1,0 +1,158 @@
+# Design: consume `PredictionArtifact`/`PredictionManifest` from `sleap-roots-contracts` (drop predict's local definitions)
+
+- **Date:** 2026-07-22
+- **Repo:** `sleap-roots-predict`
+- **Branch:** `consume-contracts-prediction-manifest`
+- **Issue:** predict#30 ("Consume PredictionArtifact/PredictionManifest from
+  sleap-roots-contracts (drop local output_contract.py definition)"). Depends on:
+  contracts#22 (merged). Precedent: predict#28/PR#29 (the `resolve_params` migration).
+  Downstream: Salk-Harnessing-Plants-Initiative/bloom#407.
+- **Status:** APPROVED — brainstorming complete. This doc is the settled design. Proceed to
+  the OpenSpec proposal (`/openspec:proposal`), suggested change-id
+  `consume-contracts-prediction-manifest`.
+
+## Motivation
+
+`PredictionArtifact`/`PredictionManifest` were promoted into `sleap-roots-contracts` (contracts
+PR #23, released `0.1.0a5` on PyPI — confirmed live) because bloom#407 needs a
+PyPI-installable way to read predict's manifest without a git dependency on this unpublished
+repo. predict still defines both classes locally in `sleap_roots_predict/output_contract.py`.
+Keeping both is a duplication risk once bloomctl starts constructing/validating against
+contracts' version: predict would be writing manifests shaped by one definition while a
+downstream consumer validates against another, with no shared source of truth if the two ever
+drift (e.g. contracts' new `kind` field). This change makes predict a pure consumer of the
+promoted models, exactly mirroring how `resolve_params` was consumed in #29.
+
+## Settled decisions (from brainstorming 2026-07-22)
+
+1. **Exact version pin.** `sleap-roots-contracts==0.1.0a4` → `==0.1.0a5` in `pyproject.toml`,
+   matching predict's existing style for pre-1.0 pins. `uv.lock` relocked in the same commit,
+   diff scoped to just the `sleap-roots-contracts` entry (verify per #29's precedent).
+2. **Import lives in `output_contract.py`, not `__init__.py`.** Unlike `param_resolution.py`
+   (deleted outright in #29), `output_contract.py` is not going away — it still owns the
+   writer functions (`write_prediction_outputs`, `predict_and_write_batch`, `ScanRequest`,
+   `slugify_model_id`, `_validate_scan_key`, `_resolve_identity`), which are untouched by this
+   change. `output_contract.py`'s two local class *definitions* are replaced with
+   `from sleap_roots_contracts import PredictionArtifact, PredictionManifest`, mirroring how
+   it already imports `ModelRef`/`ResolvedParams`/`RootType` from contracts at the top of the
+   file today. `sleap_roots_predict/__init__.py` is **unchanged** — it keeps importing both
+   names from `sleap_roots_predict.output_contract`, so the re-export and `__all__` entries
+   need no edit and `tests/test_public_api.py` needs no change.
+3. **The 2 pure-model tests in `tests/test_output_contract.py` are pruned to zero**
+   (`test_manifest_round_trips`, `test_plant_qr_code_defaults_to_scan_key`). Contracts' own
+   `tests/test_prediction_manifest.py` now owns this coverage (round-trip, immutability,
+   `plant_qr_code` default, `kind` default/validation, `root_type` validation). Unlike
+   `resolve_params` in #29 — a function predict calls at runtime through `choose_models`,
+   where the 2 kept tests verified predict's *own* wiring against an externally-produced
+   value — `PredictionArtifact`/`PredictionManifest` are now just imported data models with no
+   predict-specific logic wrapping them. There is no predict-side wiring left to test once the
+   import swaps; a thin smoke test would only re-assert "the import works," which
+   `tests/test_public_api.py`'s existing `hasattr`/`__all__` check plus every other test in the
+   file (all of which construct real manifests through the writer) already cover incidentally.
+   The other 24 tests in the file — which exercise the real warm-worker/filesystem writer —
+   are untouched.
+4. **`openspec/specs/prediction-output/spec.md`: MODIFIED delta restates the full shape.**
+   Both affected requirements ("Combined per-scan manifest and provenance sidecar" and
+   the artifact fields it lists) get their complete requirement text pasted and edited per
+   OpenSpec's MODIFIED convention — add `kind` (`BlobKind`, defaults to `"predictions_slp"`)
+   to `PredictionArtifact`'s field list, and add one sentence noting the shape is now defined
+   by `sleap-roots-contracts`' `prediction-manifest-contract` capability and imported, not
+   defined locally in this repo. Chosen over a thin pointer-only delta so predict's own
+   OpenSpec spec remains a complete, standalone reference for "what does predict write to
+   disk" without a cross-repo lookup — consistent with how contracts and predict are
+   independent OpenSpec installations with no cross-repo linking mechanism, so predict's spec
+   needs to stand on its own.
+5. **CHANGELOG: edit in place.** predict has never cut a release — everything sits under
+   `[Unreleased]`. The existing "Predict output contract" bullet (the one immediately below
+   the already-migrated "Param resolution" bullet) is edited in place to attribute
+   `PredictionArtifact`/`PredictionManifest` to `sleap-roots-contracts==0.1.0a5` and note the
+   new `kind` field, rather than adding a second bullet for a shape that was never shipped
+   under the old (local) definition.
+6. **No compatibility shim.** `output_contract.py` keeps the same import *names* available at
+   the same module path (so nothing outside the file needs to change), but there is no
+   separate re-export shim module — the two class bodies are simply replaced by the import
+   line. This matches #29's "clean subtraction" framing without also matching #29's full
+   file deletion, since here the module survives for other reasons.
+
+## Behavior change
+
+None for existing well-formed callers. `PredictionArtifact` gains one new field, `kind:
+BlobKind = "predictions_slp"`, which has a default — `write_prediction_outputs`'s existing
+construction call site (`output_contract.py`'s `write_prediction_outputs`) does not need to
+pass it and continues to work unchanged (to be confirmed empirically during implementation,
+per the issue's own caution against assuming). All other fields match name-for-name and
+type-for-type between predict's old local classes and contracts' promoted versions.
+
+## Components touched
+
+- `pyproject.toml` / `uv.lock` — version bump + relock (§1).
+- `sleap_roots_predict/output_contract.py` — replace the two local class bodies with a
+  contracts import; docstring's "schema is predict-local for now... promoted... once traits
+  consumes it" note is now stale and gets updated to reflect the promotion has happened (§2).
+- `sleap_roots_predict/__init__.py` — unchanged (§2).
+- `tests/test_output_contract.py` — remove `test_manifest_round_trips` and
+  `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact`
+  import if nothing else in the file constructs one directly (confirm during implementation;
+  several of the remaining 24 tests reference `PredictionManifest` return values, so that
+  import likely stays) (§3).
+- `openspec/specs/prediction-output/spec.md` — MODIFIED delta at archive time (§4).
+- `CHANGELOG.md` — edited in place (§5).
+- Doc references to update (grep-verified as the complete set): `API.md` (the "kept
+  single-sourced there to avoid drift" line, now stale since the schema is imported, not
+  defined, in `output_contract.py`'s docstrings), `openspec/project.md` (the
+  `output_contract.py` bullet's "+ the manifest/artifact models" phrasing, updated to match
+  the `model_selection.py` bullet's existing "consumes... predict carries no local copy"
+  phrasing for `resolve_params`), `CLAUDE.md` (Package Structure blurb, same treatment).
+  `README.md`'s architecture-tree comment (`output_contract.py # Per-scan output artifacts`)
+  needs no change — it doesn't describe the models' origin.
+
+## Testing approach
+
+Subtractive refactor, not new-behavior work — same shape as #29:
+
+- Dependency bump first, in isolation: confirm `sleap_roots_contracts.PredictionArtifact` /
+  `.PredictionManifest` importable at `0.1.0a5`, full predict suite still green (regression
+  baseline before any code changes).
+- Import swap in `output_contract.py` + test-file pruning done together (interdependent —
+  pruning first would leave dead imports; swapping first still passes since the field sets
+  match). Verification: full suite green, remaining 24 tests in `test_output_contract.py`
+  still pass unmodified (they exercise the writer, not the class definitions).
+- Empirically confirm the `kind` field's default means `write_prediction_outputs`'s
+  construction call site needs no changes (per the issue's explicit caution) — run the
+  existing writer tests and inspect a produced manifest's JSON for `"kind":
+  "predictions_slp"`.
+- Grep sweep for stray references to predict's local class definitions across code and docs
+  before calling it done.
+- `openspec validate --strict` on the MODIFIED (`prediction-output`) delta.
+- Full `/pre-merge` gate (format, lint, test, build) before opening the PR.
+
+## Out of scope
+
+- Any change to `bloomctl`/bloom#407 itself (that's the consuming side, already unblocked by
+  contracts' `0.1.0a5` release).
+- The paused `salk-bloom` OpenSpec change `add-cyl-blob-upload` — resumed separately after
+  this merges (already flagged inline in that change's `proposal.md`/`design.md`).
+- Any further change to contracts itself — already shipped (PR #23, `0.1.0a5`).
+- Emitting the full `Provenance`/`ResultEnvelope` or the prediction-parity harness (separate
+  A3/A4 roadmap items per `openspec/project.md`).
+
+## Acceptance
+
+- predict imports `PredictionArtifact`/`PredictionManifest` from contracts;
+  `output_contract.py`'s local class bodies are gone; full test suite green.
+- `from sleap_roots_predict import PredictionArtifact, PredictionManifest` still works
+  (re-export preserved, no `__init__.py` edit needed).
+- A produced manifest's JSON includes `"kind": "predictions_slp"` per artifact.
+- CHANGELOG documents the shape now coming from contracts; docs no longer claim the schema is
+  "single-sourced" locally.
+
+## Cross-repo references
+
+- **contracts**: `sleap-roots-contracts` PR #23 (the promotion, merged), `0.1.0a5` on PyPI,
+  `src/sleap_roots_contracts/prediction_manifest.py` (implementation),
+  `tests/test_prediction_manifest.py` (the full model-level test suite),
+  `openspec/specs/prediction-manifest-contract/spec.md` (the capability spec).
+- **predict**: predict#30 (this), predict#28/PR#29 (the `resolve_params` precedent this
+  mirrors).
+- **bloom**: Salk-Harnessing-Plants-Initiative/bloom#407 (downstream consumer, unblocked by
+  contracts' release, not touched here).

--- a/docs/superpowers/specs/2026-07-22-consume-contracts-prediction-manifest-design.md
+++ b/docs/superpowers/specs/2026-07-22-consume-contracts-prediction-manifest-design.md
@@ -41,23 +41,37 @@ promoted models, exactly mirroring how `resolve_params` was consumed in #29.
 3. **The 2 pure-model tests in `tests/test_output_contract.py` are pruned to zero**
    (`test_manifest_round_trips`, `test_plant_qr_code_defaults_to_scan_key`). Contracts' own
    `tests/test_prediction_manifest.py` now owns this coverage (round-trip, immutability,
-   `plant_qr_code` default, `kind` default/validation, `root_type` validation). Unlike
-   `resolve_params` in #29 — a function predict calls at runtime through `choose_models`,
-   where the 2 kept tests verified predict's *own* wiring against an externally-produced
-   value — `PredictionArtifact`/`PredictionManifest` are now just imported data models with no
-   predict-specific logic wrapping them. There is no predict-side wiring left to test once the
-   import swaps; a thin smoke test would only re-assert "the import works," which
-   `tests/test_public_api.py`'s existing `hasattr`/`__all__` check plus every other test in the
-   file (all of which construct real manifests through the writer) already cover incidentally.
-   The other 24 tests in the file — which exercise the real warm-worker/filesystem writer —
-   are untouched.
+   `plant_qr_code` default, `kind` default/validation, `root_type` validation) — verified by
+   direct comparison, not assumption: contracts' round-trip test nests a real `ModelRef`
+   inside a `PredictionArtifact` exactly like predict's version did, and predict's own kept
+   tests (`test_manifest_json_on_disk_round_trips`, `test_rerun_overwrites_in_place`)
+   round-trip a real inference-produced manifest through JSON — a strictly stronger version of
+   the same assertion. Separately, predict's writer (`write_prediction_outputs`) always
+   pre-resolves `plant_qr_code = plant_qr_code or scan_key` before construction, so the
+   model's own default-defaulting validator is dead code from predict's runtime perspective
+   regardless of which repo defines it. Unlike `resolve_params` in #29 — a function predict
+   calls at runtime through `choose_models`, where the 2 kept tests verified predict's *own*
+   wiring against an externally-produced value — `PredictionArtifact`/`PredictionManifest` are
+   now just imported data models with no predict-specific logic wrapping them. There is no
+   predict-side wiring left to test once the import swaps; a thin smoke test would only
+   re-assert "the import works," which `tests/test_public_api.py`'s existing `hasattr`/
+   `__all__` check plus every other test in the file (all of which construct real manifests
+   through the writer) already cover incidentally. The other 26 tests in the file (28 total
+   today; 2 pruned leaves 26) — which exercise the real warm-worker/filesystem writer — are
+   untouched.
 4. **`openspec/specs/prediction-output/spec.md`: MODIFIED delta restates the full shape.**
-   Both affected requirements ("Combined per-scan manifest and provenance sidecar" and
-   the artifact fields it lists) get their complete requirement text pasted and edited per
-   OpenSpec's MODIFIED convention — add `kind` (`BlobKind`, defaults to `"predictions_slp"`)
-   to `PredictionArtifact`'s field list, and add one sentence noting the shape is now defined
-   by `sleap-roots-contracts`' `prediction-manifest-contract` capability and imported, not
-   defined locally in this repo. Chosen over a thin pointer-only delta so predict's own
+   Exactly **one** requirement needs the MODIFIED treatment: `### Requirement: Combined
+   per-scan manifest and provenance sidecar` (spec.md:36-74, header through all 4 of its
+   existing scenarios) — this is the only place `PredictionArtifact`'s field list appears;
+   there is no separate requirement describing artifact fields on their own, so the delta must
+   paste this one requirement's complete existing text and edit it in place, not fabricate a
+   second header. Edits: add `kind` (`BlobKind`, defaults to `"predictions_slp"`) to
+   `PredictionArtifact`'s field list, add one sentence noting the shape is now defined by
+   `sleap-roots-contracts`' `prediction-manifest-contract` capability and imported, not defined
+   locally in this repo, and **add one new scenario** ("Artifact kind defaults to
+   predictions_slp") covering the new field's default — following the precedent set by #29's
+   own MODIFIED delta (`model-management`), which added a new scenario for its new clause
+   rather than only touching prose. Chosen over a thin pointer-only delta so predict's own
    OpenSpec spec remains a complete, standalone reference for "what does predict write to
    disk" without a cross-repo lookup — consistent with how contracts and predict are
    independent OpenSpec installations with no cross-repo linking mechanism, so predict's spec
@@ -77,11 +91,14 @@ promoted models, exactly mirroring how `resolve_params` was consumed in #29.
 ## Behavior change
 
 None for existing well-formed callers. `PredictionArtifact` gains one new field, `kind:
-BlobKind = "predictions_slp"`, which has a default — `write_prediction_outputs`'s existing
-construction call site (`output_contract.py`'s `write_prediction_outputs`) does not need to
-pass it and continues to work unchanged (to be confirmed empirically during implementation,
-per the issue's own caution against assuming). All other fields match name-for-name and
-type-for-type between predict's old local classes and contracts' promoted versions.
+BlobKind = "predictions_slp"`, which has a default. Confirmed safe by an exhaustive grep of
+every `PredictionArtifact(` construction site in the repo (only two: `output_contract.py`'s
+`write_prediction_outputs` and the now-pruned `test_manifest_round_trips`) — both construct
+with 100% keyword arguments, so contracts inserting `kind` ahead of `root_type` in the field
+order cannot break either call site even though pydantic models are keyword-safe regardless.
+All other fields match name-for-name and type-for-type between predict's old local classes and
+contracts' promoted versions. Implementation should still assert this empirically (inspect a
+produced manifest's JSON for `"kind": "predictions_slp"`), per the "Testing approach" section.
 
 ## Components touched
 
@@ -89,22 +106,31 @@ type-for-type between predict's old local classes and contracts' promoted versio
 - `sleap_roots_predict/output_contract.py` — replace the two local class bodies with a
   contracts import; docstring's "schema is predict-local for now... promoted... once traits
   consumes it" note is now stale and gets updated to reflect the promotion has happened (§2).
+  Also delete `_FROZEN` (the `ConfigDict(frozen=True, protected_namespaces=())` at line 35,
+  plus its explanatory comment) — it exists solely for the two class bodies being removed and
+  becomes dead code once they're gone; contracts' own version defines an identical `_FROZEN`
+  independently, so nothing needs to import or share it.
 - `sleap_roots_predict/__init__.py` — unchanged (§2).
 - `tests/test_output_contract.py` — remove `test_manifest_round_trips` and
-  `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact`
-  import if nothing else in the file constructs one directly (confirm during implementation;
-  several of the remaining 24 tests reference `PredictionManifest` return values, so that
-  import likely stays) (§3).
+  `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact` import
+  (confirmed mandatory, not conditional — grep shows line 94, inside the test being deleted,
+  is `PredictionArtifact`'s only use in the file; leaving the import would fail ruff's F401)
+  (§3).
 - `openspec/specs/prediction-output/spec.md` — MODIFIED delta at archive time (§4).
 - `CHANGELOG.md` — edited in place (§5).
 - Doc references to update (grep-verified as the complete set): `API.md` (the "kept
   single-sourced there to avoid drift" line, now stale since the schema is imported, not
-  defined, in `output_contract.py`'s docstrings), `openspec/project.md` (the
-  `output_contract.py` bullet's "+ the manifest/artifact models" phrasing, updated to match
-  the `model_selection.py` bullet's existing "consumes... predict carries no local copy"
-  phrasing for `resolve_params`), `CLAUDE.md` (Package Structure blurb, same treatment).
-  `README.md`'s architecture-tree comment (`output_contract.py # Per-scan output artifacts`)
-  needs no change — it doesn't describe the models' origin.
+  defined, in `output_contract.py`'s docstrings), `openspec/project.md` **in two separate
+  spots** — the Architecture Patterns `output_contract.py` bullet's "+ the manifest/artifact
+  models" phrasing (line ~52, updated to match the `model_selection.py` bullet's existing
+  "consumes... predict carries no local copy" phrasing for `resolve_params`) AND the External
+  Dependencies section's `sleap-roots-contracts` (`==0.1.0a4`) version literal (line ~105,
+  bumped to `0.1.0a5` to match the `pyproject.toml` pin — found only by an independent repo
+  sweep, since it's a separate location from the Architecture Patterns bullet and easy to miss
+  if only that one spot is edited), `CLAUDE.md` (Package Structure blurb, same treatment as
+  the Architecture Patterns bullet). `README.md`'s architecture-tree comment
+  (`output_contract.py # Per-scan output artifacts`) needs no change — it doesn't describe the
+  models' origin.
 
 ## Testing approach
 
@@ -115,7 +141,7 @@ Subtractive refactor, not new-behavior work — same shape as #29:
   baseline before any code changes).
 - Import swap in `output_contract.py` + test-file pruning done together (interdependent —
   pruning first would leave dead imports; swapping first still passes since the field sets
-  match). Verification: full suite green, remaining 24 tests in `test_output_contract.py`
+  match). Verification: full suite green, remaining 26 tests in `test_output_contract.py`
   still pass unmodified (they exercise the writer, not the class definitions).
 - Empirically confirm the `kind` field's default means `write_prediction_outputs`'s
   construction call site needs no changes (per the issue's explicit caution) — run the

--- a/openspec/changes/consume-contracts-prediction-manifest/proposal.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/proposal.md
@@ -1,13 +1,10 @@
 ## Why
 
 `PredictionArtifact`/`PredictionManifest` were promoted into `sleap-roots-contracts`
-(contracts PR #23, released `0.1.0a5` on PyPI) because bloom#407 needs a PyPI-installable way
-to read predict's manifest without a git dependency on this unpublished repo. predict still
-defines both classes locally in `sleap_roots_predict/output_contract.py` — a duplication risk
-once bloomctl constructs/validates against contracts' version, since the two definitions have
-no shared source of truth if they ever drift (contracts' version already differs by one field,
-`kind`). This mirrors exactly how `resolve_params` was consumed from contracts in predict#28/
-PR#29.
+(`0.1.0a5` on PyPI) so bloom#407 can read predict's manifest without a git dependency on this
+unpublished repo. predict still defines both classes locally, a duplication risk now that the
+two definitions already differ by one field (`kind`) with no shared source of truth — the same
+problem `resolve_params` had before predict#28/PR#29 consumed it from contracts.
 
 ## What Changes
 
@@ -40,5 +37,10 @@ PR#29.
   `CLAUDE.md`
 - No behavior change for well-formed callers: `kind` has a default (`"predictions_slp"`), and
   no `PredictionArtifact(...)` construction site in the repo uses positional arguments.
+- `docker-build.yml`'s PR trigger watches `pyproject.toml`/`uv.lock`/`sleap_roots_predict/**`,
+  so this PR will automatically run its build-only (no push) validation job — expected, not a
+  sign something is wrong. If it fails (e.g. an incompatible transitive dependency in
+  `0.1.0a5`), revert the dependency-bump commit and file an issue against
+  `sleap-roots-contracts` rather than pinning around it in this repo.
 - Closes sleap-roots-predict#30. Downstream: unblocks Salk-Harnessing-Plants-Initiative/
   bloom#407 (not touched here).

--- a/openspec/changes/consume-contracts-prediction-manifest/proposal.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`PredictionArtifact`/`PredictionManifest` were promoted into `sleap-roots-contracts`
+(contracts PR #23, released `0.1.0a5` on PyPI) because bloom#407 needs a PyPI-installable way
+to read predict's manifest without a git dependency on this unpublished repo. predict still
+defines both classes locally in `sleap_roots_predict/output_contract.py` — a duplication risk
+once bloomctl constructs/validates against contracts' version, since the two definitions have
+no shared source of truth if they ever drift (contracts' version already differs by one field,
+`kind`). This mirrors exactly how `resolve_params` was consumed from contracts in predict#28/
+PR#29.
+
+## What Changes
+
+- Bump `sleap-roots-contracts` pin from `==0.1.0a4` to `==0.1.0a5` in `pyproject.toml`; relock
+  `uv.lock` (diff scoped to the `sleap-roots-contracts` entry).
+- Replace `sleap_roots_predict/output_contract.py`'s locally-defined `PredictionArtifact`/
+  `PredictionManifest` classes with `from sleap_roots_contracts import PredictionArtifact,
+  PredictionManifest`; delete the now-dead `_FROZEN` config (only the two removed class bodies
+  used it) and update the module docstring's stale "schema is predict-local for now" note.
+  `sleap_roots_predict/__init__.py` needs no change — it already imports both names from
+  `sleap_roots_predict.output_contract`, which continues to bind them.
+- Prune `tests/test_output_contract.py`'s two pure-model tests (`test_manifest_round_trips`,
+  `test_plant_qr_code_defaults_to_scan_key`) — contracts' own `tests/test_prediction_manifest.py`
+  now owns this coverage; predict's remaining 26 tests exercise the real writer and are
+  untouched. Remove the now-unused `PredictionArtifact` import.
+- Update `openspec/specs/prediction-output/spec.md`'s "Combined per-scan manifest and
+  provenance sidecar" requirement (MODIFIED) to document the new `kind` field and that the
+  shape is now imported from contracts rather than defined locally.
+- Edit the CHANGELOG's `[Unreleased]` "Predict output contract" bullet in place (predict has
+  never cut a release) to attribute the shape to `sleap-roots-contracts==0.1.0a5`.
+- Update stale doc references in `API.md`, `openspec/project.md` (two spots: the
+  `output_contract.py` architecture bullet, and the External Dependencies version literal),
+  and `CLAUDE.md`.
+
+## Impact
+
+- Affected specs: `prediction-output` (MODIFIED)
+- Affected code: `pyproject.toml`, `uv.lock`, `sleap_roots_predict/output_contract.py`,
+  `tests/test_output_contract.py`, `CHANGELOG.md`, `API.md`, `openspec/project.md`,
+  `CLAUDE.md`
+- No behavior change for well-formed callers: `kind` has a default (`"predictions_slp"`), and
+  no `PredictionArtifact(...)` construction site in the repo uses positional arguments.
+- Closes sleap-roots-predict#30. Downstream: unblocks Salk-Harnessing-Plants-Initiative/
+  bloom#407 (not touched here).

--- a/openspec/changes/consume-contracts-prediction-manifest/specs/prediction-output/spec.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/specs/prediction-output/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Combined per-scan manifest and provenance sidecar
+
+The system SHALL write a single `{scan_key}.predictions.json` per scan that serializes a
+`PredictionManifest`: `schema_version`, `scan_key`, `plant_qr_code` (defaulting to
+`scan_key` when not given), and a list of per-root `PredictionArtifact` records. Each
+`PredictionArtifact` SHALL carry `kind` (a `BlobKind`, defaulting to `"predictions_slp"`),
+`root_type`, `model_id`, the full `ModelRef` (from `sleap-roots-contracts`), `slp_path` (the
+basename as a POSIX-style string via `Path.as_posix()`, relative to the manifest's
+directory), `checksum` (sha256 hex of the `.slp`), and `file_size` (bytes). The manifest
+SHALL also record the predict-side provenance: `predict_inference_config`,
+`predict_output_params`, `predict_code_sha`, and `predict_container_digest`. The written
+JSON SHALL reload and validate back into an equivalent `PredictionManifest`. When no root
+types are resolved, `artifacts` SHALL be an empty list. `PredictionArtifact` and
+`PredictionManifest` are defined by `sleap-roots-contracts`' `prediction-manifest-contract`
+capability and imported here, not defined locally in this repo.
+
+#### Scenario: Manifest maps each root type to its file, model_id, and full ModelRef
+
+- **WHEN** the writer runs for a scan with resolved `primary` and `lateral` models
+- **THEN** `{scan_key}.predictions.json` contains one artifact per root type whose
+  `slp_path` basename matches the written `.slp`, whose `model_id` matches the filename
+  slug, and whose `model` round-trips to the resolved `ModelRef`
+
+#### Scenario: Checksums and sizes match the written files
+
+- **WHEN** the manifest is reloaded and each artifact's `checksum`/`file_size` is compared
+  to the on-disk `.slp`
+- **THEN** each `checksum` equals the file's recomputed sha256 hex and each `file_size`
+  equals the file's byte length
+
+#### Scenario: Zero resolved roots yields an empty artifacts list
+
+- **WHEN** the writer runs for a scan where no root type resolved to a model
+- **THEN** it still writes `{scan_key}.predictions.json` with `artifacts` equal to `[]`
+
+#### Scenario: Manifest JSON round-trips to an equivalent model
+
+- **WHEN** the written `{scan_key}.predictions.json` is read back and validated into a
+  `PredictionManifest`
+- **THEN** it equals the manifest the writer returned (all fields, including each
+  artifact's `ModelRef`)
+
+#### Scenario: Artifact kind defaults to predictions_slp
+
+- **WHEN** the writer constructs a `PredictionArtifact` for a written `.slp` without
+  specifying `kind` explicitly
+- **THEN** the artifact's `kind` equals `"predictions_slp"` in both the returned manifest and
+  the written JSON

--- a/openspec/changes/consume-contracts-prediction-manifest/tasks.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/tasks.md
@@ -1,0 +1,72 @@
+## 1. Dependency bump (isolated regression baseline)
+
+- [ ] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a4` to `==0.1.0a5` in `pyproject.toml`.
+- [ ] 1.2 Relock `uv.lock`; confirm the diff is scoped to just the `sleap-roots-contracts`
+      entry (per predict#29's verified precedent).
+- [ ] 1.3 Verify `python -c "import sleap_roots_contracts as c; print(c.PredictionArtifact,
+      c.PredictionManifest)"` succeeds at the new pin, with no other code changes yet.
+- [ ] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb"`) and
+      confirm it is still green before any further edits — this is the regression baseline.
+
+## 2. Import swap + test prune (interdependent — land together)
+
+TDD framing: this is a subtractive refactor (the logic under test already lives, and is
+tested, in contracts), so the "test first" step here is confirming the *replacement* tests
+(contracts' own suite) already cover what predict's two pure-model tests assert, then pruning
+predict's copies and swapping the import in the same pass — pruning first would leave the old
+tests failing on stale imports; swapping first would leave duplicate-but-still-green coverage
+that then needs a second pass. Land both together, verified by one gate.
+
+- [ ] 2.1 In `sleap_roots_predict/output_contract.py`: replace the local `PredictionArtifact`
+      and `PredictionManifest` class bodies with `from sleap_roots_contracts import
+      PredictionArtifact, PredictionManifest` (alongside the existing `ModelRef`,
+      `ResolvedParams`, `RootType` import from the same package).
+- [ ] 2.2 Delete the now-dead `_FROZEN = ConfigDict(frozen=True, protected_namespaces=())` and
+      its explanatory comment (it existed solely for the two removed class bodies).
+- [ ] 2.3 Update the module docstring's "The schema is predict-local for now... it is
+      promoted to the shared contract once the traits stage (A3-traits) consumes it" note —
+      it's promoted now; rewrite to state the shape is imported from `sleap-roots-contracts`.
+- [ ] 2.4 In `tests/test_output_contract.py`: delete `test_manifest_round_trips` and
+      `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact`
+      import (confirmed its only other use was inside the deleted `test_manifest_round_trips`).
+- [ ] 2.5 Verify: `pytest --collect-only tests/test_output_contract.py` collects exactly 26
+      items (28 today minus the 2 pruned). Run the full suite; confirm green, and confirm
+      `sleap_roots_predict/__init__.py`'s re-export needs no edit (`from sleap_roots_predict
+      import PredictionArtifact, PredictionManifest` still works — covered by
+      `tests/test_public_api.py`, unmodified).
+- [ ] 2.6 Empirically confirm the `kind` field: run a real writer test (e.g.
+      `test_writer_writes_named_slp_and_manifest`) and inspect the produced
+      `{scan_key}.predictions.json` on disk for `"kind": "predictions_slp"` per artifact.
+
+## 3. OpenSpec spec delta
+
+- [ ] 3.1 Write the MODIFIED delta in
+      `openspec/changes/consume-contracts-prediction-manifest/specs/prediction-output/spec.md`
+      for `### Requirement: Combined per-scan manifest and provenance sidecar` — full existing
+      text plus: `kind` added to `PredictionArtifact`'s field list, a sentence noting the shape
+      is now defined by `sleap-roots-contracts`' `prediction-manifest-contract` capability and
+      imported (not locally defined), and a new scenario "Artifact kind defaults to
+      predictions_slp".
+
+## 4. Docs and changelog
+
+- [ ] 4.1 Edit `CHANGELOG.md`'s `[Unreleased]` "Predict output contract" bullet in place to
+      attribute `PredictionArtifact`/`PredictionManifest` to `sleap-roots-contracts==0.1.0a5`
+      and note the new `kind` field.
+- [ ] 4.2 Update `API.md`'s "kept single-sourced there to avoid drift" line (now stale since
+      the schema is imported, not defined, in `output_contract.py`'s docstrings).
+- [ ] 4.3 Update `openspec/project.md` in both spots: the Architecture Patterns
+      `output_contract.py` bullet's "+ the manifest/artifact models" phrasing (match the
+      `model_selection.py` bullet's existing "consumes... predict carries no local copy"
+      phrasing for `resolve_params`), and the External Dependencies section's
+      `sleap-roots-contracts` version literal (`==0.1.0a4` → `==0.1.0a5`).
+- [ ] 4.4 Update `CLAUDE.md`'s Package Structure blurb with the same treatment as the
+      Architecture Patterns bullet.
+- [ ] 4.5 Grep sweep for stray references to predict's local class definitions across code and
+      docs; confirm zero remaining (aside from immutable `openspec/changes/archive/` history).
+
+## 5. Validation gate
+
+- [ ] 5.1 `openspec validate consume-contracts-prediction-manifest --strict` — resolve any
+      issues.
+- [ ] 5.2 Full `/pre-merge` gate (format, lint, test, build) before opening the PR.

--- a/openspec/changes/consume-contracts-prediction-manifest/tasks.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/tasks.md
@@ -1,10 +1,18 @@
 ## 1. Dependency bump (isolated regression baseline)
 
+Land 1.1 and 1.2 as a single commit — the Dockerfile's `uv sync --frozen` hard-fails if
+`uv.lock` doesn't match `pyproject.toml`, so a bumped pin without its relock is never a safe
+standalone commit.
+
 - [ ] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a4` to `==0.1.0a5` in `pyproject.toml`.
-- [ ] 1.2 Relock `uv.lock`; confirm the diff is scoped to just the `sleap-roots-contracts`
-      entry (per predict#29's verified precedent).
+- [ ] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a
+      bare `uv lock`) so the resolver can't silently pull in unrelated bumps; confirm the
+      `uv.lock` diff touches only the `sleap-roots-contracts` entry.
 - [ ] 1.3 Verify `python -c "import sleap_roots_contracts as c; print(c.PredictionArtifact,
-      c.PredictionManifest)"` succeeds at the new pin, with no other code changes yet.
+      c.PredictionManifest, c.ModelRef, c.ResolvedParams, c.RootType)"` succeeds at the new
+      pin, with no other code changes yet (also touches the three symbols
+      `output_contract.py` already imports from contracts, not just the two new ones, in case
+      `0.1.0a5` changed anything about them).
 - [ ] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb"`) and
       confirm it is still green before any further edits — this is the regression baseline.
 
@@ -29,14 +37,34 @@ that then needs a second pass. Land both together, verified by one gate.
 - [ ] 2.4 In `tests/test_output_contract.py`: delete `test_manifest_round_trips` and
       `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact`
       import (confirmed its only other use was inside the deleted `test_manifest_round_trips`).
-- [ ] 2.5 Verify: `pytest --collect-only tests/test_output_contract.py` collects exactly 26
-      items (28 today minus the 2 pruned). Run the full suite; confirm green, and confirm
-      `sleap_roots_predict/__init__.py`'s re-export needs no edit (`from sleap_roots_predict
-      import PredictionArtifact, PredictionManifest` still works — covered by
-      `tests/test_public_api.py`, unmodified).
-- [ ] 2.6 Empirically confirm the `kind` field: run a real writer test (e.g.
-      `test_writer_writes_named_slp_and_manifest`) and inspect the produced
-      `{scan_key}.predictions.json` on disk for `"kind": "predictions_slp"` per artifact.
+      Add a cheap identity-guard test that catches the one regression this whole change exists
+      to prevent — a future accidental reintroduction of a local shadow class:
+      ```python
+      def test_prediction_classes_are_reexported_from_contracts():
+          import sleap_roots_contracts as c
+          assert PredictionArtifact is c.PredictionArtifact
+          assert PredictionManifest is c.PredictionManifest
+      ```
+- [ ] 2.5 Verify: `grep -c '^def test_' tests/test_output_contract.py` reports 27 (28 today,
+      minus the 2 pruned, plus the 1 identity-guard test added in 2.4). Note
+      `pytest --collect-only` will report a higher *item* count than this because two
+      unrelated tests in the file are `@pytest.mark.parametrize`d
+      (`test_rejects_reserved_and_control_chars_in_scan_key`,
+      `test_rejects_whitespace_scan_key`) — collected-item count is not the same thing as
+      test-function count and is not the right verification here. Run the full suite; confirm
+      green, and confirm `sleap_roots_predict/__init__.py`'s re-export needs no edit (`from
+      sleap_roots_predict import PredictionArtifact, PredictionManifest` still works — covered
+      by `tests/test_public_api.py`, unmodified).
+- [ ] 2.6 Extend two existing writer tests (not an ad hoc one-off check, so the assertion
+      stays in CI going forward) to cover the new `kind` field, matching the spec delta's
+      "Artifact kind defaults to predictions_slp" scenario, which requires the value to hold
+      in both the in-memory manifest and the written JSON:
+      - `test_writer_writes_named_slp_and_manifest`: add
+        `assert all(a.kind == "predictions_slp" for a in manifest.artifacts)`.
+      - `test_manifest_json_on_disk_round_trips`: add an assertion that the on-disk JSON's
+        `artifacts[*].kind` equals `"predictions_slp"` (parse the JSON directly, don't only
+        rely on `PredictionManifest.model_validate_json` round-tripping, since a wrong-but-
+        internally-consistent default wouldn't be caught by equality alone).
 
 ## 3. OpenSpec spec delta
 
@@ -50,16 +78,28 @@ that then needs a second pass. Land both together, verified by one gate.
 
 ## 4. Docs and changelog
 
-- [ ] 4.1 Edit `CHANGELOG.md`'s `[Unreleased]` "Predict output contract" bullet in place to
-      attribute `PredictionArtifact`/`PredictionManifest` to `sleap-roots-contracts==0.1.0a5`
-      and note the new `kind` field.
+- [ ] 4.1 Edit `CHANGELOG.md`'s `[Unreleased]` "Predict output contract" bullet in place.
+      Unlike the adjacent "Param resolution" bullet, this one never named
+      `sleap-roots-contracts==0.1.0a4` at all — this is an added attribution, not just a
+      version bump. Insert a sentence styled after that adjacent bullet's precedent, e.g.:
+      "`PredictionArtifact`/`PredictionManifest` are implemented in
+      `sleap-roots-contracts==0.1.0a5` (predict's local copies are deleted — contracts is now
+      the single source of truth, mirroring `resolve_params`); `PredictionArtifact` gains a
+      `kind` field (`BlobKind`, defaults to `"predictions_slp"`)."
 - [ ] 4.2 Update `API.md`'s "kept single-sourced there to avoid drift" line (now stale since
-      the schema is imported, not defined, in `output_contract.py`'s docstrings).
+      the schema is imported, not defined, in `output_contract.py`'s docstrings). Also update
+      the inline field-list comment on the `PredictionArtifact` import in the same section's
+      code block (currently `# one per-root record (model_id, ModelRef, slp_path, checksum,
+      size)`) to include `kind` — this is a second, independent copy of the field list that
+      the "single-sourced" line doesn't cover and would otherwise silently drift.
 - [ ] 4.3 Update `openspec/project.md` in both spots: the Architecture Patterns
       `output_contract.py` bullet's "+ the manifest/artifact models" phrasing (match the
       `model_selection.py` bullet's existing "consumes... predict carries no local copy"
       phrasing for `resolve_params`), and the External Dependencies section's
-      `sleap-roots-contracts` version literal (`==0.1.0a4` → `==0.1.0a5`).
+      `sleap-roots-contracts` bullet — bump the version literal (`==0.1.0a4` → `==0.1.0a5`)
+      and append `PredictionArtifact`/`PredictionManifest` to that bullet's enumerated type
+      list (`ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`), since they're now equally
+      contracts-shared types.
 - [ ] 4.4 Update `CLAUDE.md`'s Package Structure blurb with the same treatment as the
       Architecture Patterns bullet.
 - [ ] 4.5 Grep sweep for stray references to predict's local class definitions across code and

--- a/openspec/changes/consume-contracts-prediction-manifest/tasks.md
+++ b/openspec/changes/consume-contracts-prediction-manifest/tasks.md
@@ -4,16 +4,16 @@ Land 1.1 and 1.2 as a single commit — the Dockerfile's `uv sync --frozen` hard
 `uv.lock` doesn't match `pyproject.toml`, so a bumped pin without its relock is never a safe
 standalone commit.
 
-- [ ] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a4` to `==0.1.0a5` in `pyproject.toml`.
-- [ ] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a
+- [x] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a4` to `==0.1.0a5` in `pyproject.toml`.
+- [x] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a
       bare `uv lock`) so the resolver can't silently pull in unrelated bumps; confirm the
       `uv.lock` diff touches only the `sleap-roots-contracts` entry.
-- [ ] 1.3 Verify `python -c "import sleap_roots_contracts as c; print(c.PredictionArtifact,
+- [x] 1.3 Verify `python -c "import sleap_roots_contracts as c; print(c.PredictionArtifact,
       c.PredictionManifest, c.ModelRef, c.ResolvedParams, c.RootType)"` succeeds at the new
       pin, with no other code changes yet (also touches the three symbols
       `output_contract.py` already imports from contracts, not just the two new ones, in case
       `0.1.0a5` changed anything about them).
-- [ ] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb"`) and
+- [x] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb"`) and
       confirm it is still green before any further edits — this is the regression baseline.
 
 ## 2. Import swap + test prune (interdependent — land together)
@@ -25,16 +25,16 @@ predict's copies and swapping the import in the same pass — pruning first woul
 tests failing on stale imports; swapping first would leave duplicate-but-still-green coverage
 that then needs a second pass. Land both together, verified by one gate.
 
-- [ ] 2.1 In `sleap_roots_predict/output_contract.py`: replace the local `PredictionArtifact`
+- [x] 2.1 In `sleap_roots_predict/output_contract.py`: replace the local `PredictionArtifact`
       and `PredictionManifest` class bodies with `from sleap_roots_contracts import
       PredictionArtifact, PredictionManifest` (alongside the existing `ModelRef`,
       `ResolvedParams`, `RootType` import from the same package).
-- [ ] 2.2 Delete the now-dead `_FROZEN = ConfigDict(frozen=True, protected_namespaces=())` and
+- [x] 2.2 Delete the now-dead `_FROZEN = ConfigDict(frozen=True, protected_namespaces=())` and
       its explanatory comment (it existed solely for the two removed class bodies).
-- [ ] 2.3 Update the module docstring's "The schema is predict-local for now... it is
+- [x] 2.3 Update the module docstring's "The schema is predict-local for now... it is
       promoted to the shared contract once the traits stage (A3-traits) consumes it" note —
       it's promoted now; rewrite to state the shape is imported from `sleap-roots-contracts`.
-- [ ] 2.4 In `tests/test_output_contract.py`: delete `test_manifest_round_trips` and
+- [x] 2.4 In `tests/test_output_contract.py`: delete `test_manifest_round_trips` and
       `test_plant_qr_code_defaults_to_scan_key`; remove the now-unused `PredictionArtifact`
       import (confirmed its only other use was inside the deleted `test_manifest_round_trips`).
       Add a cheap identity-guard test that catches the one regression this whole change exists
@@ -45,7 +45,7 @@ that then needs a second pass. Land both together, verified by one gate.
           assert PredictionArtifact is c.PredictionArtifact
           assert PredictionManifest is c.PredictionManifest
       ```
-- [ ] 2.5 Verify: `grep -c '^def test_' tests/test_output_contract.py` reports 27 (28 today,
+- [x] 2.5 Verify: `grep -c '^def test_' tests/test_output_contract.py` reports 27 (28 today,
       minus the 2 pruned, plus the 1 identity-guard test added in 2.4). Note
       `pytest --collect-only` will report a higher *item* count than this because two
       unrelated tests in the file are `@pytest.mark.parametrize`d
@@ -55,7 +55,7 @@ that then needs a second pass. Land both together, verified by one gate.
       green, and confirm `sleap_roots_predict/__init__.py`'s re-export needs no edit (`from
       sleap_roots_predict import PredictionArtifact, PredictionManifest` still works — covered
       by `tests/test_public_api.py`, unmodified).
-- [ ] 2.6 Extend two existing writer tests (not an ad hoc one-off check, so the assertion
+- [x] 2.6 Extend two existing writer tests (not an ad hoc one-off check, so the assertion
       stays in CI going forward) to cover the new `kind` field, matching the spec delta's
       "Artifact kind defaults to predictions_slp" scenario, which requires the value to hold
       in both the in-memory manifest and the written JSON:
@@ -68,7 +68,7 @@ that then needs a second pass. Land both together, verified by one gate.
 
 ## 3. OpenSpec spec delta
 
-- [ ] 3.1 Write the MODIFIED delta in
+- [x] 3.1 Write the MODIFIED delta in
       `openspec/changes/consume-contracts-prediction-manifest/specs/prediction-output/spec.md`
       for `### Requirement: Combined per-scan manifest and provenance sidecar` — full existing
       text plus: `kind` added to `PredictionArtifact`'s field list, a sentence noting the shape
@@ -78,7 +78,7 @@ that then needs a second pass. Land both together, verified by one gate.
 
 ## 4. Docs and changelog
 
-- [ ] 4.1 Edit `CHANGELOG.md`'s `[Unreleased]` "Predict output contract" bullet in place.
+- [x] 4.1 Edit `CHANGELOG.md`'s `[Unreleased]` "Predict output contract" bullet in place.
       Unlike the adjacent "Param resolution" bullet, this one never named
       `sleap-roots-contracts==0.1.0a4` at all — this is an added attribution, not just a
       version bump. Insert a sentence styled after that adjacent bullet's precedent, e.g.:
@@ -86,13 +86,13 @@ that then needs a second pass. Land both together, verified by one gate.
       `sleap-roots-contracts==0.1.0a5` (predict's local copies are deleted — contracts is now
       the single source of truth, mirroring `resolve_params`); `PredictionArtifact` gains a
       `kind` field (`BlobKind`, defaults to `"predictions_slp"`)."
-- [ ] 4.2 Update `API.md`'s "kept single-sourced there to avoid drift" line (now stale since
+- [x] 4.2 Update `API.md`'s "kept single-sourced there to avoid drift" line (now stale since
       the schema is imported, not defined, in `output_contract.py`'s docstrings). Also update
       the inline field-list comment on the `PredictionArtifact` import in the same section's
       code block (currently `# one per-root record (model_id, ModelRef, slp_path, checksum,
       size)`) to include `kind` — this is a second, independent copy of the field list that
       the "single-sourced" line doesn't cover and would otherwise silently drift.
-- [ ] 4.3 Update `openspec/project.md` in both spots: the Architecture Patterns
+- [x] 4.3 Update `openspec/project.md` in both spots: the Architecture Patterns
       `output_contract.py` bullet's "+ the manifest/artifact models" phrasing (match the
       `model_selection.py` bullet's existing "consumes... predict carries no local copy"
       phrasing for `resolve_params`), and the External Dependencies section's
@@ -100,13 +100,13 @@ that then needs a second pass. Land both together, verified by one gate.
       and append `PredictionArtifact`/`PredictionManifest` to that bullet's enumerated type
       list (`ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`), since they're now equally
       contracts-shared types.
-- [ ] 4.4 Update `CLAUDE.md`'s Package Structure blurb with the same treatment as the
+- [x] 4.4 Update `CLAUDE.md`'s Package Structure blurb with the same treatment as the
       Architecture Patterns bullet.
-- [ ] 4.5 Grep sweep for stray references to predict's local class definitions across code and
+- [x] 4.5 Grep sweep for stray references to predict's local class definitions across code and
       docs; confirm zero remaining (aside from immutable `openspec/changes/archive/` history).
 
 ## 5. Validation gate
 
-- [ ] 5.1 `openspec validate consume-contracts-prediction-manifest --strict` — resolve any
+- [x] 5.1 `openspec validate consume-contracts-prediction-manifest --strict` — resolve any
       issues.
-- [ ] 5.2 Full `/pre-merge` gate (format, lint, test, build) before opening the PR.
+- [x] 5.2 Full `/pre-merge` gate (format, lint, test, build) before opening the PR.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -49,7 +49,9 @@ importable library.
     `WandbRegistrySource`); all wandb/network access confined here (lazy import)
   - `warm_worker.py` — `WarmModelWorker`, keeps sleap-nn `Predictor`s resident across scans
   - `output_contract.py` — per-scan output writer (`write_prediction_outputs`,
-    `predict_and_write_batch`) + the manifest/artifact models
+    `predict_and_write_batch`); consumes `PredictionArtifact`/`PredictionManifest` from
+    `sleap_roots_contracts` (re-exported from `__init__.py`; predict carries no local copy
+    of the models themselves)
   - `batch.py` — the warm-batch container runner (`run_batch`, `discover_scans`)
   - `__main__.py` — the `python -m sleap_roots_predict <in> <out>` CLI entrypoint
   - `video_utils.py` — image I/O utilities (natural sort, greyscale, load/save, video build)
@@ -102,8 +104,9 @@ downstream join.
 
 ## External Dependencies
 - **sleap-nn / sleap-io** — inference engine and label I/O.
-- **sleap-roots-contracts** (`==0.1.0a4`) — shared `ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`,
-  and the `resolve_params` oracle (Bloom scan metadata → `ResolvedParams`).
+- **sleap-roots-contracts** (`==0.1.0a5`) — shared `ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`/
+  `PredictionArtifact`/`PredictionManifest`, and the `resolve_params` oracle (Bloom scan
+  metadata → `ResolvedParams`).
 - **wandb** — the model registry the warm worker fetches root models from (network confined to
   `WandbRegistrySource`). Also a transitive sleap-nn dependency.
 - **sleap-roots model registry** — source of trained models (the wandb registry above).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pandas",
     "h5py",
     "imageio",
-    "sleap-roots-contracts==0.1.0a4",
+    "sleap-roots-contracts==0.1.0a5",
     # wandb is already a transitive dependency of sleap-nn 0.3.0; declared here
     # because WandbRegistrySource imports it directly (kept as a lazy import).
     "wandb",

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -8,10 +8,11 @@ serializes a :class:`PredictionManifest`: the manifest (per-root paths +
 ``ModelRef``s, effective inference config, code sha / container digest, and each
 ``.slp``'s checksum + file size).
 
-The schema is predict-local for now (it reuses ``ModelRef`` from
-``sleap-roots-contracts``); it is promoted to the shared contract once the traits
-stage (A3-traits) consumes it. Path strings are emitted via ``Path.as_posix()``
-(lab convention) so the manifest stays portable across POSIX and Windows.
+``PredictionArtifact``/``PredictionManifest`` are defined by
+``sleap-roots-contracts``' ``prediction-manifest-contract`` capability and
+imported here, not defined locally. Path strings are emitted via
+``Path.as_posix()`` (lab convention) so the manifest stays portable across
+POSIX and Windows.
 """
 
 import hashlib
@@ -23,75 +24,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import sleap_io as sio
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-from sleap_roots_contracts import ModelRef, ResolvedParams, RootType
+from sleap_roots_contracts import (
+    ModelRef,
+    PredictionArtifact,
+    PredictionManifest,
+    ResolvedParams,
+)
 
 if TYPE_CHECKING:
     from sleap_roots_predict.warm_worker import WarmModelWorker
-
-# Data containers, immutable. ``protected_namespaces=()`` disables pydantic's
-# ``model_``-prefix guard so the spec'd field ``model_id`` (and the ``model``
-# ModelRef field) validate without a namespace warning.
-_FROZEN = ConfigDict(frozen=True, protected_namespaces=())
-
-
-class PredictionArtifact(BaseModel):
-    """One predicted root type's ``.slp`` file plus its identity + integrity.
-
-    Attributes:
-        root_type: The root type this artifact carries.
-        model_id: Filename-safe slug of the model (a discovery label; the full
-            identity is ``model``).
-        model: The resolved ``ModelRef`` that produced this ``.slp``.
-        slp_path: Basename of the ``.slp`` (POSIX-style), relative to the
-            manifest's directory.
-        checksum: sha256 hex digest of the ``.slp`` file.
-        file_size: Size of the ``.slp`` file in bytes.
-    """
-
-    model_config = _FROZEN
-
-    root_type: RootType
-    model_id: str
-    model: ModelRef
-    slp_path: str
-    checksum: str
-    file_size: int
-
-
-class PredictionManifest(BaseModel):
-    """Per-scan output contract: manifest + predict-side provenance.
-
-    Attributes:
-        schema_version: Version of this predict-local manifest shape.
-        scan_key: Producer-side scan identifier (also the ``.slp`` filename stem).
-        plant_qr_code: Cross-scan plant key; defaults to ``scan_key`` when unset.
-        artifacts: One :class:`PredictionArtifact` per predicted root type (may be
-            empty when no root type resolved to a model).
-        predict_inference_config: Full effective inference config (audit).
-        predict_output_params: Output-defining subset of the inference config.
-        predict_code_sha: Git sha of the predict code (``""`` when unknown).
-        predict_container_digest: Image digest of the predict container (``""``
-            when unknown).
-    """
-
-    model_config = _FROZEN
-
-    schema_version: str = "1"
-    scan_key: str
-    plant_qr_code: str = ""
-    artifacts: list[PredictionArtifact] = Field(default_factory=list)
-    predict_inference_config: dict[str, Any] = Field(default_factory=dict)
-    predict_output_params: dict[str, Any] = Field(default_factory=dict)
-    predict_code_sha: str = ""
-    predict_container_digest: str = ""
-
-    @model_validator(mode="after")
-    def _default_plant_qr_code(self) -> "PredictionManifest":
-        """Default ``plant_qr_code`` to ``scan_key`` when not provided."""
-        if not self.plant_qr_code:
-            object.__setattr__(self, "plant_qr_code", self.scan_key)
-        return self
 
 
 # --- filename helpers -------------------------------------------------------

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -216,6 +216,10 @@ def test_manifest_json_on_disk_round_trips(rice_source, video, tmp_path):
     # wrong-but-internally-consistent default couldn't slip through unnoticed.
     on_disk_json = json.loads(on_disk)
     assert all(a["kind"] == "predictions_slp" for a in on_disk_json["artifacts"])
+    # schema_version's literal value is predict's own format contract with
+    # downstream consumers, not just an internal contracts default — pin it here
+    # since no other predict test asserts it after the pure-model tests were pruned.
+    assert on_disk_json["schema_version"] == "1"
 
 
 def test_checksums_and_sizes_match_files(rice_source, video, tmp_path):

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -6,6 +6,7 @@ models (reusing the `rice_source` / `video` fixtures pattern from
 """
 
 import hashlib
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -17,7 +18,6 @@ from sleap_roots_contracts import ModelCard, ModelRef, ResolvedParams
 from sleap_roots_predict.model_registry import LocalCardSource
 from sleap_roots_predict.output_contract import (
     _SCAN_KEY_FORBIDDEN,
-    PredictionArtifact,
     PredictionManifest,
     ScanRequest,
     _validate_scan_key,
@@ -89,33 +89,13 @@ def _ref(root_type="primary", registry_id="reg/rice-primary", version="v1"):
 # --- Task 2: schema models --------------------------------------------------
 
 
-def test_manifest_round_trips():
-    """A manifest with a real ModelRef dumps to JSON and reloads equal."""
-    artifact = PredictionArtifact(
-        root_type="primary",
-        model_id="reg-rice-primary-v1",
-        model=_ref(),
-        slp_path="s1.modelreg-rice-primary-v1.rootprimary.slp",
-        checksum="abc123",
-        file_size=42,
-    )
-    manifest = PredictionManifest(
-        scan_key="s1",
-        plant_qr_code="s1",
-        artifacts=[artifact],
-        predict_inference_config={"device": "cpu", "peak_threshold": 0.2},
-        predict_output_params={"peak_threshold": 0.2},
-    )
-    reloaded = PredictionManifest.model_validate_json(manifest.model_dump_json())
-    assert reloaded == manifest
-    assert reloaded.schema_version == "1"
-    assert reloaded.artifacts[0].model == _ref()
+def test_prediction_classes_are_reexported_from_contracts():
+    """PredictionArtifact/PredictionManifest are contracts' own classes, not local."""
+    import sleap_roots_contracts as contracts
+    from sleap_roots_predict.output_contract import PredictionArtifact
 
-
-def test_plant_qr_code_defaults_to_scan_key():
-    """An unset plant_qr_code defaults to scan_key."""
-    manifest = PredictionManifest(scan_key="scan0731")
-    assert manifest.plant_qr_code == "scan0731"
+    assert PredictionArtifact is contracts.PredictionArtifact
+    assert PredictionManifest is contracts.PredictionManifest
 
 
 # --- Task 3: slug + scan_key validation -------------------------------------
@@ -172,6 +152,7 @@ def test_writer_writes_named_slp_and_manifest(rice_source, video, tmp_path):
         output_params=worker.output_params(),
     )
     assert {a.root_type for a in manifest.artifacts} == {"primary", "lateral"}
+    assert all(a.kind == "predictions_slp" for a in manifest.artifacts)
     for art in manifest.artifacts:
         slp = tmp_path / art.slp_path
         assert slp.exists()
@@ -231,6 +212,10 @@ def test_manifest_json_on_disk_round_trips(rice_source, video, tmp_path):
     )
     on_disk = (tmp_path / "scan0731.predictions.json").read_text(encoding="utf-8")
     assert PredictionManifest.model_validate_json(on_disk) == manifest
+    # Parse the raw JSON directly (not only via model re-validation) so a
+    # wrong-but-internally-consistent default couldn't slip through unnoticed.
+    on_disk_json = json.loads(on_disk)
+    assert all(a["kind"] == "predictions_slp" for a in on_disk_json["artifacts"])
 
 
 def test_checksums_and_sizes_match_files(rice_source, video, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -4151,15 +4151,15 @@ wheels = [
 
 [[package]]
 name = "sleap-roots-contracts"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/f6/7ca8cb8f5fac7b1e95e45d0e8edccee7d1f1308a1511981bd5db2ebc70d4/sleap_roots_contracts-0.1.0a4.tar.gz", hash = "sha256:95074adc9ec97875fa17b8bffaaa7f78afc46d32b3816d6100bafd6df963793c", size = 22668, upload-time = "2026-07-15T21:18:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/cf/1a3d0aeaede3023a615334c6327e3212614495980b18a6c52cae26da8984/sleap_roots_contracts-0.1.0a5.tar.gz", hash = "sha256:30b61c9195818b3b0b78a1ecc8d03d2f042fce7a6590a092a99f32eb40a6e44e", size = 23724, upload-time = "2026-07-21T23:21:20.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/31/176b8ab34f1efb7f1f51f97ca1a9458719741ae4d92c28e72bdcaed08c3d/sleap_roots_contracts-0.1.0a4-py3-none-any.whl", hash = "sha256:1cb2edcc5485e4e4faabaa8a72947377ac1a6579acd7360fa0cd709af7d8c5b8", size = 29480, upload-time = "2026-07-15T21:18:34.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cd/58c9b8743eafb74b5cb51b2c73b8ca13d2b689cf35669a253dae79245fb3/sleap_roots_contracts-0.1.0a5-py3-none-any.whl", hash = "sha256:9a0f395e0a74132ea8ba61379c2a6fb324dd14156130039ee7cad9d8117993e8", size = 31126, upload-time = "2026-07-21T23:21:19.512Z" },
 ]
 
 [[package]]
@@ -4238,7 +4238,7 @@ requires-dist = [
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'linux-cuda'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'windows-cuda'", specifier = "==0.3.0" },
     { name = "sleap-roots", marker = "extra == 'dev'", specifier = ">=0.1.4" },
-    { name = "sleap-roots-contracts", specifier = "==0.1.0a4" },
+    { name = "sleap-roots-contracts", specifier = "==0.1.0a5" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "sleap-roots-predict", extra = "cpu" } },
     { name = "torch", marker = "extra == 'linux-cuda'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "sleap-roots-predict", extra = "linux-cuda" } },


### PR DESCRIPTION
## Summary

Consumes `PredictionArtifact`/`PredictionManifest` from `sleap-roots-contracts` (bumped to `==0.1.0a5`, the promoted models from contracts PR #23) instead of predict's own local copies in `output_contract.py`, which are deleted.

## Changes

- Bump `sleap-roots-contracts` to `==0.1.0a5` in `pyproject.toml`; relock `uv.lock` (diff scoped to just the `sleap-roots-contracts` entry via `uv lock -P sleap-roots-contracts` — verified).
- Replace `sleap_roots_predict/output_contract.py`'s local `PredictionArtifact`/`PredictionManifest` class bodies with `from sleap_roots_contracts import PredictionArtifact, PredictionManifest` (`__init__.py`'s re-export is unchanged — it already imports both names from `output_contract`, which continues to bind them).
- Delete the now-dead `_FROZEN` pydantic config and the now-unused `pydantic`/`RootType` imports (all were used solely by the two removed class bodies — found while making the edit, not in the original plan).
- Prune `tests/test_output_contract.py`'s two pure-model tests (`test_manifest_round_trips`, `test_plant_qr_code_defaults_to_scan_key`) — contracts' own `tests/test_prediction_manifest.py` now owns this coverage (verified by direct comparison: it nests a real `ModelRef` inside a `PredictionArtifact` exactly like predict's version did). Add `test_prediction_classes_are_reexported_from_contracts`, an identity-guard test that would catch a future accidental reintroduction of a local shadow class. Extend two existing writer tests with persistent assertions for the new `kind` field, in both the in-memory manifest and the on-disk JSON.
- Update the `prediction-output` OpenSpec spec (MODIFIED delta) to document `kind: BlobKind = "predictions_slp"` and that the shape is now imported, not locally defined.
- Update `CHANGELOG.md`, `API.md`, `openspec/project.md` (two spots), `CLAUDE.md` to stop describing the schema as predict-local.

## Behavior change

None for well-formed callers. `PredictionArtifact` gains one new field, `kind: BlobKind = "predictions_slp"`, which has a default — confirmed no `PredictionArtifact(...)` construction site in the repo uses positional arguments, so the field-order change is safe everywhere.

## OpenSpec Change

- Change ID: `consume-contracts-prediction-manifest`
- Affected capabilities: `prediction-output` (MODIFIED — one requirement, "Combined per-scan manifest and provenance sidecar", full text restated plus the `kind` field and a new scenario)
- All `tasks.md` items complete (18/18)
- Reviewed via a 5-agent adversarial review before implementation (spec quality, TDD/testing, build/CI, docs, git workflow) — one concrete bug found and fixed (a test-count assertion that conflated `pytest --collect-only` item counts with test-function counts; two tests in the file are parametrized, inflating collected items past the function count), plus several doc-drift and coverage gaps closed (API.md's inline field-list comment, a persistent `kind` regression test, the identity-guard test).

## Testing

- [x] CPU tests pass — 237 passed, 6 deselected (`uv run pytest --cov=sleap_roots_predict -m "not gpu and not acceptance and not wandb" tests/`, matching `ci.yml`'s exact marker expression)
- [x] GPU tests — 3 skipped cleanly (no CUDA/MPS accelerator on this machine; this change touches no GPU-relevant code)
- [x] New tests added: `test_prediction_classes_are_reexported_from_contracts`; `kind` assertions added to `test_writer_writes_named_slp_and_manifest` and `test_manifest_json_on_disk_round_trips`
- [x] Existing tests still cover affected paths — 27 test functions remain in `test_output_contract.py` (28 → −2 pruned → +1 added), all passing; the other 24 pre-existing tests (writer/batch/scan-key/build-identity) are unmodified

## Linting

- [x] Ruff passes (`uv run ruff check sleap_roots_predict/`)
- [x] Codespell passes (`uv run codespell`)
- [x] Formatting passes (`uv run black --check sleap_roots_predict tests`)

## Build / Image

- [x] Wheel builds (`uv build`)
- [ ] Docker image build — not run locally (multi-GB CUDA build; `sleap-roots-contracts` has no torch/sleap-nn dependency — its own deps are just `pydantic` + `pyyaml`, confirmed in `uv.lock` — so this bump carries no inference-stack risk). `docker-build.yml`'s PR trigger will run its build-only (no push) validation automatically since this PR touches `pyproject.toml`/`uv.lock`.

## Downstream Compatibility

- [x] No breaking change to the public API in `__init__.py` — `PredictionArtifact`/`PredictionManifest` re-exports preserved, no edit needed there
- [x] Output artifact format is additive only (`kind` field with a default); existing consumers unaffected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Closes #30
Depends on: talmolab/sleap-roots-contracts#22 (merged, released as `0.1.0a5`)
Precedent: #28 / #29 (the `resolve_params` migration this mirrors)
Downstream: unblocks Salk-Harnessing-Plants-Initiative/bloom#407 (not touched here)

## Follow-ups (not this PR)

- If `docker-build.yml`'s build-only validation fails on this PR (e.g. an unexpected transitive dependency in `0.1.0a5`), revert the dependency-bump commit and file an issue against `sleap-roots-contracts` rather than pinning around it here.
