### PR TITLE
feat: consume RunManifest — scoped discovery + idempotency-key skip-if-done

### DIFF
--- a/API.md
+++ b/API.md
@@ -203,13 +203,17 @@ run_batch(
 The container-oriented batch runner — also the `sleap-roots-predict` /
 `python -m sleap_roots_predict <input_dir> <output_dir>` entrypoint (the predict service
 image's `ENTRYPOINT`). Discovers scans under `input_dir` (each a directory of image frames
-with a co-located `{scan_key}.scan_metadata.json` sidecar), loads models **once** via a
-single resident `WarmModelWorker` (`source=None` → the production `WandbRegistrySource`),
-and per scan: skips if the manifest already exists (resume), else predicts, writes the
-output-contract artifacts into `out_dir/{scan_key}/`, and copies the sidecar through so the
-output is a self-contained traits-input tree. Per-scan failures are isolated;
-`BatchResult.ok` is `False` iff any scan failed (the CLI exit code). See the
-`predict-container` OpenSpec spec.
+with a co-located `{scan_key}.scan_metadata.json` sidecar); when a `run_manifest.json`
+(`RunManifest`, `sleap-roots-contracts==0.1.0a7`) is staged in `input_dir`, discovery is
+scoped to exactly its `scan_keys` (an out-of-scope sidecar is silently excluded). Loads
+models **once** via a single resident `WarmModelWorker` (`source=None` → the production
+`WandbRegistrySource`), and per scan: compares a recomputed idempotency key
+(`compute_idempotency_key`) against the prior run's own artifacts (no new storage — the key
+is recovered from the previously-copied sidecar and previously-written manifest), skipping
+only on an exact match and otherwise (re)predicting; writes the output-contract artifacts
+into `out_dir/{scan_key}/`, and copies the sidecar through so the output is a self-contained
+traits-input tree. Per-scan failures are isolated; `BatchResult.ok` is `False` iff any scan
+failed (the CLI exit code). See the `predict-container` OpenSpec spec.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,16 +37,22 @@ All notable changes to this project are documented here. The format is based on
   entrypoint — `sleap-roots-predict <input_scan_dir> <output_dir>` (also
   `python -m sleap_roots_predict`) and the `run_batch(...)` library function. Discovers scans
   (a `{scan_key}.scan_metadata.json` sidecar co-located with its frames), loads models once
-  via a resident `WarmModelWorker`, and per scan skips-if-done (existence-based resume),
-  predicts (single-channel video), writes the output-contract artifacts into
-  `out_dir/{scan_key}/`, and copies the sidecar through so the output is a self-contained
-  trait-extractor input tree. Per-scan failures are isolated; the process exits non-zero iff
-  any scan failed. The root `Dockerfile` now ships a real exec-form
-  `ENTRYPOINT ["python","-m","sleap_roots_predict"]` on the GPU (`linux_cuda`) stack and bakes
-  the build git sha (`SRP_PREDICT_CODE_SHA` build-arg → `ENV` → manifest `predict_code_sha`);
-  `docker-build.yml` tags `type=sha,format=long`. New public export: `run_batch`. See the
-  `predict-container` OpenSpec spec (closes #24). Model-derived channel handling (#25) and
-  Argo-readiness hardening (#26) are follow-ups.
+  via a resident `WarmModelWorker`, and per scan, when a `run_manifest.json` (`RunManifest`,
+  `sleap-roots-contracts==0.1.0a7`) is staged in `input_dir`, scopes discovery to exactly its
+  `scan_keys` (an out-of-scope sidecar is silently excluded); skip-if-done now compares a
+  recomputed idempotency key (`compute_idempotency_key`) against the prior run's own artifacts,
+  skipping only on an exact match and otherwise (re)predicting — no new storage. Note:
+  `resolve()` (and its one-time model-registry fetch) now runs once per batch invocation even
+  when every scan is already done, which it previously did not. Predicts (single-channel
+  video), writes the output-contract artifacts into `out_dir/{scan_key}/`, and copies the
+  sidecar through so the output is a self-contained trait-extractor input tree. Per-scan
+  failures are isolated; the process exits non-zero iff any scan failed. The root `Dockerfile`
+  now ships a real exec-form `ENTRYPOINT ["python","-m","sleap_roots_predict"]` on the GPU
+  (`linux_cuda`) stack and bakes the build git sha (`SRP_PREDICT_CODE_SHA` build-arg → `ENV` →
+  manifest `predict_code_sha`); `docker-build.yml` tags `type=sha,format=long`. New public
+  export: `run_batch`. See the `predict-container` OpenSpec spec (closes #24, and the
+  `sleap-roots-predict` row of `sleap-roots-pipeline`#37). Model-derived channel handling (#25)
+  and Argo-readiness hardening (#26) are follow-ups.
 - **A3-predict parity harness** (`sleap_roots_predict.parity`): resolves real human-labeled
   ground truth per production `ModelCard` (labels-registry lookup, bundled-labels path
   relinking, or basename search, in that priority order; unresolvable models are reported as

--- a/README.md
+++ b/README.md
@@ -206,12 +206,16 @@ docker run --rm -e WANDB_API_KEY=$WANDB_API_KEY \
 
 Each scan is a directory of image frames with a co-located
 `{scan_key}.scan_metadata.json` sidecar (carrying the resolved `{species, mode, age}`
-params). The container loads models once, predicts every scan, and writes per scan
+params). If the input directory also has a `run_manifest.json` (staged by an upstream
+pipeline stage), discovery is scoped to exactly that manifest's `scan_keys` — a leftover
+sidecar from a prior run is silently excluded rather than reprocessed. The container loads
+models once, predicts every scan, and writes per scan
 `out/{scan_key}/{scan_key}.predictions.json` + named per-root `.slp` + a copy of the
-sidecar. It skips a scan whose manifest already exists (resume) and exits non-zero if any
-scan failed. GPU is used when available (`nvidia.com/gpu`); it also runs CPU-only. The same
-entrypoint is available as a library: `from sleap_roots_predict import run_batch`, or
-`python -m sleap_roots_predict <in> <out>`.
+sidecar. Skip-if-done compares a recomputed idempotency key against the prior run's own
+artifacts (no new storage needed) and skips only on an exact match, (re)predicting
+otherwise; it exits non-zero if any scan failed. GPU is used when available
+(`nvidia.com/gpu`); it also runs CPU-only. The same entrypoint is available as a library:
+`from sleap_roots_predict import run_batch`, or `python -m sleap_roots_predict <in> <out>`.
 
 ## CI/CD
 

--- a/docs/superpowers/plans/2026-08-17-consume-run-manifest.md
+++ b/docs/superpowers/plans/2026-08-17-consume-run-manifest.md
@@ -1,0 +1,936 @@
+# Consume RunManifest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `sleap-roots-predict` consume `sleap-roots-contracts`' new `RunManifest` to scope
+`discover_scans` to exactly a run's `scan_keys`, and upgrade `run_batch`'s skip-if-done from a
+plain `Path.exists()` check to a real idempotency-key comparison recomputed from artifacts
+already on disk.
+
+**Architecture:** All changes are confined to `sleap_roots_predict/batch.py` (plus its test file
+and a version bump). `discover_scans` gains an optional manifest-read step ahead of its existing
+`rglob`; `run_batch`'s per-scan loop gains two small private helpers
+(`_identity_key`/`_previous_identity_key`) and is reordered so the existing `scan.error`
+short-circuit and per-scan `try/except` still isolate every new failure mode.
+
+**Tech Stack:** Python 3.11+, pydantic (via `sleap-roots-contracts`), pytest, `uv` for
+dependency management.
+
+**Spec:** `openspec/changes/consume-run-manifest/` (proposal.md, tasks.md,
+`specs/predict-container/spec.md`) and `docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md`
+(design rationale — read this for *why*, this plan is the *how*). Both have already been through
+a critical multi-lens review round; every fix from that round is folded into the tasks below.
+
+## Global Constraints
+
+- `sleap-roots-contracts` pin is exact (`==X.Y.Z`), not a range — `pyproject.toml:24`.
+- The Dockerfile uses `uv sync --frozen` — a pin bump without a matching `uv.lock` relock in the
+  **same commit** breaks the Docker build-validation job.
+- Path strings that leave this process go through `Path.as_posix()` (lab convention) — not
+  applicable to anything in this plan (no new path strings are emitted), noted for awareness only.
+- Task Group 3 below (identity-key skip-if-done) **must land as a single commit** — its tests
+  assert behavior that doesn't exist until the loop restructuring lands.
+- Every new/changed test must run under `pytest -m "not gpu and not acceptance and not wandb and
+  not parity"` (this repo's CI marker filter) with no network access and no GPU.
+
+---
+
+## Task 1: Bump sleap-roots-contracts to 0.1.0a7 (regression baseline)
+
+**Files:**
+- Modify: `pyproject.toml:24`
+- Modify: `uv.lock` (regenerated, not hand-edited)
+
+**Interfaces:**
+- Produces: `RunManifest`, `RUN_MANIFEST_FILENAME` (from `sleap_roots_contracts`),
+  `compute_idempotency_key` (from `sleap_roots_contracts.identity`) — all consumed by Tasks 2–6.
+
+This task has no test to write (it's a dependency bump); its "test" is the existing full suite
+staying green.
+
+- [ ] **Step 1: Bump the pin**
+
+In `pyproject.toml:24`, change:
+```toml
+    "sleap-roots-contracts==0.1.0a6",
+```
+to:
+```toml
+    "sleap-roots-contracts==0.1.0a7",
+```
+
+- [ ] **Step 2: Relock scoped to this dependency**
+
+Run: `uv lock -P sleap-roots-contracts`
+
+Confirm the `uv.lock` diff (`git diff uv.lock`) touches only the `sleap-roots-contracts` package
+entry (version, hashes, and its own `pydantic`/`pyyaml` sub-dependencies if their versions moved)
+— not an unrelated dependency. If anything else changed, stop and investigate before continuing.
+
+- [ ] **Step 3: Verify the new symbols import cleanly**
+
+Run:
+```bash
+uv run python -c "from sleap_roots_contracts import RunManifest, RUN_MANIFEST_FILENAME; from sleap_roots_contracts.identity import compute_idempotency_key; print('ok')"
+```
+Expected: prints `ok` with no error.
+
+- [ ] **Step 4: Run the full existing suite as the regression baseline**
+
+Run: `uv run pytest -m "not gpu and not acceptance and not wandb and not parity" tests/`
+
+Expected: every test passes, identical to before the bump (no code changed yet — this proves the
+version bump alone doesn't break anything before any new logic is introduced).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: bump sleap-roots-contracts to 0.1.0a7"
+```
+
+---
+
+## Task 2: Scope discover_scans to a present run_manifest.json
+
+**Files:**
+- Modify: `sleap_roots_predict/batch.py` (imports, `discover_scans`)
+- Test: `tests/test_batch.py`
+
+**Interfaces:**
+- Consumes: `RunManifest`, `RUN_MANIFEST_FILENAME` (Task 1)
+- Produces: `discover_scans(input_dir)` now scopes to a manifest's `scan_keys` when
+  `input_dir / RUN_MANIFEST_FILENAME` exists; unchanged (full unscoped `rglob`) otherwise. This
+  is what Tasks 3–4 extend and what Task 6's `run_batch` continues to call unmodified.
+
+- [ ] **Step 1: Write the failing test (scoped discovery)**
+
+Add to `tests/test_batch.py`:
+```python
+def test_discover_scans_scopes_to_run_manifest(tmp_path: Path):
+    _write_scan(tmp_path, "scan_1009", _RICE)
+    _write_scan(tmp_path, "scan_1010", _RICE)  # leftover from a prior run, not in scope
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scan_1009"]})
+    )
+    scans = discover_scans(tmp_path)
+    assert [s.scan_key for s in scans] == ["scan_1009"]
+```
+(`_write_scan` and `_RICE` already exist in this file — `_write_scan` at line ~14, `_RICE` at
+line ~168. Python resolves them at call time, so referencing them from an earlier-defined test is
+fine.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_batch.py::test_discover_scans_scopes_to_run_manifest -v`
+
+Expected: FAIL — both `scan_1009` and `scan_1010` are returned (today's unscoped behavior).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `sleap_roots_predict/batch.py`, add to the imports (near the existing
+`from sleap_roots_contracts import ResolvedParams`):
+```python
+from sleap_roots_contracts import RUN_MANIFEST_FILENAME, ResolvedParams, RunManifest
+```
+
+Replace `discover_scans` (currently `batch.py:66-102`) with:
+```python
+def discover_scans(input_dir: str | Path) -> list[ScanInput]:
+    """Discover scans under ``input_dir`` by their scan-metadata sidecars.
+
+    Recursively finds ``*.scan_metadata.json`` files; each sidecar's parent
+    directory holds that scan's frames. ``scan_key`` is the sidecar's filename
+    stem and must equal the sidecar's internal ``scan_key``. Invalid scans are
+    returned with ``.error`` set (isolated failure); a duplicate ``scan_key``
+    anywhere in the tree raises.
+
+    If ``input_dir / RUN_MANIFEST_FILENAME`` exists, discovery is scoped to
+    exactly its ``scan_keys``: a discovered sidecar outside that set is
+    silently excluded, and a listed ``scan_key`` with no matching sidecar is
+    returned as an isolated error entry. Absent a manifest, every sidecar found
+    is returned (unscoped), unchanged from before manifest-awareness existed.
+
+    Args:
+        input_dir: Directory of staged scans (must exist).
+
+    Returns:
+        One :class:`ScanInput` per discovered (or manifest-expected-but-missing)
+        sidecar, sorted by path.
+
+    Raises:
+        FileNotFoundError: If ``input_dir`` does not exist (a mis-configured mount,
+            distinct from an empty-but-present directory which is a no-op).
+        ValueError: If two in-scope sidecars share a ``scan_key``.
+        pydantic.ValidationError: If a present ``run_manifest.json`` fails to parse
+            or validate as a :class:`RunManifest`.
+    """
+    input_dir = Path(input_dir)
+    if not input_dir.exists():
+        raise FileNotFoundError(
+            f"input scan directory does not exist: {input_dir.as_posix()}"
+        )
+
+    manifest_path = input_dir / RUN_MANIFEST_FILENAME
+    scoped_keys: set[str] | None = None
+    if manifest_path.exists():
+        manifest = RunManifest.model_validate_json(manifest_path.read_text())
+        scoped_keys = set(manifest.scan_keys)
+
+    scans: list[ScanInput] = []
+    seen: dict[str, Path] = {}
+    for sidecar in sorted(input_dir.rglob("*" + _SIDECAR_SUFFIX)):
+        scan_key = sidecar.name[: -len(_SIDECAR_SUFFIX)]
+        if scoped_keys is not None and scan_key not in scoped_keys:
+            continue
+        if scan_key in seen:
+            raise ValueError(
+                f"duplicate scan_key {scan_key!r}: "
+                f"{seen[scan_key].as_posix()} and {sidecar.as_posix()}"
+            )
+        seen[scan_key] = sidecar
+        scans.append(_load_scan(sidecar, scan_key))
+
+    if scoped_keys is not None:
+        for key in sorted(scoped_keys - set(seen)):
+            scans.append(
+                ScanInput(
+                    key,
+                    input_dir / f"{key}{_SIDECAR_SUFFIX}",
+                    error=f"no sidecar found for manifest scan_key {key!r}",
+                )
+            )
+
+    return scans
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_batch.py::test_discover_scans_scopes_to_run_manifest -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the no-manifest regression guard**
+
+This isn't a new-behavior RED/GREEN cycle — it documents that the fallback path is intentional,
+not incidental. Add:
+```python
+def test_no_manifest_falls_back_to_unscoped_discovery(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    _write_scan(tmp_path, "scanB", _RICE)
+    scans = discover_scans(tmp_path)
+    assert sorted(s.scan_key for s in scans) == ["scanA", "scanB"]
+```
+Run: `uv run pytest tests/test_batch.py::test_no_manifest_falls_back_to_unscoped_discovery -v`
+
+Expected: PASS immediately (this path was never changed — confirms no regression).
+
+- [ ] **Step 6: Run the full existing discovery test suite**
+
+Run: `uv run pytest tests/test_batch.py -k discover -v`
+
+Expected: all pass, including every pre-existing discovery test (`test_discover_scans_reads_sidecar_and_frames`, `test_duplicate_scan_key_raises`, `test_stem_scan_key_mismatch_is_error`, etc.) with no changes needed to any of them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sleap_roots_predict/batch.py tests/test_batch.py
+git commit -m "feat: scope discover_scans to run_manifest.json when present"
+```
+
+---
+
+## Task 3: A manifest scan_key with no sidecar becomes an isolated failed scan
+
+**Files:**
+- Modify: `tests/test_batch.py` (test only — Task 2's implementation already produces this)
+
+**Interfaces:**
+- Consumes: `discover_scans` (Task 2) — its synthetic-error-`ScanInput` behavior for a missing
+  sidecar is already implemented; this task adds the test proving it end-to-end via `run_batch`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_batch.py`:
+```python
+def test_manifest_scan_key_with_no_sidecar_is_failed(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    (inp / "run_manifest.json").write_text(
+        json.dumps(
+            {"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]}
+        )
+    )
+    out = tmp_path / "out"
+    result = run_batch(inp, out, source=all_roots_source)
+    statuses = {s.scan_key: s.status for s in result.scans}
+    assert statuses["scanGOOD"] == "ok"
+    assert statuses["scanMISSING"] == "failed"
+```
+(`_real_scan` already exists at line ~171, writes a real 8-frame scan + sidecar.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_batch.py::test_manifest_scan_key_with_no_sidecar_is_failed -v`
+
+Expected: FAIL — at this point `run_batch` hasn't been touched yet (Task 6 does that), so trace
+the failure carefully. `discover_scans` already returns the synthetic error `ScanInput` for
+`scanMISSING` (Task 2), and `run_batch`'s existing loop already checks `scan.error is not None`
+first and records `failed` — so this test may in fact **already pass** at this point in the
+plan, since Task 2 alone is sufficient to satisfy it. If it passes, that's expected (not a bug in
+this plan) — proceed to Step 3 as a confirmation run instead of a RED step, and note this in the
+commit message.
+
+- [ ] **Step 3: Confirm passing and commit**
+
+Run: `uv run pytest tests/test_batch.py::test_manifest_scan_key_with_no_sidecar_is_failed -v`
+
+Expected: PASS.
+
+```bash
+git add tests/test_batch.py
+git commit -m "test: manifest scan_key with no sidecar is an isolated failure"
+```
+
+---
+
+## Task 4: A malformed run_manifest.json raises
+
+**Files:**
+- Modify: `tests/test_batch.py` (test only — Task 2's implementation already raises)
+
+- [ ] **Step 1: Write the tests**
+
+Add to `tests/test_batch.py`:
+```python
+def test_malformed_manifest_json_raises(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    (tmp_path / "run_manifest.json").write_text("{not valid json")
+    with pytest.raises(Exception):
+        discover_scans(tmp_path)
+
+
+def test_manifest_with_empty_scan_keys_raises(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": []})
+    )
+    with pytest.raises(Exception):
+        discover_scans(tmp_path)
+```
+
+- [ ] **Step 2: Run and confirm both pass**
+
+Run: `uv run pytest tests/test_batch.py -k malformed_manifest or empty_scan_keys -v`
+
+Expected: PASS — `RunManifest.model_validate_json` already raises `pydantic.ValidationError` on
+invalid JSON, and `RunManifest`'s own `_check_scan_keys` validator already rejects an empty list;
+Task 2's implementation doesn't catch either, so they propagate.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_batch.py
+git commit -m "test: malformed run_manifest.json raises before any scan is processed"
+```
+
+---
+
+## Task 5: images_checksum field + identity-key helpers
+
+**Files:**
+- Modify: `sleap_roots_predict/batch.py` (`ScanInput`, `_load_scan`, new helpers)
+- Test: `tests/test_batch.py`
+
+**Interfaces:**
+- Consumes: `compute_idempotency_key` (`sleap_roots_contracts.identity`, Task 1),
+  `compute_param_hash` (already exported from `sleap_roots_contracts` top-level),
+  `PredictionManifest` (already imported in `output_contract.py`; import it into `batch.py` too).
+- Produces:
+  - `ScanInput.images_checksum: str` (new field, default `""`)
+  - `_identity_key(*, scan_key: str, images_checksum: str, params_dict: dict, model_refs, predict_code_sha: str, predict_output_params: dict) -> str`
+  - `_previous_identity_key(out_scan_dir: Path, scan_key: str) -> str | None`
+  Both consumed by Task 6's `run_batch` restructuring.
+
+- [ ] **Step 1: Add the field (no test needed standalone)**
+
+In `sleap_roots_predict/batch.py`, modify the `ScanInput` dataclass (currently `batch.py:30-42`):
+```python
+@dataclass(frozen=True)
+class ScanInput:
+    """A discovered scan.
+
+    ``error`` is set (and ``params``/``frames`` may be empty) when the sidecar is
+    invalid — an isolated per-scan failure, not a batch abort.
+    """
+
+    scan_key: str
+    sidecar_path: Path
+    frames: list[Path] = field(default_factory=list)
+    params: ResolvedParams | None = None
+    images_checksum: str = ""
+    error: str | None = None
+```
+
+In `_load_scan` (currently `batch.py:105-142`), after building `resolved`, read the checksum and
+pass it through:
+```python
+    resolved = ResolvedParams(values={k: params[k] for k in _REQUIRED_PARAM_KEYS})
+    images_checksum = meta.get("images_checksum", "")
+    return ScanInput(
+        scan_key, sidecar, frames=frames, params=resolved, images_checksum=images_checksum
+    )
+```
+
+- [ ] **Step 2: Write the failing tests for the helpers**
+
+Add to `tests/test_batch.py` (needs `import sleap_roots_predict.batch as batch_mod` — some
+existing tests already do this, e.g. `test_run_batch_constructs_single_worker`; add the import
+inside each test function that needs it, matching that existing style):
+```python
+def test_identity_key_changes_with_images_checksum():
+    import sleap_roots_predict.batch as batch_mod
+    from sleap_roots_contracts import ModelRef
+
+    ref = ModelRef(registry_id="reg/x", version="v1", sleap_nn_version="0.3.0")
+    base_kwargs = dict(
+        scan_key="scanA",
+        params_dict={"species": "rice", "mode": "cylinder", "age": 3},
+        model_refs={"primary": ref},
+        predict_code_sha="sha1",
+        predict_output_params={"peak_threshold": 0.2},
+    )
+    key_a = batch_mod._identity_key(images_checksum="sha256:a", **base_kwargs)
+    key_b = batch_mod._identity_key(images_checksum="sha256:b", **base_kwargs)
+    assert key_a != key_b
+
+
+def test_previous_identity_key_none_when_nothing_on_disk(tmp_path: Path):
+    import sleap_roots_predict.batch as batch_mod
+
+    assert batch_mod._previous_identity_key(tmp_path, "scanA") is None
+
+
+def test_previous_identity_key_none_when_predictions_json_corrupt(tmp_path: Path):
+    import sleap_roots_predict.batch as batch_mod
+
+    (tmp_path / "scanA.scan_metadata.json").write_text(
+        json.dumps(
+            {"scan_key": "scanA", "images_checksum": "sha256:x", "params": _RICE}
+        )
+    )
+    (tmp_path / "scanA.predictions.json").write_text('{"not": "a valid manifest"}')
+    assert batch_mod._previous_identity_key(tmp_path, "scanA") is None
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `uv run pytest tests/test_batch.py -k identity_key -v`
+
+Expected: FAIL with `AttributeError: module 'sleap_roots_predict.batch' has no attribute
+'_identity_key'` (or `_previous_identity_key`) — the helpers don't exist yet.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+In `sleap_roots_predict/batch.py`, update the contracts import to also pull in
+`compute_param_hash` and `PredictionManifest`, and add the submodule import:
+```python
+from sleap_roots_contracts import (
+    RUN_MANIFEST_FILENAME,
+    PredictionManifest,
+    ResolvedParams,
+    RunManifest,
+    compute_param_hash,
+)
+from sleap_roots_contracts.identity import compute_idempotency_key
+```
+
+Add these two functions (near `_load_scan`, before `run_batch`):
+```python
+def _identity_key(
+    *,
+    scan_key: str,
+    images_checksum: str,
+    params_dict: dict,
+    model_refs,
+    predict_code_sha: str,
+    predict_output_params: dict,
+) -> str:
+    """Derive the predict-scoped identity key for one scan's current or prior state.
+
+    ``model_refs`` may be a ``dict[RootType, ModelRef]`` (as returned by
+    ``worker.resolve``) or any iterable of ``ModelRef`` (as read back from a
+    ``PredictionManifest``'s ``artifacts``) — both are reduced to the same
+    order-independent ``(registry_id, version, weights_checksum)`` tuples
+    ``compute_idempotency_key`` expects. ``traits_code_sha`` is a fixed empty-string
+    placeholder: predict never owns that value and only ever compares this key
+    against its own previously-derived one, never against a traits-computed key.
+    """
+    refs = model_refs.values() if isinstance(model_refs, dict) else model_refs
+    models = [(ref.registry_id, ref.version, ref.weights_checksum) for ref in refs]
+    return compute_idempotency_key(
+        scan_key=scan_key,
+        images_checksum=images_checksum,
+        models=models,
+        param_hash=compute_param_hash(params_dict),
+        predict_code_sha=predict_code_sha,
+        traits_code_sha="",
+        predict_output_params=predict_output_params,
+    )
+
+
+def _previous_identity_key(out_scan_dir: Path, scan_key: str) -> str | None:
+    """Recompute the previous run's identity key from artifacts already on disk.
+
+    Reads back the already-copied sidecar and already-written prediction manifest
+    from ``out_scan_dir`` — no new storage is needed. Returns ``None`` if either
+    file is missing, unreadable, or present but fails to parse/validate (a
+    :class:`pydantic.ValidationError`, which subclasses ``ValueError`` and is
+    caught here without importing pydantic directly) — a corrupt or absent
+    *previous* state is treated as "changed," never as a failure.
+    """
+    sidecar_path = out_scan_dir / f"{scan_key}{_SIDECAR_SUFFIX}"
+    manifest_path = out_scan_dir / f"{scan_key}.predictions.json"
+    try:
+        meta = json.loads(sidecar_path.read_text())
+        manifest = PredictionManifest.model_validate_json(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    params = meta.get("params")
+    if not isinstance(params, dict):
+        return None
+    return _identity_key(
+        scan_key=scan_key,
+        images_checksum=meta.get("images_checksum", ""),
+        params_dict={k: params[k] for k in _REQUIRED_PARAM_KEYS if k in params},
+        model_refs=[artifact.model for artifact in manifest.artifacts],
+        predict_code_sha=manifest.predict_code_sha,
+        predict_output_params=manifest.predict_output_params,
+    )
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `uv run pytest tests/test_batch.py -k identity_key -v`
+
+Expected: PASS, all three.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sleap_roots_predict/batch.py tests/test_batch.py
+git commit -m "feat: add images_checksum field and identity-key helpers"
+```
+
+---
+
+## Task 6: Idempotency-key skip-if-done in run_batch
+
+**Land this entire task as ONE commit** — the tests in Steps 1–5 assert behavior that doesn't
+exist until Step 6's implementation lands; splitting would leave an intermediate commit red.
+
+**Files:**
+- Modify: `sleap_roots_predict/batch.py` (`run_batch`, `_predict_one`)
+- Test: `tests/test_batch.py`
+
+**Interfaces:**
+- Consumes: `_identity_key`, `_previous_identity_key` (Task 5), `discover_scans` (Task 2,
+  unmodified by this task)
+- Produces: `run_batch`'s skip decision is now identity-key-based; `_predict_one`'s signature
+  changes to accept a precomputed `refs` argument instead of resolving internally.
+
+- [ ] **Step 1: Write the failing tests — changed inputs cause a re-predict**
+
+Add to `tests/test_batch.py`:
+```python
+def test_changed_params_causes_repredict(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    sidecar = inp / "scanA" / "scanA.scan_metadata.json"
+    body = json.loads(sidecar.read_text())
+    body["params"] = {"species": "rice", "mode": "cylinder", "age": 4}
+    sidecar.write_text(json.dumps(body))
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_images_checksum_causes_repredict(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    sidecar = inp / "scanA" / "scanA.scan_metadata.json"
+    body = json.loads(sidecar.read_text())
+    body["images_checksum"] = "sha256:changed"
+    sidecar.write_text(json.dumps(body))
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_predict_code_sha_causes_repredict(all_roots_source, tmp_path, monkeypatch):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    monkeypatch.setenv("SRP_PREDICT_CODE_SHA", "sha-one")
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    monkeypatch.setenv("SRP_PREDICT_CODE_SHA", "sha-two")
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_model_ref_causes_repredict(tmp_path: Path, native_model_dir):
+    from sleap_roots_contracts import ModelCard
+    from sleap_roots_predict.model_registry import LocalCardSource
+
+    def _source(version):
+        card = ModelCard(
+            species="rice",
+            mode="cylinder",
+            age_min=2,
+            age_max=5,
+            root_type="primary",
+            registry_id="reg/rice-primary",
+            version=version,
+        )
+        return LocalCardSource([(card, native_model_dir)])
+
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=_source("v1"))
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    result2 = run_batch(inp, out, source=_source("v2"))
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_corrupt_previous_manifest_causes_repredict_not_failure(all_roots_source, tmp_path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    (out / "scanA" / "scanA.predictions.json").write_text('{"not": "a valid manifest"}')
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+```
+
+- [ ] **Step 2: Write the failing test — batch isolation survives the loop restructuring**
+
+```python
+def test_manifest_missing_sidecar_does_not_abort_other_scans(all_roots_source, tmp_path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    (inp / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]})
+    )
+    out = tmp_path / "out"
+    result = run_batch(inp, out, source=all_roots_source)
+    statuses = {s.scan_key: s.status for s in result.scans}
+    assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}
+```
+This proves the `scan.error` short-circuit still runs before `resolve()` — a naive
+"move `resolve()` up" implementation would call `resolve(None)` on `scanMISSING`'s
+`params=None` and raise `AttributeError` inside `choose_models`, which (without the ordering
+fix below) would abort the whole batch instead of isolating one scan.
+
+- [ ] **Step 3: Run all new tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/test_batch.py -k "changed_params_causes_repredict or changed_images_checksum_causes_repredict or changed_predict_code_sha_causes_repredict or changed_model_ref_causes_repredict or corrupt_previous_manifest or manifest_missing_sidecar_does_not_abort" -v
+```
+Expected: every one FAILS — today's `run_batch` still skips on `Path.exists()` alone (the
+`test_changed_*`/`test_corrupt_previous_manifest*` tests fail because the second run is
+`skipped` instead of `ok`), and `test_manifest_missing_sidecar_does_not_abort_other_scans` may
+already pass (Task 2/3 cover it) or may already fail depending on `resolve()`'s current position
+— either is fine at this checkpoint; Step 6 makes all of them pass together.
+
+- [ ] **Step 4: Also run the existing skip test to see its current (still-passing) baseline**
+
+Run: `uv run pytest tests/test_batch.py::test_rerun_skips_completed_scan -v`
+
+Expected: PASS (unchanged by this task — recorded here as a baseline to re-check in Step 8, not
+because it needs editing).
+
+- [ ] **Step 5: Verify `_predict_one`'s current behavior before changing its signature**
+
+Read `sleap_roots_predict/batch.py:207-245` (`_predict_one`) — note it currently calls
+`worker.resolve(scan.params)` internally at its top. Step 6 removes that internal call and takes
+`refs` as a parameter instead.
+
+- [ ] **Step 6: Implement the restructured run_batch loop**
+
+Replace `run_batch` (currently `batch.py:145-205`, post-Task-2/5 line numbers will have shifted —
+locate by function name) with:
+```python
+def run_batch(
+    input_dir: str | Path,
+    output_dir: str | Path,
+    *,
+    source: ModelCardSource | None = None,
+    predict_code_sha: str | None = None,
+    predict_container_digest: str | None = None,
+) -> BatchResult:
+    """Predict every scan under ``input_dir``, writing outputs under ``output_dir``.
+
+    Loads models once via a single resident worker. Per scan: a scan already
+    recorded as invalid (``scan.error`` set) is isolated as ``failed`` immediately,
+    before any model resolution runs. Otherwise, the currently-resolved models plus
+    the scan's current inputs are compared, via a recomputed idempotency key,
+    against the key recomputed from that scan's own previously-written artifacts
+    (no new storage — see :func:`_previous_identity_key`); an exact match skips,
+    anything else (including no previous artifacts at all) predicts and overwrites.
+    A per-scan error is isolated (recorded ``failed``, batch continues). An empty
+    (but present) input directory is a no-op.
+
+    Args:
+        input_dir: Directory of staged scans.
+        output_dir: Directory to write per-scan outputs into.
+        source: Model-card source; ``None`` uses the production WandbRegistrySource.
+        predict_code_sha: Provenance sha (falls back to ``SRP_PREDICT_CODE_SHA``).
+        predict_container_digest: Provenance digest (env fallback).
+
+    Returns:
+        A :class:`BatchResult` with one :class:`ScanResult` per scan.
+
+    Raises:
+        FileNotFoundError: If ``input_dir`` does not exist.
+        ValueError: If two sidecars share a ``scan_key`` (a batch-level staging error,
+            surfaced before any prediction).
+    """
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    scans = discover_scans(input_dir)
+    result = BatchResult()
+    if not scans:
+        logger.warning("No scans discovered under %s", input_dir.as_posix())
+        return result
+
+    resolved_code_sha = (
+        predict_code_sha
+        if predict_code_sha is not None
+        else os.environ.get("SRP_PREDICT_CODE_SHA", "")
+    )
+    worker = WarmModelWorker(source=source)
+    for scan in scans:
+        if scan.error is not None:
+            logger.error("Scan %s failed: %s", scan.scan_key, scan.error)
+            result.scans.append(ScanResult(scan.scan_key, "failed", scan.error))
+            continue
+
+        out_scan_dir = output_dir / scan.scan_key
+        try:
+            refs = worker.resolve(scan.params)
+            current_key = _identity_key(
+                scan_key=scan.scan_key,
+                images_checksum=scan.images_checksum,
+                params_dict=scan.params.values,
+                model_refs=refs,
+                predict_code_sha=resolved_code_sha,
+                predict_output_params=worker.output_params(),
+            )
+            previous_key = _previous_identity_key(out_scan_dir, scan.scan_key)
+            if previous_key is not None and previous_key == current_key:
+                logger.info("Skipping %s (idempotency key unchanged)", scan.scan_key)
+                result.scans.append(ScanResult(scan.scan_key, "skipped"))
+                continue
+            _predict_one(
+                worker, scan, out_scan_dir, refs, predict_code_sha, predict_container_digest
+            )
+            result.scans.append(ScanResult(scan.scan_key, "ok"))
+        except Exception as exc:  # noqa: BLE001 - isolate per-scan failures
+            logger.exception("Scan %s failed", scan.scan_key)
+            result.scans.append(ScanResult(scan.scan_key, "failed", str(exc)))
+    return result
+```
+This requires `import os` at the top of `batch.py` if not already present — check; if absent,
+add it alongside the existing `import json`/`import logging`/`import shutil` block.
+
+Replace `_predict_one` (currently `batch.py:207-245`) with:
+```python
+def _predict_one(
+    worker: WarmModelWorker,
+    scan: ScanInput,
+    out_scan_dir: Path,
+    refs: dict,
+    predict_code_sha: str | None,
+    predict_container_digest: str | None,
+) -> None:
+    """Predict one scan and write its outputs + copied sidecar. Raises on failure."""
+    if not scan.frames:
+        raise ValueError(
+            f"no image frames co-located with sidecar {scan.sidecar_path.as_posix()}"
+        )
+    assert scan.params is not None  # run_batch filters error scans (params-None) first
+    if not refs:
+        # A scan matching no model for any root type is a hard per-scan failure rather
+        # than an empty-artifacts manifest: write_prediction_outputs permits an empty
+        # manifest, but the downstream trait-extractor rejects one, so surface it here.
+        raise ValueError(f"no models resolved for params {scan.params.values!r}")
+    video = make_video_from_images(scan.frames, greyscale=True)
+    labels = worker.predict(scan.params, video)
+    out_scan_dir.mkdir(parents=True, exist_ok=True)
+    # Copy the sidecar BEFORE the manifest: write_prediction_outputs writes the manifest
+    # last as the resume commit-marker, so the sidecar must already be present when it
+    # lands — else a crash in between leaves a manifest with no sidecar that resume skips
+    # forever and the trait-extractor then rejects (an incomplete input tree).
+    shutil.copyfile(
+        scan.sidecar_path, out_scan_dir / f"{scan.scan_key}{_SIDECAR_SUFFIX}"
+    )
+    write_prediction_outputs(
+        labels,
+        refs,
+        out_scan_dir,
+        scan_key=scan.scan_key,
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+        predict_code_sha=predict_code_sha,
+        predict_container_digest=predict_container_digest,
+    )
+```
+Note `refs` is passed straight through to `write_prediction_outputs` unchanged from before;
+`worker.predict(scan.params, video)` still resolves internally a second time via
+`get_predictors()` — that's pre-existing, harmless (the one real cost, `list_cards()`, is cached
+after its first call per `WarmModelWorker` instance), and out of scope to change here.
+
+- [ ] **Step 7: Run every new test from Steps 1–2 to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_batch.py -k "changed_params_causes_repredict or changed_images_checksum_causes_repredict or changed_predict_code_sha_causes_repredict or changed_model_ref_causes_repredict or corrupt_previous_manifest or manifest_missing_sidecar_does_not_abort" -v
+```
+Expected: all PASS.
+
+- [ ] **Step 8: Run the full test_batch.py file, with special attention to the highest-risk pre-existing tests**
+
+Run: `uv run pytest tests/test_batch.py -v`
+
+Expected: 100% pass, including (name them explicitly and check each one in the output):
+`test_rerun_skips_completed_scan`, `test_zero_resolved_models_is_failed`,
+`test_one_failing_scan_does_not_abort_batch`, `test_sidecar_copy_failure_leaves_no_manifest`,
+`test_resume_mixed_skip_and_predict`, `test_run_batch_writes_outputs_and_copies_sidecar`,
+`test_run_batch_constructs_single_worker`.
+
+- [ ] **Step 9: Run the full project test suite**
+
+Run: `uv run pytest -m "not gpu and not acceptance and not wandb and not parity" tests/`
+
+Expected: 100% pass.
+
+- [ ] **Step 10: Commit (single commit for this entire task)**
+
+```bash
+git add sleap_roots_predict/batch.py tests/test_batch.py
+git commit -m "feat: idempotency-key skip-if-done, replacing Path.exists() resume"
+```
+
+---
+
+## Task 7: OpenSpec validation gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Validate**
+
+Run: `openspec validate consume-run-manifest --strict`
+
+Expected: `Change 'consume-run-manifest' is valid`. If not, fix the delta spec (it should already
+be correct from the review round — this is a final confirmation, not expected to need edits).
+
+---
+
+## Task 8: Docs
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]` → "Predict container CLI" bullet)
+- Modify: `API.md` (`run_batch` section prose)
+- Modify: `README.md` (~line 211, "Running the predict container" section)
+- Modify: `openspec/project.md` (External Dependencies version literal + Roadmap note)
+
+- [ ] **Step 1: Update CHANGELOG.md**
+
+In the `[Unreleased]` → "Predict container CLI" bullet, replace the clause
+`"and per scan skips-if-done (existence-based resume),"` with:
+```
+and per scan, when a `run_manifest.json` (`RunManifest`, `sleap-roots-contracts==0.1.0a7`) is
+staged in `input_dir`, scopes discovery to exactly its `scan_keys` (an out-of-scope sidecar is
+silently excluded); skip-if-done now compares a recomputed idempotency key
+(`compute_idempotency_key`) against the prior run's own artifacts, skipping only on an exact
+match and otherwise (re)predicting — no new storage. Note: this means `resolve()` (and its
+one-time model-registry fetch) now runs once per batch invocation even when every scan is
+already done, which it previously did not.
+```
+
+- [ ] **Step 2: Update API.md**
+
+In the `run_batch` section, replace `"skips if the manifest already exists (resume)"` with
+wording matching Step 1 (manifest-scoped discovery + idempotency-key comparison).
+
+- [ ] **Step 3: Update README.md**
+
+Around line 211, replace `"It skips a scan whose manifest already exists (resume) and exits
+non-zero if any scan failed."` with wording matching Step 1, plus a sentence noting
+`run_manifest.json`-scoped discovery when a pipeline stages one.
+
+- [ ] **Step 4: Update openspec/project.md**
+
+- Bump the External Dependencies `sleap-roots-contracts` version literal: `==0.1.0a6` →
+  `==0.1.0a7`.
+- In the Roadmap note at the top of the file, add a credit for this change closing the
+  `sleap-roots-predict` row of `sleap-roots-pipeline#37`, parallel to the existing `#15` credit
+  for the parity harness.
+
+- [ ] **Step 5: Grep sweep**
+
+Run (adjust for your shell):
+```bash
+grep -rniE "skip.{0,20}(exist|manifest)|exists.{0,20}resume" README.md API.md CHANGELOG.md openspec/project.md
+```
+Confirm no stale existence-based-resume phrasing remains anywhere.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md API.md README.md openspec/project.md
+git commit -m "docs: update run-manifest scoping and idempotency-key skip-if-done docs"
+```
+
+---
+
+## Task 9: Pre-merge gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the pre-merge gate**
+
+Invoke `/pre-merge`. Confirm its pytest invocation uses `-m "not gpu and not acceptance and not
+wandb and not parity"` (matching `ci.yml`'s exact filter), not `/pre-merge`'s own default `-m
+"not gpu"` (which would pull in flaky wandb-registry tests) — override explicitly if needed.
+
+- [ ] **Step 2: Confirm every tasks.md item is checked off**
+
+Open `openspec/changes/consume-run-manifest/tasks.md` and mark every item `- [x]`.
+
+```bash
+git add openspec/changes/consume-run-manifest/tasks.md
+git commit -m "chore: mark consume-run-manifest tasks complete"
+```

--- a/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
+++ b/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
@@ -66,15 +66,56 @@ input_dir/
 `ScanInput` gains one field: `images_checksum: str = ""`, read from the sidecar's existing
 `images_checksum` key (already present in every sidecar fixture today, just previously ignored).
 
-`run_batch`'s per-scan loop, restructured:
-1. `refs = worker.resolve(scan.params)` — moved up from `_predict_one`; cheap (matches against
-   the already-listed `ModelCard`s, no network/download), safe to call before the skip decision.
-2. `current_key = _identity_key(scan_key, images_checksum=scan.images_checksum, refs, param_hash=scan.params.param_hash, predict_code_sha=resolved_code_sha, output_params=worker.output_params())` —
-   a thin wrapper around `compute_idempotency_key` (see below).
-3. `previous_key = _stored_identity_key(out_scan_dir, scan.scan_key)` — `None` if nothing usable
-   is on disk yet (see below).
-4. `previous_key == current_key` → `skipped`. Otherwise (differs, or `None`) → predict, write
-   outputs as today.
+`run_batch`'s per-scan loop, restructured — **ordering matters, and is more subtle than "move
+resolve() up" alone suggests** (a critical review round caught this: three independent reviewers
+converged on the same bug in an earlier draft that called `resolve()` unconditionally, ahead of
+both the existing `scan.error` check and the existing per-scan `try/except`):
+
+1. **`scan.error` check stays first**, exactly where it is today, before anything else runs. A
+   scan with `.error` set (invalid sidecar, stem/scan_key mismatch, or the new manifest-scan_key-
+   with-no-sidecar case) is recorded `failed` immediately and never reaches `resolve()` — this
+   matters concretely because that last case's synthetic `ScanInput` has `params=None`, and
+   `resolve(None)` would otherwise raise `AttributeError` inside `choose_models`.
+2. **Everything else moves inside the existing per-scan `try/except Exception`** — not just
+   `_predict_one` as before, but `refs = worker.resolve(scan.params)`, both key computations, and
+   the skip decision too. This preserves the existing "one bad scan doesn't abort the batch"
+   guarantee (`test_zero_resolved_models_is_failed`, `test_one_failing_scan_does_not_abort_batch`)
+   for failure modes that can now occur earlier than before: an ambiguous-match `ValueError` from
+   `choose_models`, or — without the next point — a `pydantic.ValidationError` from a corrupt
+   leftover `.predictions.json`.
+3. Inside that block: `refs = worker.resolve(scan.params)` (cheap — matches against the
+   already-listed `ModelCard`s; see the accepted trade-off below on what "cheap" actually means
+   now), then `current_key = _identity_key(scan_key, images_checksum=scan.images_checksum, refs,
+   param_hash=scan.params.param_hash, predict_code_sha=resolved_code_sha,
+   output_params=worker.output_params())` (a thin wrapper around `compute_idempotency_key`, see
+   below), then `previous_key = _previous_identity_key(out_scan_dir, scan.scan_key)`.
+4. **`_previous_identity_key` catches its own file/parse errors internally** — `OSError`,
+   `json.JSONDecodeError`, and `pydantic.ValidationError` (a corrupt-but-present old
+   `.predictions.json`, distinct from missing-entirely) — and returns `None` rather than letting
+   them propagate. This is a deliberate distinction from point 2's outer `try/except`: a scan
+   whose *previous* artifacts are corrupt should be treated as "changed" and re-predicted
+   (overwriting the corrupt state), not recorded as `failed` — those are two different outcomes,
+   and only an internal catch inside `_previous_identity_key` produces the right one.
+5. `previous_key == current_key` → `skipped`. Otherwise (differs, or either is `None`) → predict,
+   write outputs as today.
+
+### Accepted trade-off: resolve() now runs once per batch even on a full resume
+
+Today, `resolve()` only runs for scans that aren't skipped, so a fully-resumed batch (every scan
+already done) calls it **zero times** — no model-registry network access at all. After this
+change, `resolve()` must run for every scan to get the current model refs to compare against the
+previous run's, so the one-time `list_cards()` catalog fetch (a real network call, for the
+production `WandbRegistrySource`) now happens **once per `run_batch()` invocation regardless of
+whether anything ends up (re)predicted**. Concretely: a wandb outage would turn a should-be-
+trivial "everything's already done" resume into a hard failure, where today it silently succeeds.
+
+This is accepted as-is (confirmed with the user during review) rather than special-cased away,
+because there's no way to know whether models changed without listing them — special-casing
+"only call `resolve()` if some other identity input changed" would restore the old free resume
+but silently miss a model-registry change as a reason to re-predict, undermining the exact
+guarantee including model refs in the identity key is meant to provide. It's a real, inherent cost
+of the correctness this feature buys, not a bug — worth stating plainly rather than leaving
+implicit, which is the only reason it's called out here.
 
 ## No new storage — recompute both sides from artifacts predict already writes
 
@@ -89,27 +130,31 @@ sidecar verbatim:
 | `scan_key` | the scan itself (identical either way) |
 | `images_checksum` | `out_scan_dir/{scan_key}.scan_metadata.json`'s `images_checksum` (the previously-copied sidecar, byte-identical to what was actually used) |
 | `param_hash` | recomputed via `compute_param_hash` over that same old sidecar's `params` — pure function, so this reproduces the exact value used at write time |
-| `models` | `out_scan_dir/{scan_key}.predictions.json`'s `artifacts[].model` (the `ModelRef`s actually used) |
+| `models` | `out_scan_dir/{scan_key}.predictions.json`'s `artifacts[].model` (the `ModelRef`s actually used) — converted to the `list[tuple[registry_id, version, weights_checksum]]` shape `compute_idempotency_key` expects, the same conversion applied on the current side to `refs.values()` |
 | `predict_code_sha` / `predict_output_params` | the same manifest's `predict_code_sha` / `predict_output_params` fields |
 
-So `_stored_identity_key(out_scan_dir, scan_key)` just reads those two existing files (returning
-`None` if either is missing/unreadable — e.g. a first run, or a crash left a partial write — which
-naturally falls through to "re-run," matching the existing "prefer re-run over serving stale/
-incomplete data" philosophy already baked into the sidecar-before-manifest ordering) and calls the
-same `compute_idempotency_key` used for the current side. No new file, no contracts change, and
-the exact same trick is available to traits later (it reads the identical two files plus its own
+So `_previous_identity_key(out_scan_dir, scan_key)` just reads those two existing files (returning
+`None` if either is missing/unreadable — e.g. a first run, a crash left a partial write, or the
+old files are present but corrupt/unparseable, see the ordering section above — which naturally
+falls through to "re-run," matching the existing "prefer re-run over serving stale/incomplete
+data" philosophy already baked into the sidecar-before-manifest ordering) and calls the same
+`compute_idempotency_key` used for the current side. No new file, no contracts change, and the
+exact same trick is available to traits later (it reads the identical two files plus its own
 `traits_code_sha`).
 
 ## Error handling summary
 
 - Malformed manifest → raises (batch-level, before any scan is touched).
 - Sidecar not in scope → excluded silently (debug log only).
-- Manifest scan_key with no sidecar → `ScanResult(status="failed")`, batch continues.
-- Zero models resolved → unchanged, still `failed` (check happens right after the moved-up
-  `resolve()` call).
-- No previous manifest/sidecar on disk yet, or either is unreadable → `previous_key = None` →
-  treated as changed → predict runs (first run, or a prior crash mid-write; never silently
-  skips on ambiguous state).
+- Manifest scan_key with no sidecar → synthetic `ScanInput.error` set, so it's caught by the
+  existing `scan.error` check *before* `resolve()` is ever called → `ScanResult(status="failed")`,
+  batch continues.
+- Zero models resolved, or any other exception inside the widened per-scan `try/except` (e.g. an
+  ambiguous-match `ValueError` from `choose_models`) → `failed`, batch continues — unchanged
+  guarantee, now covering a slightly larger block (see the ordering section above).
+- Previous manifest/sidecar missing, unreadable, *or corrupt/unparseable* → `_previous_identity_key`
+  catches this internally and returns `None` → treated as changed → predict runs (never silently
+  skips on ambiguous state, and never recorded as `failed` for a *previous*-side problem).
 - Everything else (missing input_dir, duplicate scan_key, unreadable sidecar, missing params) →
   unchanged.
 
@@ -132,12 +177,23 @@ cleaner split out):
 7. `run_batch` re-run with a different `SRP_PREDICT_CODE_SHA` re-predicts.
 8. `pyproject.toml` bumped to `sleap-roots-contracts==0.1.0a7`; full existing suite still green
    (regression gate for the version bump itself).
-9. A first run (nothing in `out_scan_dir` yet) always predicts — `_stored_identity_key` returns
+9. A first run (nothing in `out_scan_dir` yet) always predicts — `_previous_identity_key` returns
    `None`.
+10. A re-run where the currently-resolved `ModelRef` for some root type differs from what
+    produced the existing outputs (registry/version/weights_checksum) re-predicts, not skips —
+    identity-key inputs include model refs, so this needs its own explicit test rather than
+    relying on the sidecar-change tests to imply it.
+11. A re-run where the existing `out_scan_dir/{scan_key}.predictions.json` is present but corrupt
+    (valid JSON, fails `PredictionManifest` validation) re-predicts (status `ok`, overwriting the
+    corrupt state), and is **not** recorded as a batch failure.
+12. A scan whose synthetic error `ScanInput` (manifest scan_key, no sidecar; `params=None`) never
+    reaches `resolve()` — regression guard for the ordering fix above.
 
 ## Open note (non-blocking)
 
 `compute_idempotency_key` is not in `sleap_roots_contracts.__all__` — it's imported from its
 submodule (`sleap_roots_contracts.identity`) rather than the package root. Worth flagging to the
 contracts maintainers as a candidate for a future `__all__` addition, but not blocking (submodule
-import is stable, already-shipped code).
+import is stable, already-shipped code; no other module in this repo currently reaches into a
+non-`__all__` contracts submodule, so this is a new-but-low-risk pattern here, capped by the exact
+version pin).

--- a/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
+++ b/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
@@ -1,0 +1,127 @@
+# Consuming RunManifest: scoped discovery + real idempotency-key skip-if-done
+
+## Context
+
+Part of `sleap-roots-pipeline` issue #37's cross-repo idempotency chain (see that repo's
+`docs/superpowers/specs/2026-08-03-manifest-scoped-processing-redesign.md`, the canonical design
+rationale). Two incidents motivate this:
+
+1. A leftover scan directory from a prior run got reprocessed by predict's directory-wide
+   `discover_scans` scan, even though it wasn't in the current run's scope.
+2. A stale prediction output blocked a corrected sidecar from propagating on a later run, because
+   `run_batch`'s skip-if-done is a plain `Path.exists()` check, not an identity comparison.
+
+`sleap-roots-contracts` 0.1.0a7 now ships `RunManifest` (written by `bloomctl` into the same
+shared, already-mounted staging directory as the per-scan `{scan_key}.scan_metadata.json`
+sidecars — a discoverable file, not a CLI arg, confirmed against this repo's and traits'
+`argparse` signatures, both fixed two-positional-arg entrypoints). This change makes
+`sleap-roots-predict` consume it.
+
+## Goals
+
+- `discover_scans` scopes to exactly `RunManifest.scan_keys` when a manifest is present.
+- `run_batch`'s skip-if-done compares a real identity key, not just file existence.
+- Preserve every existing behavior when no manifest is present (standalone/local/test usage).
+
+## Non-goals (explicitly out of scope)
+
+- `sleap-roots`/traits consuming the manifest (separate repo/handoff).
+- write-back's identical unscoped-glob bug (bloom #678, fixed in bloomcli).
+- Any change to `sleap-roots-contracts` (a schema addition to `PredictionManifest` would be the
+  "cleaner" long-term home for the stored key, but is a separate repo's PR).
+
+## Confirmed decisions (from clarifying questions)
+
+| Question | Decision |
+|---|---|
+| `run_manifest.json` absent from `input_dir` | Fall back to today's unscoped `rglob` — scoping only activates when a manifest is present. Keeps every existing test/local/standalone usage unchanged. |
+| Sidecar on disk, `scan_key` NOT in manifest | Silently excluded from discovery (no `ScanInput`, no `ScanResult`); a single debug-level log line reports the count skipped. |
+| Manifest `scan_key` with NO matching sidecar on disk | Isolated failure: a synthetic `ScanInput` with `.error` set (reuses the existing per-scan error → `ScanResult(status="failed")` path; batch continues). |
+| Idempotency-key derivation | Reuse `sleap_roots_contracts.identity.compute_idempotency_key` directly (present in the installed package, just not re-exported in `__all__`), passing `traits_code_sha=""` as a fixed placeholder — predict only ever compares against its own previously-stored key, never against a traits-computed one, so the placeholder just needs to be consistent across runs. Avoids a second hashing implementation (this program's own contracts docs warn a duplicate "would silently break first-writer-wins idempotency"). |
+| Malformed `run_manifest.json` (bad JSON / fails `RunManifest` validation) | Batch-level `ValueError`/`ValidationError`, not a per-scan failure — mirrors the existing duplicate-`scan_key` raise, since an invalid manifest means scope itself can't be trusted. |
+
+## Data flow
+
+```
+input_dir/
+├── run_manifest.json                 # RunManifest{schema_version, pipeline_run_id, scan_keys}
+├── scan_1009/
+│   ├── scan_1009.scan_metadata.json  # {scan_key, image_ids, images_checksum, params}
+│   └── frame_*.png
+└── scan_1010/  (leftover from a prior run, NOT in scan_keys -> excluded)
+    └── ...
+```
+
+`discover_scans`:
+1. Look for `input_dir / RUN_MANIFEST_FILENAME` (`"run_manifest.json"`, the constant imported
+   from contracts, not hardcoded).
+2. If present: `RunManifest.model_validate_json(...)` (raises on malformed content — batch-level
+   abort). Build the sidecar set as today (`rglob`, dup-`scan_key` check), but only keep sidecars
+   whose `scan_key ∈ manifest.scan_keys`; for any `scan_key` in the manifest with no discovered
+   sidecar, append a synthetic error `ScanInput` (`error="no sidecar found for manifest scan_key
+   {key!r}"`).
+3. If absent: unchanged — full unscoped `rglob`.
+
+`ScanInput` gains one field: `images_checksum: str = ""`, read from the sidecar's existing
+`images_checksum` key (already present in every sidecar fixture today, just previously ignored).
+
+`run_batch`'s per-scan loop, restructured:
+1. `refs = worker.resolve(scan.params)` — moved up from `_predict_one`; cheap (matches against
+   the already-listed `ModelCard`s, no network/download), safe to call before the skip decision.
+2. `current_key = compute_idempotency_key(scan_key=scan.scan_key, images_checksum=scan.images_checksum, models=[(r.registry_id, r.version, r.weights_checksum) for r in refs.values()], param_hash=scan.params.param_hash, predict_code_sha=resolved_code_sha, traits_code_sha="", predict_output_params=worker.output_params())`
+3. Compare against the stored key (read from a new predict-owned marker file, see below). Equal →
+   `skipped`. Different or absent → predict, write outputs, then write the new key.
+
+## Stored key: a predict-owned marker file, not a `PredictionManifest` field
+
+`PredictionManifest` (from `sleap-roots-contracts`) is a frozen pydantic model with no
+`idempotency_key`/`images_checksum` field, and extending it is a separate repo's contracts
+change — out of scope here. Instead, `write_prediction_outputs`'s existing artifacts get one
+sibling file, written **last** (after `{scan_key}.predictions.json`, mirroring the existing
+"sidecar-before-manifest" commit-marker ordering — the newest-written file is always the resume
+marker so a crash mid-write is safe to re-run):
+
+```
+<output_dir>/{scan_key}/{scan_key}.idempotency_key.json    # {"idempotency_key": "<sha256 hex>"}
+```
+
+This is purely predict's own internal resume bookkeeping — not part of any cross-repo contract,
+so its shape can change freely later (e.g. if `sleap-roots-contracts` eventually grows a real
+field for it).
+
+## Error handling summary
+
+- Malformed manifest → raises (batch-level, before any scan is touched).
+- Sidecar not in scope → excluded silently (debug log only).
+- Manifest scan_key with no sidecar → `ScanResult(status="failed")`, batch continues.
+- Zero models resolved → unchanged, still `failed` (check happens right after the moved-up
+  `resolve()` call).
+- Everything else (missing input_dir, duplicate scan_key, unreadable sidecar, missing params) →
+  unchanged.
+
+## Testing plan (TDD)
+
+New/changed tests in `tests/test_batch.py` (or a new `tests/test_run_manifest.py` if it reads
+cleaner split out):
+
+1. `discover_scans` scopes to `run_manifest.json`'s `scan_keys` when present; an extra sidecar
+   outside scope is excluded (not returned, not an error).
+2. `discover_scans` falls back to unscoped `rglob` when no manifest is present (regression guard
+   for every existing test/fixture).
+3. A manifest `scan_key` with no matching sidecar becomes a `failed` `ScanResult`.
+4. A malformed `run_manifest.json` raises before any scan is processed.
+5. `run_batch` re-run with an unchanged scan (same sidecar, same models, same
+   `predict_code_sha`) skips via key match (replaces/extends
+   `test_rerun_skips_completed_scan`).
+6. `run_batch` re-run with a **changed** sidecar (different `params` → different `param_hash`, or
+   different `images_checksum`) **re-predicts** rather than skipping — the actual incident-2 fix.
+7. `run_batch` re-run with a different `SRP_PREDICT_CODE_SHA` re-predicts.
+8. `pyproject.toml` bumped to `sleap-roots-contracts==0.1.0a7`; full existing suite still green
+   (regression gate for the version bump itself).
+
+## Open note (non-blocking)
+
+`compute_idempotency_key` is not in `sleap_roots_contracts.__all__` — it's imported from its
+submodule (`sleap_roots_contracts.identity`) rather than the package root. Worth flagging to the
+contracts maintainers as a candidate for a future `__all__` addition, but not blocking (submodule
+import is stable, already-shipped code).

--- a/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
+++ b/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
@@ -27,8 +27,9 @@ sidecars — a discoverable file, not a CLI arg, confirmed against this repo's a
 
 - `sleap-roots`/traits consuming the manifest (separate repo/handoff).
 - write-back's identical unscoped-glob bug (bloom #678, fixed in bloomcli).
-- Any change to `sleap-roots-contracts` (a schema addition to `PredictionManifest` would be the
-  "cleaner" long-term home for the stored key, but is a separate repo's PR).
+- Any change to `sleap-roots-contracts`. Not needed: every input the idempotency key requires is
+  already recoverable from artifacts predict already writes (see below) — no schema addition
+  earns its keep here.
 
 ## Confirmed decisions (from clarifying questions)
 
@@ -68,26 +69,36 @@ input_dir/
 `run_batch`'s per-scan loop, restructured:
 1. `refs = worker.resolve(scan.params)` — moved up from `_predict_one`; cheap (matches against
    the already-listed `ModelCard`s, no network/download), safe to call before the skip decision.
-2. `current_key = compute_idempotency_key(scan_key=scan.scan_key, images_checksum=scan.images_checksum, models=[(r.registry_id, r.version, r.weights_checksum) for r in refs.values()], param_hash=scan.params.param_hash, predict_code_sha=resolved_code_sha, traits_code_sha="", predict_output_params=worker.output_params())`
-3. Compare against the stored key (read from a new predict-owned marker file, see below). Equal →
-   `skipped`. Different or absent → predict, write outputs, then write the new key.
+2. `current_key = _identity_key(scan_key, images_checksum=scan.images_checksum, refs, param_hash=scan.params.param_hash, predict_code_sha=resolved_code_sha, output_params=worker.output_params())` —
+   a thin wrapper around `compute_idempotency_key` (see below).
+3. `previous_key = _stored_identity_key(out_scan_dir, scan.scan_key)` — `None` if nothing usable
+   is on disk yet (see below).
+4. `previous_key == current_key` → `skipped`. Otherwise (differs, or `None`) → predict, write
+   outputs as today.
 
-## Stored key: a predict-owned marker file, not a `PredictionManifest` field
+## No new storage — recompute both sides from artifacts predict already writes
 
-`PredictionManifest` (from `sleap-roots-contracts`) is a frozen pydantic model with no
-`idempotency_key`/`images_checksum` field, and extending it is a separate repo's contracts
-change — out of scope here. Instead, `write_prediction_outputs`'s existing artifacts get one
-sibling file, written **last** (after `{scan_key}.predictions.json`, mirroring the existing
-"sidecar-before-manifest" commit-marker ordering — the newest-written file is always the resume
-marker so a crash mid-write is safe to re-run):
+`PredictionManifest` (from `sleap-roots-contracts`) has no `idempotency_key`/`param_hash` field,
+and extending it would be a separate repo's contracts PR. It doesn't need to be: everything
+`compute_idempotency_key` needs for the *previous* run is already sitting in `out_scan_dir` from
+that run, because `write_prediction_outputs` writes the manifest and `run_batch` copies the
+sidecar verbatim:
 
-```
-<output_dir>/{scan_key}/{scan_key}.idempotency_key.json    # {"idempotency_key": "<sha256 hex>"}
-```
+| Input | Recovered from |
+|---|---|
+| `scan_key` | the scan itself (identical either way) |
+| `images_checksum` | `out_scan_dir/{scan_key}.scan_metadata.json`'s `images_checksum` (the previously-copied sidecar, byte-identical to what was actually used) |
+| `param_hash` | recomputed via `compute_param_hash` over that same old sidecar's `params` — pure function, so this reproduces the exact value used at write time |
+| `models` | `out_scan_dir/{scan_key}.predictions.json`'s `artifacts[].model` (the `ModelRef`s actually used) |
+| `predict_code_sha` / `predict_output_params` | the same manifest's `predict_code_sha` / `predict_output_params` fields |
 
-This is purely predict's own internal resume bookkeeping — not part of any cross-repo contract,
-so its shape can change freely later (e.g. if `sleap-roots-contracts` eventually grows a real
-field for it).
+So `_stored_identity_key(out_scan_dir, scan_key)` just reads those two existing files (returning
+`None` if either is missing/unreadable — e.g. a first run, or a crash left a partial write — which
+naturally falls through to "re-run," matching the existing "prefer re-run over serving stale/
+incomplete data" philosophy already baked into the sidecar-before-manifest ordering) and calls the
+same `compute_idempotency_key` used for the current side. No new file, no contracts change, and
+the exact same trick is available to traits later (it reads the identical two files plus its own
+`traits_code_sha`).
 
 ## Error handling summary
 
@@ -96,6 +107,9 @@ field for it).
 - Manifest scan_key with no sidecar → `ScanResult(status="failed")`, batch continues.
 - Zero models resolved → unchanged, still `failed` (check happens right after the moved-up
   `resolve()` call).
+- No previous manifest/sidecar on disk yet, or either is unreadable → `previous_key = None` →
+  treated as changed → predict runs (first run, or a prior crash mid-write; never silently
+  skips on ambiguous state).
 - Everything else (missing input_dir, duplicate scan_key, unreadable sidecar, missing params) →
   unchanged.
 
@@ -118,6 +132,8 @@ cleaner split out):
 7. `run_batch` re-run with a different `SRP_PREDICT_CODE_SHA` re-predicts.
 8. `pyproject.toml` bumped to `sleap-roots-contracts==0.1.0a7`; full existing suite still green
    (regression gate for the version bump itself).
+9. A first run (nothing in `out_scan_dir` yet) always predicts — `_stored_identity_key` returns
+   `None`.
 
 ## Open note (non-blocking)
 

--- a/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
+++ b/docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md
@@ -135,7 +135,7 @@ sidecar verbatim:
 
 So `_previous_identity_key(out_scan_dir, scan_key)` just reads those two existing files (returning
 `None` if either is missing/unreadable — e.g. a first run, a crash left a partial write, or the
-old files are present but corrupt/unparseable, see the ordering section above — which naturally
+old files are present but corrupt/unparsable, see the ordering section above — which naturally
 falls through to "re-run," matching the existing "prefer re-run over serving stale/incomplete
 data" philosophy already baked into the sidecar-before-manifest ordering) and calls the same
 `compute_idempotency_key` used for the current side. No new file, no contracts change, and the
@@ -152,7 +152,7 @@ exact same trick is available to traits later (it reads the identical two files 
 - Zero models resolved, or any other exception inside the widened per-scan `try/except` (e.g. an
   ambiguous-match `ValueError` from `choose_models`) → `failed`, batch continues — unchanged
   guarantee, now covering a slightly larger block (see the ordering section above).
-- Previous manifest/sidecar missing, unreadable, *or corrupt/unparseable* → `_previous_identity_key`
+- Previous manifest/sidecar missing, unreadable, *or corrupt/unparsable* → `_previous_identity_key`
   catches this internally and returns `None` → treated as changed → predict runs (never silently
   skips on ambiguous state, and never recorded as `failed` for a *previous*-side problem).
 - Everything else (missing input_dir, duplicate scan_key, unreadable sidecar, missing params) →

--- a/openspec/changes/consume-run-manifest/proposal.md
+++ b/openspec/changes/consume-run-manifest/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`sleap-roots-pipeline` issue #37 documents two contamination/staleness incidents from PR #33's
+testing: (1) a leftover scan directory from a prior run got reprocessed by predict's
+directory-wide `discover_scans` scan even though it wasn't in the current run's scope, and (2) a
+corrected sidecar failed to propagate on a later run because `run_batch`'s skip-if-done is a
+plain `Path.exists()` check, not an identity comparison. `sleap-roots-contracts` 0.1.0a7 now ships
+`RunManifest` (written by `bloomctl` into the same shared, already-mounted staging directory as
+the per-scan sidecars) specifically to close incident (1); the design doc for this change
+(`docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md`) also closes incident (2)
+using data predict already has on disk, no new storage or contracts change required.
+
+## What Changes
+
+- Bump `sleap-roots-contracts` pin from `==0.1.0a6` to `==0.1.0a7` in `pyproject.toml` (relock
+  scoped to that dependency); `RunManifest` doesn't exist before `a7`.
+- `discover_scans` reads an optional `run_manifest.json` (`RunManifest`: `schema_version`,
+  `pipeline_run_id`, `scan_keys`; fixed filename via the imported `RUN_MANIFEST_FILENAME`
+  constant) from `input_dir`:
+  - **Present**: scope discovery to exactly `scan_keys`. A sidecar on disk whose `scan_key` is
+    not in that set is silently excluded (not discovered, not reported — the contamination case
+    this change fixes). A `scan_key` in the manifest with no matching sidecar on disk becomes an
+    isolated failed scan (reuses the existing `ScanInput.error` → `ScanResult(status="failed")`
+    path; the batch continues).
+  - **Absent**: unchanged — full unscoped `rglob`, exactly today's behavior. Every existing
+    local/standalone/test caller that doesn't stage a manifest is unaffected.
+  - **Malformed** (present but invalid JSON / fails `RunManifest` validation): raises, a
+    batch-level abort before any scan is touched — mirrors the existing duplicate-`scan_key`
+    raise, since scope itself can't be trusted.
+- `run_batch`'s skip-if-done becomes a real identity comparison instead of `Path.exists()`.
+  `worker.resolve(scan.params)` moves up from inside `_predict_one` (cheap — matches against
+  already-listed `ModelCard`s, no network/download) so the resolved `ModelRef`s are available
+  before the skip decision. The "current" and "previous" idempotency keys are both derived via
+  `sleap_roots_contracts.identity.compute_idempotency_key` (imported directly — present in the
+  installed package, not re-exported in `__all__`, `traits_code_sha=""` fixed placeholder since
+  predict never owns that value and only ever compares against its own prior key). The "previous"
+  key needs **no new storage anywhere**: every input is already recoverable from the
+  already-copied sidecar (`images_checksum`, and `params` to recompute `param_hash`) and the
+  already-written `{scan_key}.predictions.json` (`artifacts[].model`, `predict_code_sha`,
+  `predict_output_params`) sitting in `out_scan_dir` from the prior run. Missing or unreadable
+  prior artifacts (first run, or a crash mid-write) yield no previous key, which is treated as
+  "changed" — the scan is (re)predicted rather than silently skipped on ambiguous state.
+
+## Impact
+
+- Affected specs: `predict-container` (MODIFIED: scan discovery; RENAMED + MODIFIED:
+  skip-if-exists resume → skip-if-done resume, idempotency-key verified)
+- Affected code: `pyproject.toml`, `uv.lock`, `sleap_roots_predict/batch.py`,
+  `tests/test_batch.py`
+- No behavior change for any caller that never stages a `run_manifest.json` (the entire existing
+  test suite and any standalone/local usage) — scoping and the stricter skip-if-done comparison
+  only activate what a manifest and a changed identity actually require; an unchanged re-run
+  still skips exactly as before.
+- Out of scope (tracked separately): `sleap-roots`/traits consuming the manifest (separate
+  repo/handoff); write-back's identical unscoped-glob bug (bloom #678, fixed in `bloomcli`); any
+  change to `sleap-roots-contracts` (not needed — see design doc).
+- Resolves the `sleap-roots-predict` row of `sleap-roots-pipeline`#37's cross-repo idempotency
+  chain (design doc: that repo's
+  `docs/superpowers/specs/2026-08-03-manifest-scoped-processing-redesign.md`).

--- a/openspec/changes/consume-run-manifest/proposal.md
+++ b/openspec/changes/consume-run-manifest/proposal.md
@@ -38,7 +38,7 @@ using data predict already has on disk, no new storage or contracts change requi
   already-copied sidecar (`images_checksum`, and `params` to recompute `param_hash`) and the
   already-written `{scan_key}.predictions.json` (`artifacts[].model`, `predict_code_sha`,
   `predict_output_params`) sitting in `out_scan_dir` from the prior run. Missing, unreadable, or
-  corrupt/unparseable prior artifacts (first run, a crash mid-write, or a hand-corrupted leftover)
+  corrupt/unparsable prior artifacts (first run, a crash mid-write, or a hand-corrupted leftover)
   yield no previous key, which is treated as "changed" — the scan is (re)predicted rather than
   silently skipped on ambiguous state or recorded as a batch failure. The existing `scan.error`
   check (invalid sidecar, stem mismatch, or a manifest scan_key with no sidecar) still runs first,

--- a/openspec/changes/consume-run-manifest/proposal.md
+++ b/openspec/changes/consume-run-manifest/proposal.md
@@ -37,20 +37,31 @@ using data predict already has on disk, no new storage or contracts change requi
   key needs **no new storage anywhere**: every input is already recoverable from the
   already-copied sidecar (`images_checksum`, and `params` to recompute `param_hash`) and the
   already-written `{scan_key}.predictions.json` (`artifacts[].model`, `predict_code_sha`,
-  `predict_output_params`) sitting in `out_scan_dir` from the prior run. Missing or unreadable
-  prior artifacts (first run, or a crash mid-write) yield no previous key, which is treated as
-  "changed" — the scan is (re)predicted rather than silently skipped on ambiguous state.
+  `predict_output_params`) sitting in `out_scan_dir` from the prior run. Missing, unreadable, or
+  corrupt/unparseable prior artifacts (first run, a crash mid-write, or a hand-corrupted leftover)
+  yield no previous key, which is treated as "changed" — the scan is (re)predicted rather than
+  silently skipped on ambiguous state or recorded as a batch failure. The existing `scan.error`
+  check (invalid sidecar, stem mismatch, or a manifest scan_key with no sidecar) still runs first,
+  before `resolve()` is ever called, and the resolve-plus-key-comparison logic lives inside the
+  existing per-scan `try/except`, preserving today's "one bad scan doesn't abort the batch"
+  guarantee for failure modes that can now surface earlier (an ambiguous model match, a corrupt
+  leftover manifest).
+- **Accepted trade-off**: `resolve()` (and its one-time model-registry `list_cards()` fetch) now
+  runs once per `run_batch()` invocation even when every scan is already done and will be
+  skipped — previously a fully-resumed batch touched the registry zero times. This is inherent to
+  comparing model identity correctly (there's no way to know if models changed without listing
+  them), not a design flaw; see the design doc for the full reasoning.
 
 ## Impact
 
 - Affected specs: `predict-container` (MODIFIED: scan discovery; RENAMED + MODIFIED:
   skip-if-exists resume → skip-if-done resume, idempotency-key verified)
 - Affected code: `pyproject.toml`, `uv.lock`, `sleap_roots_predict/batch.py`,
-  `tests/test_batch.py`
+  `tests/test_batch.py`, `CHANGELOG.md`, `README.md`, `API.md`, `openspec/project.md`
 - No behavior change for any caller that never stages a `run_manifest.json` (the entire existing
   test suite and any standalone/local usage) — scoping and the stricter skip-if-done comparison
   only activate what a manifest and a changed identity actually require; an unchanged re-run
-  still skips exactly as before.
+  still skips exactly as before, aside from the accepted `resolve()`-cost trade-off noted above.
 - Out of scope (tracked separately): `sleap-roots`/traits consuming the manifest (separate
   repo/handoff); write-back's identical unscoped-glob bug (bloom #678, fixed in `bloomcli`); any
   change to `sleap-roots-contracts` (not needed — see design doc).

--- a/openspec/changes/consume-run-manifest/specs/predict-container/spec.md
+++ b/openspec/changes/consume-run-manifest/specs/predict-container/spec.md
@@ -103,9 +103,13 @@ against its own previously-derived key, never against a traits-computed one). Th
 SHALL require no storage beyond what the runner already writes: `images_checksum` and `params`
 (to recompute `param_hash`) come from the already-copied `{scan_key}.scan_metadata.json` sidecar
 in `out_scan_dir`, and the resolved models, `predict_code_sha`, and `predict_output_params` come
-from the already-written `{scan_key}.predictions.json` there. When either prior file is missing
-or unreadable (a first run, or a crash left a partial write), no previous key exists, and the
-scan SHALL be (re)predicted rather than skipped.
+from the already-written `{scan_key}.predictions.json` there. When either prior file is missing,
+unreadable, or present but corrupt/fails to parse (e.g. invalid JSON or schema-invalid content),
+no previous key exists, and the scan SHALL be (re)predicted rather than skipped or recorded as a
+failure. A scan already recorded as failed for another reason (an invalid sidecar, a scan_key/stem
+mismatch, or a manifest scan_key with no matching sidecar) SHALL NOT reach model resolution or key
+computation at all — that isolation check SHALL run first, unchanged from before this
+idempotency-key comparison existed.
 
 #### Scenario: An unchanged scan is skipped on re-run
 
@@ -133,3 +137,24 @@ scan SHALL be (re)predicted rather than skipped.
 - **WHEN** `out_scan_dir` for a scan has no prior `{scan_key}.scan_metadata.json` or
   `{scan_key}.predictions.json` (nothing written yet)
 - **THEN** the scan is predicted (no previous key exists to compare against)
+
+#### Scenario: A changed resolved model causes a re-predict rather than a skip
+
+- **WHEN** a scan already has completed outputs, but the currently-resolved `ModelRef` for some
+  root type (`registry_id`/`version`/`weights_checksum`) differs from the one recorded in its
+  existing `{scan_key}.predictions.json`
+- **THEN** the scan is re-predicted (status `ok`), not skipped
+
+#### Scenario: Corrupt previous artifacts cause a re-predict, not a recorded failure
+
+- **WHEN** a scan's existing `{scan_key}.predictions.json` is present but fails to parse or
+  validate (e.g. hand-corrupted, or written by an incompatible schema)
+- **THEN** no previous key is derived, the scan is (re)predicted (status `ok`, overwriting the
+  corrupt state), and it is NOT recorded as a batch failure
+
+#### Scenario: A scan already recorded as failed never reaches model resolution
+
+- **WHEN** a scan has `.error` set (an invalid sidecar, a scan_key/stem mismatch, or a manifest
+  scan_key with no matching sidecar)
+- **THEN** the scan is recorded as failed without `resolve()` or any identity-key computation
+  ever running for it

--- a/openspec/changes/consume-run-manifest/specs/predict-container/spec.md
+++ b/openspec/changes/consume-run-manifest/specs/predict-container/spec.md
@@ -1,0 +1,135 @@
+## RENAMED Requirements
+- FROM: `### Requirement: Skip-if-exists resume`
+- TO: `### Requirement: Skip-if-done resume (idempotency-key verified)`
+
+## MODIFIED Requirements
+
+### Requirement: Scan discovery and params from the scan-metadata sidecar
+
+The runner SHALL discover scans by recursively globbing `*.scan_metadata.json` under the input
+directory. Each scan's image frames and its sidecar SHALL reside together in a **single
+dedicated directory** (the sidecar co-located with the frames it describes); the directory's
+name is not significant — the `scan_key` SHALL be the sidecar's filename stem and SHALL equal
+the sidecar's internal `scan_key` field. Multiple scans SHALL reside in **separate**
+directories (a single-scan input is the degenerate case of one directory). A scan's frames are
+the image files co-located with the sidecar, matched by extension
+(`.png/.tif/.tiff/.jpg/.jpeg`) **case-insensitively**; any non-image file in that directory
+(including the sidecar itself) SHALL be ignored. The scan's `ResolvedParams` SHALL be built
+directly from the sidecar's normalized `params` object (`{species, mode, age}`) — the
+container does not call `resolve_params` (which runs upstream) and SHALL NOT import the
+`trait_extractor` package. Two sidecars resolving to the same `scan_key` anywhere in the tree
+SHALL be rejected.
+
+If a `RunManifest` (`sleap-roots-contracts`; fixed filename `RUN_MANIFEST_FILENAME`,
+`"run_manifest.json"`) is present directly under the input directory, discovery SHALL be scoped
+to exactly its `scan_keys`: a discovered sidecar whose `scan_key` is not in that set SHALL be
+silently excluded (not returned, not recorded as an error — a leftover from a prior run is not
+this run's concern), and a `scan_key` listed in the manifest with no matching sidecar anywhere
+under the input directory SHALL be recorded as a failed scan (isolated, batch continues) rather
+than silently omitted. If no `run_manifest.json` is present, discovery SHALL fall back to the
+unscoped behavior described above (every sidecar found is discovered), unchanged from before this
+manifest-awareness existed. A `run_manifest.json` that is present but fails to parse or validate
+as a `RunManifest` SHALL raise (a batch-level error surfaced before any scan is processed), since
+scope cannot be trusted from an invalid manifest.
+
+#### Scenario: Discovers a scan and resolves its params
+
+- **WHEN** a directory holds image frames and a co-located `{scan_key}.scan_metadata.json` with
+  `params={"species":"rice","mode":"cylinder","age":3}`
+- **THEN** discovery yields that scan with `scan_key`, its frame paths, and a `ResolvedParams`
+  carrying `species=rice`, `mode=cylinder`, `age=3`
+
+#### Scenario: Non-image files are ignored as frames
+
+- **WHEN** a scan directory contains image frames alongside non-image files (e.g. a stray
+  `.txt` and the `.scan_metadata.json` sidecar itself)
+- **THEN** only the image files are collected as frames; the non-image files are not ingested
+
+#### Scenario: Sidecar stem must match its scan_key
+
+- **WHEN** a `{stem}.scan_metadata.json` whose internal `scan_key` differs from `stem` is
+  discovered
+- **THEN** that scan is recorded as failed (not silently mis-keyed) and the batch continues
+
+#### Scenario: A sidecar with missing or incomplete params fails only that scan
+
+- **WHEN** a discovered sidecar has no `params` object, or `params` lacking a required field
+  (`species`/`mode`/`age`)
+- **THEN** that scan is recorded as failed and the batch continues (other scans still written)
+
+#### Scenario: Duplicate scan_key across the tree is rejected
+
+- **WHEN** two `*.scan_metadata.json` files anywhere under the input directory share a
+  `scan_key`
+- **THEN** the runner raises rather than silently overwriting a scan's output
+
+#### Scenario: Discovery is scoped to a present RunManifest's scan_keys
+
+- **WHEN** `run_manifest.json` under the input directory lists `scan_keys=["scan_1009"]`, and
+  the input directory also contains a leftover `scan_1010/` sidecar from a prior run
+- **THEN** discovery returns only `scan_1009`; `scan_1010` is neither discovered nor reported as
+  an error
+
+#### Scenario: A manifest scan_key with no matching sidecar fails only that scan
+
+- **WHEN** `run_manifest.json` lists a `scan_key` for which no `*.scan_metadata.json` exists
+  anywhere under the input directory
+- **THEN** that scan is recorded as failed (isolated; the batch continues for scans that do have
+  a sidecar)
+
+#### Scenario: No manifest present falls back to unscoped discovery
+
+- **WHEN** the input directory contains sidecars but no `run_manifest.json`
+- **THEN** discovery behaves exactly as it did before manifest-awareness existed — every
+  discovered sidecar is returned, none excluded
+
+#### Scenario: A malformed manifest raises before any scan is processed
+
+- **WHEN** `run_manifest.json` is present but is invalid JSON, or fails `RunManifest` validation
+  (e.g. an empty `scan_keys` list)
+- **THEN** `discover_scans` raises and no scan is processed
+
+### Requirement: Skip-if-done resume (idempotency-key verified)
+
+The runner SHALL skip a scan only when its previously-written outputs are still identical in
+effect to what predicting it now would produce, rather than merely checking that
+`<output_dir>/{scan_key}/{scan_key}.predictions.json` exists. Both the current scan's identity
+key and the previously-recorded identity key SHALL be derived via
+`sleap_roots_contracts.identity.compute_idempotency_key`, over: `scan_key`, `images_checksum`,
+the resolved `ModelRef`s (`registry_id`, `version`, `weights_checksum`), the params'
+`param_hash`, `predict_code_sha`, and `predict_output_params`; `traits_code_sha` SHALL be passed
+as a fixed empty-string placeholder (the runner never owns that value and only ever compares
+against its own previously-derived key, never against a traits-computed one). The previous key
+SHALL require no storage beyond what the runner already writes: `images_checksum` and `params`
+(to recompute `param_hash`) come from the already-copied `{scan_key}.scan_metadata.json` sidecar
+in `out_scan_dir`, and the resolved models, `predict_code_sha`, and `predict_output_params` come
+from the already-written `{scan_key}.predictions.json` there. When either prior file is missing
+or unreadable (a first run, or a crash left a partial write), no previous key exists, and the
+scan SHALL be (re)predicted rather than skipped.
+
+#### Scenario: An unchanged scan is skipped on re-run
+
+- **WHEN** `run_batch` runs a second time over an output directory that already holds a
+  completed scan, with the same sidecar (same `images_checksum`/`params`), the same resolved
+  models, and the same `predict_code_sha` as the run that produced it
+- **THEN** that scan is skipped (status `skipped`, not re-predicted) while any scan without a
+  matching previous key is still predicted
+
+#### Scenario: A changed sidecar causes a re-predict rather than a skip
+
+- **WHEN** a scan already has completed outputs, but its current sidecar's `params` (hence
+  `param_hash`) or `images_checksum` differs from what produced those outputs
+- **THEN** the scan is re-predicted (status `ok`), not skipped, and its outputs are overwritten
+
+#### Scenario: A changed predict_code_sha causes a re-predict rather than a skip
+
+- **WHEN** a scan already has completed outputs, but the current run's `predict_code_sha` (e.g.
+  `SRP_PREDICT_CODE_SHA`) differs from the one recorded in its existing
+  `{scan_key}.predictions.json`
+- **THEN** the scan is re-predicted (status `ok`), not skipped
+
+#### Scenario: A first run always predicts
+
+- **WHEN** `out_scan_dir` for a scan has no prior `{scan_key}.scan_metadata.json` or
+  `{scan_key}.predictions.json` (nothing written yet)
+- **THEN** the scan is predicted (no previous key exists to compare against)

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -28,11 +28,11 @@ it, per the design doc's data-flow section.
       today (every sidecar found, none excluded) — a regression guard, not new behavior; existing
       fixtures/tests should need no changes to keep passing.
 - [ ] 2.3 Test: a manifest `scan_key` with no matching sidecar anywhere under the input directory
-      becomes a `ScanInput` with `.error` set (reuses the existing error → `ScanResult(status=
-      "failed")` path — verify via `run_batch`, not just `discover_scans`, since that's where the
-      status actually surfaces). Implement: after building the scoped+discovered set, compute
-      `manifest.scan_keys - {discovered scan_keys}` and append a synthetic errored `ScanInput` per
-      missing key.
+      becomes a `ScanInput` with `.error` set and `params=None` (reuses the existing error →
+      `ScanResult(status="failed")` path — verify via `run_batch`, not just `discover_scans`,
+      since that's where the status actually surfaces). Implement: after building the
+      scoped+discovered set, compute `manifest.scan_keys - {discovered scan_keys}` and append a
+      synthetic errored `ScanInput` per missing key.
 - [ ] 2.4 Test: a malformed `run_manifest.json` (invalid JSON, or valid JSON failing `RunManifest`
       validation, e.g. empty `scan_keys`) raises from `discover_scans` before any scan is
       returned/processed.
@@ -41,17 +41,30 @@ it, per the design doc's data-flow section.
 
 ## 3. Idempotency-key skip-if-done (TDD)
 
+**Land 3.1–3.9 as a single commit.** Tests 3.3–3.7 assert key-based skip/re-predict behavior that
+doesn't exist until 3.8's loop restructuring lands — committing them separately would leave an
+intermediate commit red, unlike group 2 (whose tests are independently satisfiable one at a time).
+
 - [ ] 3.1 Add `images_checksum: str = ""` to `ScanInput`, populated in `_load_scan` from
-      `meta.get("images_checksum", "")` (no test needed standalone — covered by 3.3's fixtures
-      already carrying `images_checksum`, and by the identity-key tests below).
-- [ ] 3.2 Write a small helper (private to `batch.py`) that derives the identity key from
-      arbitrary `(images_checksum, params_dict, model_refs, predict_code_sha,
-      predict_output_params)` via `compute_idempotency_key(..., traits_code_sha="")`, and a
-      second helper `_previous_identity_key(out_scan_dir, scan_key)` that reads back
-      `{scan_key}.scan_metadata.json` + `{scan_key}.predictions.json` from `out_scan_dir` (via the
-      first helper) and returns `None` if either file is missing/unreadable. Unit-test both
-      helpers directly first (pure functions / simple file reads — fastest feedback), before
-      wiring them into `run_batch`.
+      `meta.get("images_checksum", "")`.
+- [ ] 3.2 Write two small helpers, private to `batch.py`:
+      - `_identity_key(*, scan_key, images_checksum, params_dict, model_refs, predict_code_sha,
+        predict_output_params)` — converts `model_refs` (a `dict[RootType, ModelRef]` or
+        iterable of `ModelRef`) to the `list[tuple[registry_id, version, weights_checksum]]` shape
+        `compute_idempotency_key` expects, recomputes `param_hash` via `compute_param_hash
+        (params_dict)`, and calls `compute_idempotency_key(..., traits_code_sha="")`.
+      - `_previous_identity_key(out_scan_dir, scan_key)` — reads back
+        `{scan_key}.scan_metadata.json` + `{scan_key}.predictions.json` from `out_scan_dir` and
+        calls `_identity_key` with their contents. **Must internally catch `OSError`,
+        `json.JSONDecodeError`, and `pydantic.ValidationError`** (missing file, unreadable file,
+        or present-but-corrupt/schema-invalid content) and return `None` in every one of those
+        cases — this is a deliberate design choice (see design doc's ordering section), not
+        reliance on the outer per-scan `try/except` added in 3.8, because a corrupt *previous*
+        artifact must be treated as "changed → re-predict," not as a scan failure.
+      Unit-test both helpers directly first (pure function / simple file reads — fastest
+      feedback), including a case where `_previous_identity_key` is pointed at a directory with a
+      hand-corrupted `{scan_key}.predictions.json` (valid JSON, invalid schema) and confirmed to
+      return `None` rather than raising.
 - [ ] 3.3 Test: `test_rerun_skips_completed_scan` (existing) still passes essentially unchanged —
       an unchanged re-run (same sidecar, same models, same `predict_code_sha`) skips via key
       match, not just `Path.exists()`. Update its assertions/setup only as needed to reflect that
@@ -65,14 +78,33 @@ it, per the design doc's data-flow section.
       `run_batch` calls → re-predicted, not skipped.
 - [ ] 3.7 Test (new): a scan with no prior `out_scan_dir` contents at all (first run) always
       predicts — `_previous_identity_key` returns `None`, never raises.
-- [ ] 3.8 Implement the `run_batch` loop restructuring: move `refs = worker.resolve(scan.params)`
-      up before the skip decision (ahead of `_predict_one`); compute `current_key` and
-      `previous_key` via 3.2's helpers; skip iff both exist and are equal; otherwise call
-      `_predict_one` (passing `refs` through so it isn't re-resolved) and let it write outputs as
-      today. Remove the old `manifest_path.exists()` check entirely.
-- [ ] 3.9 Run `pytest tests/test_batch.py` in full and confirm green, including every pre-existing
-      test (e.g. `test_resume_mixed_skip_and_predict`, `test_run_batch_writes_outputs_and_copies_
-      sidecar`) with no regressions.
+- [ ] 3.7a Test (new): re-run against a `source` whose card for the same scan resolves to a
+      different `registry_id`/`version`/`weights_checksum` than the previous run → re-predicted,
+      not skipped (identity-key inputs include model refs; no other test exercises this input).
+- [ ] 3.7b Test (new): re-run where the existing `{scan_key}.predictions.json` is present but
+      hand-corrupted (valid JSON, fails `PredictionManifest` validation) → the scan is
+      re-predicted (`status="ok"`), and — critically — is NOT recorded as `failed`; assert on
+      `BatchResult.scans` directly, not just that a new manifest was written.
+- [ ] 3.7c Test (new): a manifest `scan_key` with no sidecar (2.3's synthetic error `ScanInput`,
+      `params=None`) is recorded `failed` via `run_batch` without raising — regression guard
+      confirming the `scan.error` check still runs before `resolve()` (a naive "move resolve() up"
+      implementation would call `resolve(None)` and raise `AttributeError` inside `choose_models`
+      instead of isolating this as a per-scan failure).
+- [ ] 3.8 Implement the `run_batch` loop restructuring, in this exact order per scan:
+      1. Check `scan.error is not None` first, unchanged from today — record `failed` and
+         `continue` before anything else runs.
+      2. Wrap everything else in the existing per-scan `try/except Exception` (widened to cover
+         more than just `_predict_one`): `refs = worker.resolve(scan.params)`, then
+         `current_key = _identity_key(...)`, then `previous_key =
+         _previous_identity_key(out_scan_dir, scan.scan_key)`, then compare.
+      3. `previous_key is not None and previous_key == current_key` → record `skipped`,
+         `continue`. Otherwise → call `_predict_one` (passing `refs` through so it isn't
+         re-resolved) and let it write outputs as today.
+      Remove the old `manifest_path.exists()` check entirely.
+- [ ] 3.9 Run `pytest tests/test_batch.py` in full and confirm green, with special attention to
+      the tests most at risk from this restructuring: `test_zero_resolved_models_is_failed`,
+      `test_one_failing_scan_does_not_abort_batch`, `test_sidecar_copy_failure_leaves_no_manifest`,
+      and `test_resume_mixed_skip_and_predict` — all must stay green with no behavior change.
 
 ## 4. OpenSpec validation gate
 
@@ -81,16 +113,31 @@ it, per the design doc's data-flow section.
 ## 5. Docs
 
 - [ ] 5.1 Update `CHANGELOG.md`'s `[Unreleased]` "Predict container CLI" bullet in place: replace
-      "skips-if-done (existence-based resume)" with a sentence describing manifest-scoped
-      discovery (`RunManifest`, `sleap-roots-contracts==0.1.0a7`) and idempotency-key-verified
-      skip-if-done (recomputed from already-written artifacts, no new storage).
+      "skips-if-done (existence-based resume)" with: "and per scan, when a `run_manifest.json`
+      (`RunManifest`, `sleap-roots-contracts==0.1.0a7`) is staged in `input_dir`, scopes discovery
+      to exactly its `scan_keys` (an out-of-scope sidecar is silently excluded); skip-if-done now
+      compares a recomputed idempotency key (`compute_idempotency_key`) against the prior run's
+      own artifacts, skipping only on an exact match and otherwise (re)predicting — no new
+      storage." Note the accepted trade-off (resolve() now runs once per batch even on a full
+      resume) in a short follow-up sentence.
 - [ ] 5.2 Update `API.md`'s `run_batch` prose ("skips if the manifest already exists (resume)")
       to describe the idempotency-key comparison and manifest-scoped discovery, matching the
-      CHANGELOG wording.
-- [ ] 5.3 Update `openspec/project.md`'s External Dependencies `sleap-roots-contracts` version
-      literal (`==0.1.0a6` → `==0.1.0a7`) and, if useful, note `RunManifest`/
-      `compute_idempotency_key` alongside the existing enumerated type list.
+      CHANGELOG wording from 5.1.
+- [ ] 5.3 Update `README.md`'s "Running the predict container" section (~line 211, "It skips a
+      scan whose manifest already exists (resume)...") with the same replacement wording as 5.1,
+      and add a sentence noting `run_manifest.json`-scoped discovery when the operator's pipeline
+      stages one.
+- [ ] 5.4 Update `openspec/project.md`: the External Dependencies `sleap-roots-contracts` version
+      literal (`==0.1.0a6` → `==0.1.0a7`), and the Roadmap note at the top of the file to credit
+      this change with closing the `sleap-roots-predict` row of `sleap-roots-pipeline#37`,
+      parallel to the existing `#15` credit for the parity harness.
+- [ ] 5.5 Grep sweep: search `README.md`, `API.md`, `CHANGELOG.md`, `openspec/project.md` for
+      `skip|manifest|exists|resume` and confirm no stale existence-based-resume phrasing survives
+      anywhere (mirrors the precedent PR's closing sweep task).
 
 ## 6. Pre-merge gate
 
-- [ ] 6.1 Full `/pre-merge` gate (format, lint, test, build) before opening the PR.
+- [ ] 6.1 Full `/pre-merge` gate (format, lint, test, build) before opening the PR. Confirm the
+      pytest invocation matches `ci.yml`'s exact marker expression (`-m "not gpu and not
+      acceptance and not wandb"`), not `/pre-merge`'s own default `-m "not gpu"` (which would pull
+      in flaky wandb-registry tests).

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -111,7 +111,8 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
 
 ## 4. OpenSpec validation gate
 
-- [ ] 4.1 `openspec validate consume-run-manifest --strict` — resolve any issues.
+- [x] 4.1 `openspec validate consume-run-manifest --strict` — resolve any issues.
+      (`Change 'consume-run-manifest' is valid`.)
 
 ## 5. Docs
 

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -116,7 +116,7 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
 
 ## 5. Docs
 
-- [ ] 5.1 Update `CHANGELOG.md`'s `[Unreleased]` "Predict container CLI" bullet in place: replace
+- [x] 5.1 Update `CHANGELOG.md`'s `[Unreleased]` "Predict container CLI" bullet in place: replace
       "skips-if-done (existence-based resume)" with: "and per scan, when a `run_manifest.json`
       (`RunManifest`, `sleap-roots-contracts==0.1.0a7`) is staged in `input_dir`, scopes discovery
       to exactly its `scan_keys` (an out-of-scope sidecar is silently excluded); skip-if-done now
@@ -124,20 +124,20 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
       own artifacts, skipping only on an exact match and otherwise (re)predicting — no new
       storage." Note the accepted trade-off (resolve() now runs once per batch even on a full
       resume) in a short follow-up sentence.
-- [ ] 5.2 Update `API.md`'s `run_batch` prose ("skips if the manifest already exists (resume)")
+- [x] 5.2 Update `API.md`'s `run_batch` prose ("skips if the manifest already exists (resume)")
       to describe the idempotency-key comparison and manifest-scoped discovery, matching the
       CHANGELOG wording from 5.1.
-- [ ] 5.3 Update `README.md`'s "Running the predict container" section (~line 211, "It skips a
+- [x] 5.3 Update `README.md`'s "Running the predict container" section (~line 211, "It skips a
       scan whose manifest already exists (resume)...") with the same replacement wording as 5.1,
       and add a sentence noting `run_manifest.json`-scoped discovery when the operator's pipeline
       stages one.
-- [ ] 5.4 Update `openspec/project.md`: the External Dependencies `sleap-roots-contracts` version
+- [x] 5.4 Update `openspec/project.md`: the External Dependencies `sleap-roots-contracts` version
       literal (`==0.1.0a6` → `==0.1.0a7`), and the Roadmap note at the top of the file to credit
       this change with closing the `sleap-roots-predict` row of `sleap-roots-pipeline#37`,
       parallel to the existing `#15` credit for the parity harness.
-- [ ] 5.5 Grep sweep: search `README.md`, `API.md`, `CHANGELOG.md`, `openspec/project.md` for
+- [x] 5.5 Grep sweep: search `README.md`, `API.md`, `CHANGELOG.md`, `openspec/project.md` for
       `skip|manifest|exists|resume` and confirm no stale existence-based-resume phrasing survives
-      anywhere (mirrors the precedent PR's closing sweep task).
+      anywhere (mirrors the precedent PR's closing sweep task). (Clean — no matches.)
 
 ## 6. Pre-merge gate
 

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -4,14 +4,15 @@ Land 1.1–1.2 as a single commit — the Dockerfile's `uv sync --frozen` hard-f
 doesn't match `pyproject.toml`, so a bumped pin without its relock is never a safe standalone
 commit.
 
-- [ ] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a6` to `==0.1.0a7` in `pyproject.toml`.
-- [ ] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a bare
+- [x] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a6` to `==0.1.0a7` in `pyproject.toml`.
+- [x] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a bare
       `uv lock`); confirm the `uv.lock` diff touches only the `sleap-roots-contracts` entry.
-- [ ] 1.3 Verify `python -c "from sleap_roots_contracts import RunManifest, RUN_MANIFEST_FILENAME;
+- [x] 1.3 Verify `python -c "from sleap_roots_contracts import RunManifest, RUN_MANIFEST_FILENAME;
       from sleap_roots_contracts.identity import compute_idempotency_key; print('ok')"` succeeds
       at the new pin, with no other code changes yet.
-- [ ] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb and not
+- [x] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb and not
       parity"`) and confirm it is still green before any further edits — the regression baseline.
+      (290 passed, 7 deselected.)
 
 ## 2. Manifest-scoped discovery (TDD)
 

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -1,0 +1,96 @@
+## 1. Dependency bump (isolated regression baseline)
+
+Land 1.1–1.2 as a single commit — the Dockerfile's `uv sync --frozen` hard-fails if `uv.lock`
+doesn't match `pyproject.toml`, so a bumped pin without its relock is never a safe standalone
+commit.
+
+- [ ] 1.1 Bump `sleap-roots-contracts` from `==0.1.0a6` to `==0.1.0a7` in `pyproject.toml`.
+- [ ] 1.2 Relock scoped to just this dependency: `uv lock -P sleap-roots-contracts` (not a bare
+      `uv lock`); confirm the `uv.lock` diff touches only the `sleap-roots-contracts` entry.
+- [ ] 1.3 Verify `python -c "from sleap_roots_contracts import RunManifest, RUN_MANIFEST_FILENAME;
+      from sleap_roots_contracts.identity import compute_idempotency_key; print('ok')"` succeeds
+      at the new pin, with no other code changes yet.
+- [ ] 1.4 Run the full test suite (`pytest -m "not gpu and not acceptance and not wandb and not
+      parity"`) and confirm it is still green before any further edits — the regression baseline.
+
+## 2. Manifest-scoped discovery (TDD)
+
+Each sub-item: write the failing test first, then the minimal `discover_scans` change to pass
+it, per the design doc's data-flow section.
+
+- [ ] 2.1 Test: `discover_scans` scopes to a present `run_manifest.json`'s `scan_keys` — a
+      leftover sidecar outside that set is excluded (not returned, no error recorded). Then
+      implement: read `input_dir / RUN_MANIFEST_FILENAME` if present, parse via
+      `RunManifest.model_validate_json`, filter the `rglob` results to `scan_key in
+      manifest.scan_keys` before dup-tracking (so an out-of-scope sidecar is never even
+      considered for the duplicate-`scan_key` check).
+- [ ] 2.2 Test: no `run_manifest.json` present → `discover_scans` returns exactly what it does
+      today (every sidecar found, none excluded) — a regression guard, not new behavior; existing
+      fixtures/tests should need no changes to keep passing.
+- [ ] 2.3 Test: a manifest `scan_key` with no matching sidecar anywhere under the input directory
+      becomes a `ScanInput` with `.error` set (reuses the existing error → `ScanResult(status=
+      "failed")` path — verify via `run_batch`, not just `discover_scans`, since that's where the
+      status actually surfaces). Implement: after building the scoped+discovered set, compute
+      `manifest.scan_keys - {discovered scan_keys}` and append a synthetic errored `ScanInput` per
+      missing key.
+- [ ] 2.4 Test: a malformed `run_manifest.json` (invalid JSON, or valid JSON failing `RunManifest`
+      validation, e.g. empty `scan_keys`) raises from `discover_scans` before any scan is
+      returned/processed.
+- [ ] 2.5 Run the targeted test file (`pytest tests/test_batch.py -k manifest or discover`) and
+      confirm all four new scenarios pass alongside the untouched existing discovery tests.
+
+## 3. Idempotency-key skip-if-done (TDD)
+
+- [ ] 3.1 Add `images_checksum: str = ""` to `ScanInput`, populated in `_load_scan` from
+      `meta.get("images_checksum", "")` (no test needed standalone — covered by 3.3's fixtures
+      already carrying `images_checksum`, and by the identity-key tests below).
+- [ ] 3.2 Write a small helper (private to `batch.py`) that derives the identity key from
+      arbitrary `(images_checksum, params_dict, model_refs, predict_code_sha,
+      predict_output_params)` via `compute_idempotency_key(..., traits_code_sha="")`, and a
+      second helper `_previous_identity_key(out_scan_dir, scan_key)` that reads back
+      `{scan_key}.scan_metadata.json` + `{scan_key}.predictions.json` from `out_scan_dir` (via the
+      first helper) and returns `None` if either file is missing/unreadable. Unit-test both
+      helpers directly first (pure functions / simple file reads — fastest feedback), before
+      wiring them into `run_batch`.
+- [ ] 3.3 Test: `test_rerun_skips_completed_scan` (existing) still passes essentially unchanged —
+      an unchanged re-run (same sidecar, same models, same `predict_code_sha`) skips via key
+      match, not just `Path.exists()`. Update its assertions/setup only as needed to reflect that
+      the skip is now key-based.
+- [ ] 3.4 Test (new): re-run after mutating the *input* sidecar's `params` (different
+      `param_hash`) between the two `run_batch` calls → the scan is re-predicted (`status="ok"`,
+      manifest mtime changes), not skipped. This is the actual incident-2 fix from the design doc.
+- [ ] 3.5 Test (new): re-run after changing the input sidecar's `images_checksum` only (params
+      unchanged) → re-predicted, not skipped.
+- [ ] 3.6 Test (new): re-run with a different `SRP_PREDICT_CODE_SHA` env value between the two
+      `run_batch` calls → re-predicted, not skipped.
+- [ ] 3.7 Test (new): a scan with no prior `out_scan_dir` contents at all (first run) always
+      predicts — `_previous_identity_key` returns `None`, never raises.
+- [ ] 3.8 Implement the `run_batch` loop restructuring: move `refs = worker.resolve(scan.params)`
+      up before the skip decision (ahead of `_predict_one`); compute `current_key` and
+      `previous_key` via 3.2's helpers; skip iff both exist and are equal; otherwise call
+      `_predict_one` (passing `refs` through so it isn't re-resolved) and let it write outputs as
+      today. Remove the old `manifest_path.exists()` check entirely.
+- [ ] 3.9 Run `pytest tests/test_batch.py` in full and confirm green, including every pre-existing
+      test (e.g. `test_resume_mixed_skip_and_predict`, `test_run_batch_writes_outputs_and_copies_
+      sidecar`) with no regressions.
+
+## 4. OpenSpec validation gate
+
+- [ ] 4.1 `openspec validate consume-run-manifest --strict` — resolve any issues.
+
+## 5. Docs
+
+- [ ] 5.1 Update `CHANGELOG.md`'s `[Unreleased]` "Predict container CLI" bullet in place: replace
+      "skips-if-done (existence-based resume)" with a sentence describing manifest-scoped
+      discovery (`RunManifest`, `sleap-roots-contracts==0.1.0a7`) and idempotency-key-verified
+      skip-if-done (recomputed from already-written artifacts, no new storage).
+- [ ] 5.2 Update `API.md`'s `run_batch` prose ("skips if the manifest already exists (resume)")
+      to describe the idempotency-key comparison and manifest-scoped discovery, matching the
+      CHANGELOG wording.
+- [ ] 5.3 Update `openspec/project.md`'s External Dependencies `sleap-roots-contracts` version
+      literal (`==0.1.0a6` → `==0.1.0a7`) and, if useful, note `RunManifest`/
+      `compute_idempotency_key` alongside the existing enumerated type list.
+
+## 6. Pre-merge gate
+
+- [ ] 6.1 Full `/pre-merge` gate (format, lint, test, build) before opening the PR.

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -151,3 +151,39 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
       itself is unchanged and CI's build-only PR job covers it; GPU subset: `uv sync --extra dev
       --extra windows_cuda` then `pytest -m gpu tests/` — 3 passed on this machine's NVIDIA RTX
       A5000; full suite re-confirmed green under the CUDA-enabled environment, 304 passed.)
+
+## 7. Post-review hardening (PR #35 5-lens review findings)
+
+None of these change the spec deltas — they close gaps the review found between the design doc's
+promises / this PR's own correctness margins and the shipped code, plus two DRY follow-ups the
+reviewers flagged as coupling risks. Land as normal TDD commits (test-first where new behavior is
+being added; refactors verified by keeping existing tests green, per the TDD refactor discipline).
+
+- [x] 7.1 Test-first: `discover_scans` emits a `logger.debug` line reporting the excluded
+      out-of-scope scan_key(s) when a manifest is present (the design doc already promises this;
+      the implementation never added it). Use `caplog` to assert the debug message appears when a
+      leftover sidecar is excluded, and confirm no regression on the no-manifest path.
+- [x] 7.2 Test-first: add a regression test proving `run_batch` never calls `WarmModelWorker.resolve`
+      for a scan with `.error` set (the manifest-scan_key-with-no-sidecar case) — spy/monkeypatch
+      `resolve` and assert zero calls for that scan. Closes the gap where every existing test only
+      checks the final `status`, not that resolution was skipped.
+- [x] 7.3 Refactor (no new test; keep all existing tests green): extract a shared
+      `predictions_json_path(out_dir, scan_key)` helper in `output_contract.py` (single source of
+      truth for the `{scan_key}.predictions.json` filename, mirroring the existing `_SIDECAR_SUFFIX`
+      pattern); use it from both `write_prediction_outputs` and `batch.py`'s
+      `_previous_identity_key`.
+- [x] 7.4 Refactor (no new test; keep all existing tests green): promote `output_contract.py`'s
+      private `_resolve_identity` to a public `resolve_identity`; reuse it from `batch.py`'s
+      `resolved_code_sha` computation instead of a second inline implementation of the same
+      fallback.
+- [x] 7.5 Test-first: add a test combining manifest scoping with a sidecar whose filename stem
+      matches a manifest `scan_key` but whose internal `scan_key` field doesn't — confirm the
+      correct stem-mismatch failure surfaces (not a misleading "no sidecar found for manifest
+      scan_key" message), pinning down behavior currently correct only by code-order coincidence.
+- [x] 7.6 Strengthen `test_changed_predict_code_sha_causes_repredict` to assert the persisted
+      `predict_code_sha` value directly (matching `test_run_batch_writes_outputs_and_copies_sidecar`'s
+      existing pattern), not just that the manifest's mtime changed.
+- [x] 7.7 Fix PR #35's description: "`resolve()` now runs once per `run_batch()` invocation" is
+      imprecise — `resolve()` runs once per non-error scan; what's actually cached per-batch is
+      `WarmModelWorker._cards` (the `list_cards()` network call). Tighten the wording.
+- [x] 7.8 Full lint + test gate; push; re-post an updated summary to the PR.

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -141,7 +141,12 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
 
 ## 6. Pre-merge gate
 
-- [ ] 6.1 Full `/pre-merge` gate (format, lint, test, build) before opening the PR. Confirm the
+- [x] 6.1 Full `/pre-merge` gate (format, lint, test, build) before opening the PR. Confirm the
       pytest invocation matches `ci.yml`'s exact marker expression (`-m "not gpu and not
       acceptance and not wandb"`), not `/pre-merge`'s own default `-m "not gpu"` (which would pull
       in flaky wandb-registry tests).
+      (black/ruff/codespell PASS; 304 passed, 7 deselected via bare `pytest tests/`, which relies
+      on `addopts` rather than `/pre-merge`'s own stale `-m "not gpu"` suggestion, for the same
+      reason flagged here; `uv build` PASS; Docker image build skipped locally — Dockerfile
+      itself is unchanged and CI's build-only PR job covers it; GPU subset: N/A, no CUDA/MPS
+      accelerator on this machine — needs verification on a GPU box before merge.)

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -187,3 +187,22 @@ being added; refactors verified by keeping existing tests green, per the TDD ref
       imprecise — `resolve()` runs once per non-error scan; what's actually cached per-batch is
       `WarmModelWorker._cards` (the `list_cards()` network call). Tighten the wording.
 - [x] 7.8 Full lint + test gate; push; re-post an updated summary to the PR.
+
+## 8. Second review round follow-ups (cheap suggestions)
+
+A second `/review-pr` pass (report-only, Mode B) re-verified all of group 7's fixes by direct
+tracing and found no BLOCKING/IMPORTANT issues (scores 8-9/10 across all five lenses). These
+three items address the cheapest of its SUGGESTION-tier findings.
+
+- [x] 8.1 Add a docstring note to `output_contract.py`'s `resolve_identity` and
+      `predictions_json_path` marking them as intentionally cross-module-internal helpers (not
+      part of the package's public API / not re-exported via `__init__.py`), so their
+      un-underscored naming doesn't read as an oversight.
+- [x] 8.2 Remove `test_manifest_missing_sidecar_does_not_abort_other_scans` — it is now a strict
+      subset of `test_scan_error_short_circuits_before_resolve` (identical fixture, weaker
+      assertion) and adds no coverage.
+- [x] 8.3 Strengthen `test_scan_error_short_circuits_before_resolve`'s assertion from
+      `all(params is not None for params in calls)` to `len(calls) == 2`, locking in the
+      documented "resolve() runs twice per successful scan" behavior instead of only ruling out
+      a `None`-params call.
+- [x] 8.4 Full lint + test gate; commit; push; update the PR.

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -148,5 +148,6 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
       (black/ruff/codespell PASS; 304 passed, 7 deselected via bare `pytest tests/`, which relies
       on `addopts` rather than `/pre-merge`'s own stale `-m "not gpu"` suggestion, for the same
       reason flagged here; `uv build` PASS; Docker image build skipped locally — Dockerfile
-      itself is unchanged and CI's build-only PR job covers it; GPU subset: N/A, no CUDA/MPS
-      accelerator on this machine — needs verification on a GPU box before merge.)
+      itself is unchanged and CI's build-only PR job covers it; GPU subset: `uv sync --extra dev
+      --extra windows_cuda` then `pytest -m gpu tests/` — 3 passed on this machine's NVIDIA RTX
+      A5000; full suite re-confirmed green under the CUDA-enabled environment, 304 passed.)

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -19,26 +19,27 @@ commit.
 Each sub-item: write the failing test first, then the minimal `discover_scans` change to pass
 it, per the design doc's data-flow section.
 
-- [ ] 2.1 Test: `discover_scans` scopes to a present `run_manifest.json`'s `scan_keys` — a
+- [x] 2.1 Test: `discover_scans` scopes to a present `run_manifest.json`'s `scan_keys` — a
       leftover sidecar outside that set is excluded (not returned, no error recorded). Then
       implement: read `input_dir / RUN_MANIFEST_FILENAME` if present, parse via
       `RunManifest.model_validate_json`, filter the `rglob` results to `scan_key in
       manifest.scan_keys` before dup-tracking (so an out-of-scope sidecar is never even
       considered for the duplicate-`scan_key` check).
-- [ ] 2.2 Test: no `run_manifest.json` present → `discover_scans` returns exactly what it does
+- [x] 2.2 Test: no `run_manifest.json` present → `discover_scans` returns exactly what it does
       today (every sidecar found, none excluded) — a regression guard, not new behavior; existing
       fixtures/tests should need no changes to keep passing.
-- [ ] 2.3 Test: a manifest `scan_key` with no matching sidecar anywhere under the input directory
+- [x] 2.3 Test: a manifest `scan_key` with no matching sidecar anywhere under the input directory
       becomes a `ScanInput` with `.error` set and `params=None` (reuses the existing error →
       `ScanResult(status="failed")` path — verify via `run_batch`, not just `discover_scans`,
       since that's where the status actually surfaces). Implement: after building the
       scoped+discovered set, compute `manifest.scan_keys - {discovered scan_keys}` and append a
       synthetic errored `ScanInput` per missing key.
-- [ ] 2.4 Test: a malformed `run_manifest.json` (invalid JSON, or valid JSON failing `RunManifest`
+- [x] 2.4 Test: a malformed `run_manifest.json` (invalid JSON, or valid JSON failing `RunManifest`
       validation, e.g. empty `scan_keys`) raises from `discover_scans` before any scan is
       returned/processed.
-- [ ] 2.5 Run the targeted test file (`pytest tests/test_batch.py -k manifest or discover`) and
+- [x] 2.5 Run the targeted test file (`pytest tests/test_batch.py -k manifest or discover`) and
       confirm all four new scenarios pass alongside the untouched existing discovery tests.
+      (28 tests in test_batch.py, all passing; full suite 295 passed, 7 deselected.)
 
 ## 3. Idempotency-key skip-if-done (TDD)
 

--- a/openspec/changes/consume-run-manifest/tasks.md
+++ b/openspec/changes/consume-run-manifest/tasks.md
@@ -47,9 +47,9 @@ it, per the design doc's data-flow section.
 doesn't exist until 3.8's loop restructuring lands — committing them separately would leave an
 intermediate commit red, unlike group 2 (whose tests are independently satisfiable one at a time).
 
-- [ ] 3.1 Add `images_checksum: str = ""` to `ScanInput`, populated in `_load_scan` from
+- [x] 3.1 Add `images_checksum: str = ""` to `ScanInput`, populated in `_load_scan` from
       `meta.get("images_checksum", "")`.
-- [ ] 3.2 Write two small helpers, private to `batch.py`:
+- [x] 3.2 Write two small helpers, private to `batch.py`:
       - `_identity_key(*, scan_key, images_checksum, params_dict, model_refs, predict_code_sha,
         predict_output_params)` — converts `model_refs` (a `dict[RootType, ModelRef]` or
         iterable of `ModelRef`) to the `list[tuple[registry_id, version, weights_checksum]]` shape
@@ -67,32 +67,32 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
       feedback), including a case where `_previous_identity_key` is pointed at a directory with a
       hand-corrupted `{scan_key}.predictions.json` (valid JSON, invalid schema) and confirmed to
       return `None` rather than raising.
-- [ ] 3.3 Test: `test_rerun_skips_completed_scan` (existing) still passes essentially unchanged —
+- [x] 3.3 Test: `test_rerun_skips_completed_scan` (existing) still passes essentially unchanged —
       an unchanged re-run (same sidecar, same models, same `predict_code_sha`) skips via key
       match, not just `Path.exists()`. Update its assertions/setup only as needed to reflect that
       the skip is now key-based.
-- [ ] 3.4 Test (new): re-run after mutating the *input* sidecar's `params` (different
+- [x] 3.4 Test (new): re-run after mutating the *input* sidecar's `params` (different
       `param_hash`) between the two `run_batch` calls → the scan is re-predicted (`status="ok"`,
       manifest mtime changes), not skipped. This is the actual incident-2 fix from the design doc.
-- [ ] 3.5 Test (new): re-run after changing the input sidecar's `images_checksum` only (params
+- [x] 3.5 Test (new): re-run after changing the input sidecar's `images_checksum` only (params
       unchanged) → re-predicted, not skipped.
-- [ ] 3.6 Test (new): re-run with a different `SRP_PREDICT_CODE_SHA` env value between the two
+- [x] 3.6 Test (new): re-run with a different `SRP_PREDICT_CODE_SHA` env value between the two
       `run_batch` calls → re-predicted, not skipped.
-- [ ] 3.7 Test (new): a scan with no prior `out_scan_dir` contents at all (first run) always
+- [x] 3.7 Test (new): a scan with no prior `out_scan_dir` contents at all (first run) always
       predicts — `_previous_identity_key` returns `None`, never raises.
-- [ ] 3.7a Test (new): re-run against a `source` whose card for the same scan resolves to a
+- [x] 3.7a Test (new): re-run against a `source` whose card for the same scan resolves to a
       different `registry_id`/`version`/`weights_checksum` than the previous run → re-predicted,
       not skipped (identity-key inputs include model refs; no other test exercises this input).
-- [ ] 3.7b Test (new): re-run where the existing `{scan_key}.predictions.json` is present but
+- [x] 3.7b Test (new): re-run where the existing `{scan_key}.predictions.json` is present but
       hand-corrupted (valid JSON, fails `PredictionManifest` validation) → the scan is
       re-predicted (`status="ok"`), and — critically — is NOT recorded as `failed`; assert on
       `BatchResult.scans` directly, not just that a new manifest was written.
-- [ ] 3.7c Test (new): a manifest `scan_key` with no sidecar (2.3's synthetic error `ScanInput`,
+- [x] 3.7c Test (new): a manifest `scan_key` with no sidecar (2.3's synthetic error `ScanInput`,
       `params=None`) is recorded `failed` via `run_batch` without raising — regression guard
       confirming the `scan.error` check still runs before `resolve()` (a naive "move resolve() up"
       implementation would call `resolve(None)` and raise `AttributeError` inside `choose_models`
       instead of isolating this as a per-scan failure).
-- [ ] 3.8 Implement the `run_batch` loop restructuring, in this exact order per scan:
+- [x] 3.8 Implement the `run_batch` loop restructuring, in this exact order per scan:
       1. Check `scan.error is not None` first, unchanged from today — record `failed` and
          `continue` before anything else runs.
       2. Wrap everything else in the existing per-scan `try/except Exception` (widened to cover
@@ -103,10 +103,11 @@ intermediate commit red, unlike group 2 (whose tests are independently satisfiab
          `continue`. Otherwise → call `_predict_one` (passing `refs` through so it isn't
          re-resolved) and let it write outputs as today.
       Remove the old `manifest_path.exists()` check entirely.
-- [ ] 3.9 Run `pytest tests/test_batch.py` in full and confirm green, with special attention to
+- [x] 3.9 Run `pytest tests/test_batch.py` in full and confirm green, with special attention to
       the tests most at risk from this restructuring: `test_zero_resolved_models_is_failed`,
       `test_one_failing_scan_does_not_abort_batch`, `test_sidecar_copy_failure_leaves_no_manifest`,
       and `test_resume_mixed_skip_and_predict` — all must stay green with no behavior change.
+      (36 tests in test_batch.py, all passing; full suite 304 passed, 7 deselected.)
 
 ## 4. OpenSpec validation gate
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -20,9 +20,12 @@ importable library.
 > the real GPU service-image `ENTRYPOINT`). The **prediction-parity** harness (this repo's
 > `sleap_roots_predict.parity`, resolving sleap-roots-pipeline#15) also landed, with a
 > measured, relative empirical tolerance (`distance_p95` ≤ 25% relative delta,
-> `visibility_recall` ≥ -0.10) across all 13 production `ModelCard`s. Remaining A3/A4 work:
-> emitting the full `Provenance`/`ResultEnvelope` (traits assembles these from predict's
-> manifest).
+> `visibility_recall` ≥ -0.10) across all 13 production `ModelCard`s. The `predict-container`
+> capability now also consumes `RunManifest` (`sleap-roots-contracts` 0.1.0a7) to scope
+> discovery and verify skip-if-done via a recomputed idempotency key, closing the
+> `sleap-roots-predict` row of `sleap-roots-pipeline`#37's cross-repo idempotency chain.
+> Remaining A3/A4 work: emitting the full `Provenance`/`ResultEnvelope` (traits assembles
+> these from predict's manifest).
 
 ## Tech Stack
 - **Python** ≥ 3.11 (CI matrix: 3.11, 3.12)
@@ -120,9 +123,10 @@ downstream join.
 
 ## External Dependencies
 - **sleap-nn / sleap-io** — inference engine and label I/O.
-- **sleap-roots-contracts** (`==0.1.0a6`) — shared `ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`/
-  `PredictionArtifact`/`PredictionManifest`/`LabelCard`, and the `resolve_params` oracle (Bloom
-  scan metadata → `ResolvedParams`).
+- **sleap-roots-contracts** (`==0.1.0a7`) — shared `ModelCard`/`ModelRef`/`ResolvedParams`/`RootType`/
+  `PredictionArtifact`/`PredictionManifest`/`LabelCard`/`RunManifest`, the `resolve_params` oracle
+  (Bloom scan metadata → `ResolvedParams`), and `compute_idempotency_key`
+  (`sleap_roots_contracts.identity`, used for skip-if-done comparison).
 - **wandb** — the model registry the warm worker fetches root models from (network confined to
   `WandbRegistrySource`). Also a transitive sleap-nn dependency.
 - **sleap-roots model registry** — source of trained models (the wandb registry above).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pandas",
     "h5py",
     "imageio",
-    "sleap-roots-contracts==0.1.0a6",
+    "sleap-roots-contracts==0.1.0a7",
     # wandb is already a transitive dependency of sleap-nn 0.3.0; declared here
     # because WandbRegistrySource imports it directly (kept as a lazy import).
     "wandb",

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -9,7 +9,6 @@ writes the prediction-output artifacts, and copies the sidecar through so each
 
 import json
 import logging
-import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -24,7 +23,11 @@ from sleap_roots_contracts import (
 from sleap_roots_contracts.identity import compute_idempotency_key
 
 from sleap_roots_predict.model_registry import ModelCardSource
-from sleap_roots_predict.output_contract import write_prediction_outputs
+from sleap_roots_predict.output_contract import (
+    predictions_json_path,
+    resolve_identity,
+    write_prediction_outputs,
+)
 from sleap_roots_predict.video_utils import make_video_from_images, natural_sort
 from sleap_roots_predict.warm_worker import WarmModelWorker
 
@@ -115,9 +118,11 @@ def discover_scans(input_dir: str | Path) -> list[ScanInput]:
 
     scans: list[ScanInput] = []
     seen: dict[str, Path] = {}
+    excluded: list[str] = []
     for sidecar in sorted(input_dir.rglob("*" + _SIDECAR_SUFFIX)):
         scan_key = sidecar.name[: -len(_SIDECAR_SUFFIX)]
         if scoped_keys is not None and scan_key not in scoped_keys:
+            excluded.append(scan_key)
             continue
         if scan_key in seen:
             raise ValueError(
@@ -126,6 +131,13 @@ def discover_scans(input_dir: str | Path) -> list[ScanInput]:
             )
         seen[scan_key] = sidecar
         scans.append(_load_scan(sidecar, scan_key))
+
+    if excluded:
+        logger.debug(
+            "Excluded %d sidecar(s) outside run_manifest.json scope: %s",
+            len(excluded),
+            sorted(excluded),
+        )
 
     if scoped_keys is not None:
         for key in sorted(scoped_keys - set(seen)):
@@ -230,7 +242,7 @@ def _previous_identity_key(out_scan_dir: Path, scan_key: str) -> str | None:
     *previous* state is treated as "changed," never as a failure.
     """
     sidecar_path = out_scan_dir / f"{scan_key}{_SIDECAR_SUFFIX}"
-    manifest_path = out_scan_dir / f"{scan_key}.predictions.json"
+    manifest_path = predictions_json_path(out_scan_dir, scan_key)
     try:
         meta = json.loads(sidecar_path.read_text())
         manifest = PredictionManifest.model_validate_json(manifest_path.read_text())
@@ -292,11 +304,7 @@ def run_batch(
         logger.warning("No scans discovered under %s", input_dir.as_posix())
         return result
 
-    resolved_code_sha = (
-        predict_code_sha
-        if predict_code_sha is not None
-        else os.environ.get("SRP_PREDICT_CODE_SHA", "")
-    )
+    resolved_code_sha = resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA")
     worker = WarmModelWorker(source=source)
     for scan in scans:
         if scan.error is not None:

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -13,7 +13,7 @@ import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from sleap_roots_contracts import ResolvedParams
+from sleap_roots_contracts import RUN_MANIFEST_FILENAME, ResolvedParams, RunManifest
 
 from sleap_roots_predict.model_registry import ModelCardSource
 from sleap_roots_predict.output_contract import write_prediction_outputs
@@ -72,26 +72,44 @@ def discover_scans(input_dir: str | Path) -> list[ScanInput]:
     returned with ``.error`` set (isolated failure); a duplicate ``scan_key``
     anywhere in the tree raises.
 
+    If ``input_dir / RUN_MANIFEST_FILENAME`` exists, discovery is scoped to
+    exactly its ``scan_keys``: a discovered sidecar outside that set is
+    silently excluded, and a listed ``scan_key`` with no matching sidecar is
+    returned as an isolated error entry. Absent a manifest, every sidecar found
+    is returned (unscoped), unchanged from before manifest-awareness existed.
+
     Args:
         input_dir: Directory of staged scans (must exist).
 
     Returns:
-        One :class:`ScanInput` per discovered sidecar, sorted by path.
+        One :class:`ScanInput` per discovered (or manifest-expected-but-missing)
+        sidecar, sorted by path.
 
     Raises:
         FileNotFoundError: If ``input_dir`` does not exist (a mis-configured mount,
             distinct from an empty-but-present directory which is a no-op).
-        ValueError: If two sidecars share a ``scan_key``.
+        ValueError: If two in-scope sidecars share a ``scan_key``.
+        pydantic.ValidationError: If a present ``run_manifest.json`` fails to parse
+            or validate as a :class:`RunManifest`.
     """
     input_dir = Path(input_dir)
     if not input_dir.exists():
         raise FileNotFoundError(
             f"input scan directory does not exist: {input_dir.as_posix()}"
         )
+
+    manifest_path = input_dir / RUN_MANIFEST_FILENAME
+    scoped_keys: set[str] | None = None
+    if manifest_path.exists():
+        manifest = RunManifest.model_validate_json(manifest_path.read_text())
+        scoped_keys = set(manifest.scan_keys)
+
     scans: list[ScanInput] = []
     seen: dict[str, Path] = {}
     for sidecar in sorted(input_dir.rglob("*" + _SIDECAR_SUFFIX)):
         scan_key = sidecar.name[: -len(_SIDECAR_SUFFIX)]
+        if scoped_keys is not None and scan_key not in scoped_keys:
+            continue
         if scan_key in seen:
             raise ValueError(
                 f"duplicate scan_key {scan_key!r}: "
@@ -99,6 +117,17 @@ def discover_scans(input_dir: str | Path) -> list[ScanInput]:
             )
         seen[scan_key] = sidecar
         scans.append(_load_scan(sidecar, scan_key))
+
+    if scoped_keys is not None:
+        for key in sorted(scoped_keys - set(seen)):
+            scans.append(
+                ScanInput(
+                    key,
+                    input_dir / f"{key}{_SIDECAR_SUFFIX}",
+                    error=f"no sidecar found for manifest scan_key {key!r}",
+                )
+            )
+
     return scans
 
 

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -9,11 +9,19 @@ writes the prediction-output artifacts, and copies the sidecar through so each
 
 import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from sleap_roots_contracts import RUN_MANIFEST_FILENAME, ResolvedParams, RunManifest
+from sleap_roots_contracts import (
+    RUN_MANIFEST_FILENAME,
+    PredictionManifest,
+    ResolvedParams,
+    RunManifest,
+    compute_param_hash,
+)
+from sleap_roots_contracts.identity import compute_idempotency_key
 
 from sleap_roots_predict.model_registry import ModelCardSource
 from sleap_roots_predict.output_contract import write_prediction_outputs
@@ -39,6 +47,7 @@ class ScanInput:
     sidecar_path: Path
     frames: list[Path] = field(default_factory=list)
     params: ResolvedParams | None = None
+    images_checksum: str = ""
     error: str | None = None
 
 
@@ -168,7 +177,76 @@ def _load_scan(sidecar: Path, scan_key: str) -> ScanInput:
         )
     ]
     resolved = ResolvedParams(values={k: params[k] for k in _REQUIRED_PARAM_KEYS})
-    return ScanInput(scan_key, sidecar, frames=frames, params=resolved)
+    images_checksum = meta.get("images_checksum", "")
+    return ScanInput(
+        scan_key,
+        sidecar,
+        frames=frames,
+        params=resolved,
+        images_checksum=images_checksum,
+    )
+
+
+def _identity_key(
+    *,
+    scan_key: str,
+    images_checksum: str,
+    params_dict: dict,
+    model_refs,
+    predict_code_sha: str,
+    predict_output_params: dict,
+) -> str:
+    """Derive the predict-scoped identity key for one scan's current or prior state.
+
+    ``model_refs`` may be a ``dict[RootType, ModelRef]`` (as returned by
+    ``worker.resolve``) or any iterable of ``ModelRef`` (as read back from a
+    ``PredictionManifest``'s ``artifacts``) — both are reduced to the same
+    order-independent ``(registry_id, version, weights_checksum)`` tuples
+    ``compute_idempotency_key`` expects. ``traits_code_sha`` is a fixed empty-string
+    placeholder: predict never owns that value and only ever compares this key
+    against its own previously-derived one, never against a traits-computed key.
+    """
+    refs = model_refs.values() if isinstance(model_refs, dict) else model_refs
+    models = [(ref.registry_id, ref.version, ref.weights_checksum) for ref in refs]
+    return compute_idempotency_key(
+        scan_key=scan_key,
+        images_checksum=images_checksum,
+        models=models,
+        param_hash=compute_param_hash(params_dict),
+        predict_code_sha=predict_code_sha,
+        traits_code_sha="",
+        predict_output_params=predict_output_params,
+    )
+
+
+def _previous_identity_key(out_scan_dir: Path, scan_key: str) -> str | None:
+    """Recompute the previous run's identity key from artifacts already on disk.
+
+    Reads back the already-copied sidecar and already-written prediction manifest
+    from ``out_scan_dir`` — no new storage is needed. Returns ``None`` if either
+    file is missing, unreadable, or present but fails to parse/validate (a
+    :class:`pydantic.ValidationError`, which subclasses ``ValueError`` and is
+    caught here without importing pydantic directly) — a corrupt or absent
+    *previous* state is treated as "changed," never as a failure.
+    """
+    sidecar_path = out_scan_dir / f"{scan_key}{_SIDECAR_SUFFIX}"
+    manifest_path = out_scan_dir / f"{scan_key}.predictions.json"
+    try:
+        meta = json.loads(sidecar_path.read_text())
+        manifest = PredictionManifest.model_validate_json(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    params = meta.get("params")
+    if not isinstance(params, dict):
+        return None
+    return _identity_key(
+        scan_key=scan_key,
+        images_checksum=meta.get("images_checksum", ""),
+        params_dict={k: params[k] for k in _REQUIRED_PARAM_KEYS if k in params},
+        model_refs=[artifact.model for artifact in manifest.artifacts],
+        predict_code_sha=manifest.predict_code_sha,
+        predict_output_params=manifest.predict_output_params,
+    )
 
 
 def run_batch(
@@ -181,11 +259,15 @@ def run_batch(
 ) -> BatchResult:
     """Predict every scan under ``input_dir``, writing outputs under ``output_dir``.
 
-    Loads models once via a single resident worker. Per scan: skip if its manifest
-    already exists (resume); otherwise resolve + predict, write the prediction-output
-    artifacts into ``output_dir/{scan_key}/``, and copy the sidecar through. A
-    per-scan error is isolated (recorded ``failed``, batch continues). An empty (but
-    present) input directory is a no-op.
+    Loads models once via a single resident worker. Per scan: a scan already
+    recorded as invalid (``scan.error`` set) is isolated as ``failed`` immediately,
+    before any model resolution runs. Otherwise, the currently-resolved models plus
+    the scan's current inputs are compared, via a recomputed idempotency key,
+    against the key recomputed from that scan's own previously-written artifacts
+    (no new storage — see :func:`_previous_identity_key`); an exact match skips,
+    anything else (including no previous artifacts at all) predicts and overwrites.
+    A per-scan error is isolated (recorded ``failed``, batch continues). An empty
+    (but present) input directory is a no-op.
 
     Args:
         input_dir: Directory of staged scans.
@@ -210,21 +292,41 @@ def run_batch(
         logger.warning("No scans discovered under %s", input_dir.as_posix())
         return result
 
+    resolved_code_sha = (
+        predict_code_sha
+        if predict_code_sha is not None
+        else os.environ.get("SRP_PREDICT_CODE_SHA", "")
+    )
     worker = WarmModelWorker(source=source)
     for scan in scans:
-        out_scan_dir = output_dir / scan.scan_key
-        manifest_path = out_scan_dir / f"{scan.scan_key}.predictions.json"
-        if manifest_path.exists():
-            logger.info("Skipping %s (manifest exists)", scan.scan_key)
-            result.scans.append(ScanResult(scan.scan_key, "skipped"))
-            continue
         if scan.error is not None:
             logger.error("Scan %s failed: %s", scan.scan_key, scan.error)
             result.scans.append(ScanResult(scan.scan_key, "failed", scan.error))
             continue
+
+        out_scan_dir = output_dir / scan.scan_key
         try:
+            refs = worker.resolve(scan.params)
+            current_key = _identity_key(
+                scan_key=scan.scan_key,
+                images_checksum=scan.images_checksum,
+                params_dict=scan.params.values,
+                model_refs=refs,
+                predict_code_sha=resolved_code_sha,
+                predict_output_params=worker.output_params(),
+            )
+            previous_key = _previous_identity_key(out_scan_dir, scan.scan_key)
+            if previous_key is not None and previous_key == current_key:
+                logger.info("Skipping %s (idempotency key unchanged)", scan.scan_key)
+                result.scans.append(ScanResult(scan.scan_key, "skipped"))
+                continue
             _predict_one(
-                worker, scan, out_scan_dir, predict_code_sha, predict_container_digest
+                worker,
+                scan,
+                out_scan_dir,
+                refs,
+                predict_code_sha,
+                predict_container_digest,
             )
             result.scans.append(ScanResult(scan.scan_key, "ok"))
         except Exception as exc:  # noqa: BLE001 - isolate per-scan failures
@@ -237,6 +339,7 @@ def _predict_one(
     worker: WarmModelWorker,
     scan: ScanInput,
     out_scan_dir: Path,
+    refs: dict,
     predict_code_sha: str | None,
     predict_container_digest: str | None,
 ) -> None:
@@ -246,7 +349,6 @@ def _predict_one(
             f"no image frames co-located with sidecar {scan.sidecar_path.as_posix()}"
         )
     assert scan.params is not None  # run_batch filters error scans (params-None) first
-    refs = worker.resolve(scan.params)
     if not refs:
         # A scan matching no model for any root type is a hard per-scan failure rather
         # than an empty-artifacts manifest: write_prediction_outputs permits an empty

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -99,7 +99,9 @@ def resolve_identity(explicit: str | None, env_var: str) -> str:
 
     Public (not module-private) because ``batch.py`` reuses it to resolve
     ``predict_code_sha`` for the skip-if-done identity-key comparison, so both sites
-    derive the exact same value from the exact same input.
+    derive the exact same value from the exact same input. Not part of this
+    package's public API — it is a cross-module-internal helper, deliberately not
+    re-exported from ``sleap_roots_predict``'s ``__init__.py``.
     """
     if explicit is not None:
         return explicit
@@ -110,7 +112,9 @@ def predictions_json_path(out_dir: str | Path, scan_key: str) -> Path:
     """Return the per-scan prediction-manifest path (single source of truth).
 
     Used by both this module's writer and ``batch.py``'s skip-if-done reader, so a
-    future filename change can't desync the two.
+    future filename change can't desync the two. Not part of this package's public
+    API — it is a cross-module-internal helper, deliberately not re-exported from
+    ``sleap_roots_predict``'s ``__init__.py``.
     """
     return Path(out_dir) / f"{scan_key}{_PREDICTIONS_JSON_SUFFIX}"
 

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
 
 # --- filename helpers -------------------------------------------------------
 
+# Single source of truth for the manifest's filename, so a future rename can't silently
+# desync the writer here from batch.py's skip-if-done reader.
+_PREDICTIONS_JSON_SUFFIX = ".predictions.json"
+
 _SLUG_UNSAFE = re.compile(r"[^A-Za-z0-9-]")
 
 # Characters that break a single path segment on POSIX and/or Windows, plus `.`
@@ -90,11 +94,25 @@ def _validate_scan_key(scan_key: str) -> None:
         )
 
 
-def _resolve_identity(explicit: str | None, env_var: str) -> str:
-    """Return the explicit value, else the environment value, else ``""``."""
+def resolve_identity(explicit: str | None, env_var: str) -> str:
+    """Return the explicit value, else the environment value, else ``""``.
+
+    Public (not module-private) because ``batch.py`` reuses it to resolve
+    ``predict_code_sha`` for the skip-if-done identity-key comparison, so both sites
+    derive the exact same value from the exact same input.
+    """
     if explicit is not None:
         return explicit
     return os.environ.get(env_var, "")
+
+
+def predictions_json_path(out_dir: str | Path, scan_key: str) -> Path:
+    """Return the per-scan prediction-manifest path (single source of truth).
+
+    Used by both this module's writer and ``batch.py``'s skip-if-done reader, so a
+    future filename change can't desync the two.
+    """
+    return Path(out_dir) / f"{scan_key}{_PREDICTIONS_JSON_SUFFIX}"
 
 
 # --- writer -----------------------------------------------------------------
@@ -190,12 +208,12 @@ def write_prediction_outputs(
         artifacts=artifacts,
         predict_inference_config=dict(inference_config),
         predict_output_params=dict(output_params),
-        predict_code_sha=_resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA"),
-        predict_container_digest=_resolve_identity(
+        predict_code_sha=resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA"),
+        predict_container_digest=resolve_identity(
             predict_container_digest, "SRP_PREDICT_CONTAINER_DIGEST"
         ),
     )
-    (out / f"{scan_key}.predictions.json").write_text(
+    predictions_json_path(out, scan_key).write_text(
         manifest.model_dump_json(indent=2), encoding="utf-8"
     )
     return manifest

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -92,6 +92,52 @@ def test_discover_scans_scopes_to_run_manifest(tmp_path: Path):
     assert [s.scan_key for s in scans] == ["scan_1009"]
 
 
+def test_excluded_out_of_scope_sidecar_logs_debug(tmp_path: Path, caplog):
+    _write_scan(tmp_path, "scan_1009", _RICE)
+    _write_scan(tmp_path, "scan_1010", _RICE)  # leftover from a prior run, not in scope
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scan_1009"]})
+    )
+    with caplog.at_level("DEBUG", logger="sleap_roots_predict.batch"):
+        discover_scans(tmp_path)
+    assert any("scan_1010" in r.message for r in caplog.records)
+
+
+def test_no_exclusion_logs_no_debug_line(tmp_path: Path, caplog):
+    _write_scan(tmp_path, "scan_1009", _RICE)
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scan_1009"]})
+    )
+    with caplog.at_level("DEBUG", logger="sleap_roots_predict.batch"):
+        discover_scans(tmp_path)
+    assert not any("excluded" in r.message.lower() for r in caplog.records)
+
+
+def test_manifest_scoped_stem_mismatch_reports_the_real_error(tmp_path: Path):
+    # sidecar filename stem "scanB" (matches the manifest's scan_key, so it passes
+    # scoping) but its internal scan_key is "scanOTHER" — must surface the actual
+    # stem-mismatch error, not a misleading "no sidecar found for manifest scan_key"
+    # (which would fire if this sidecar were wrongly treated as never having been found).
+    d = tmp_path / "scanB"
+    d.mkdir()
+    Image.fromarray(np.zeros((16, 16), dtype="uint8")).save(d / "frame_000.png")
+    (d / "scanB.scan_metadata.json").write_text(
+        json.dumps(
+            {
+                "scan_key": "scanOTHER",
+                "params": {"species": "rice", "mode": "cylinder", "age": 3},
+            }
+        )
+    )
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scanB"]})
+    )
+    (scan,) = discover_scans(tmp_path)
+    assert scan.error is not None
+    assert "scanOTHER" in scan.error
+    assert "no sidecar found" not in scan.error
+
+
 def test_no_manifest_falls_back_to_unscoped_discovery(tmp_path: Path):
     _write_scan(tmp_path, "scanA", _RICE)
     _write_scan(tmp_path, "scanB", _RICE)
@@ -504,6 +550,7 @@ def test_changed_predict_code_sha_causes_repredict(
     result2 = run_batch(inp, out, source=all_roots_source)
     assert [s.status for s in result2.scans] == ["ok"]
     assert manifest.stat().st_mtime_ns != mtime1
+    assert json.loads(manifest.read_text())["predict_code_sha"] == "sha-two"
 
 
 def test_changed_model_ref_causes_repredict(tmp_path: Path, native_model_dir):
@@ -561,3 +608,35 @@ def test_manifest_missing_sidecar_does_not_abort_other_scans(
     result = run_batch(inp, out, source=all_roots_source)
     statuses = {s.scan_key: s.status for s in result.scans}
     assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}
+
+
+def test_scan_error_short_circuits_before_resolve(
+    all_roots_source, tmp_path, monkeypatch
+):
+    import sleap_roots_predict.batch as batch_mod
+
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    (inp / "run_manifest.json").write_text(
+        json.dumps(
+            {"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]}
+        )
+    )
+    out = tmp_path / "out"
+
+    calls = []
+    original_resolve = batch_mod.WarmModelWorker.resolve
+
+    def spy_resolve(self, params, overrides=None):
+        calls.append(params)
+        return original_resolve(self, params, overrides)
+
+    monkeypatch.setattr(batch_mod.WarmModelWorker, "resolve", spy_resolve)
+    result = run_batch(inp, out, source=all_roots_source)
+    statuses = {s.scan_key: s.status for s in result.scans}
+    assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}
+    # resolve() legitimately runs more than once for a successful scan (once for the
+    # identity-key comparison, once more inside worker.predict()) — what must never happen
+    # is a call for scanMISSING, whose ScanInput.params is None.
+    assert calls, "resolve() should have been called at least once, for scanGOOD"
+    assert all(params is not None for params in calls)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -416,3 +416,148 @@ def test_extra_params_keys_ignored(tmp_path: Path):
     (scan,) = discover_scans(tmp_path)
     assert scan.error is None
     assert scan.params.values == {"species": "rice", "mode": "cylinder", "age": 3}
+
+
+def test_identity_key_changes_with_images_checksum():
+    import sleap_roots_predict.batch as batch_mod
+    from sleap_roots_contracts import ModelRef
+
+    ref = ModelRef(registry_id="reg/x", version="v1", sleap_nn_version="0.3.0")
+    base_kwargs = dict(
+        scan_key="scanA",
+        params_dict={"species": "rice", "mode": "cylinder", "age": 3},
+        model_refs={"primary": ref},
+        predict_code_sha="sha1",
+        predict_output_params={"peak_threshold": 0.2},
+    )
+    key_a = batch_mod._identity_key(images_checksum="sha256:a", **base_kwargs)
+    key_b = batch_mod._identity_key(images_checksum="sha256:b", **base_kwargs)
+    assert key_a != key_b
+
+
+def test_previous_identity_key_none_when_nothing_on_disk(tmp_path: Path):
+    import sleap_roots_predict.batch as batch_mod
+
+    assert batch_mod._previous_identity_key(tmp_path, "scanA") is None
+
+
+def test_previous_identity_key_none_when_predictions_json_corrupt(tmp_path: Path):
+    import sleap_roots_predict.batch as batch_mod
+
+    (tmp_path / "scanA.scan_metadata.json").write_text(
+        json.dumps(
+            {"scan_key": "scanA", "images_checksum": "sha256:x", "params": _RICE}
+        )
+    )
+    (tmp_path / "scanA.predictions.json").write_text('{"not": "a valid manifest"}')
+    assert batch_mod._previous_identity_key(tmp_path, "scanA") is None
+
+
+def test_changed_params_causes_repredict(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    sidecar = inp / "scanA" / "scanA.scan_metadata.json"
+    body = json.loads(sidecar.read_text())
+    body["params"] = {"species": "rice", "mode": "cylinder", "age": 4}
+    sidecar.write_text(json.dumps(body))
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_images_checksum_causes_repredict(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    sidecar = inp / "scanA" / "scanA.scan_metadata.json"
+    body = json.loads(sidecar.read_text())
+    body["images_checksum"] = "sha256:changed"
+    sidecar.write_text(json.dumps(body))
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_predict_code_sha_causes_repredict(
+    all_roots_source, tmp_path, monkeypatch
+):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    monkeypatch.setenv("SRP_PREDICT_CODE_SHA", "sha-one")
+    run_batch(inp, out, source=all_roots_source)
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    monkeypatch.setenv("SRP_PREDICT_CODE_SHA", "sha-two")
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_changed_model_ref_causes_repredict(tmp_path: Path, native_model_dir):
+    from sleap_roots_contracts import ModelCard
+    from sleap_roots_predict.model_registry import LocalCardSource
+
+    def _source(version):
+        card = ModelCard(
+            species="rice",
+            mode="cylinder",
+            age_min=2,
+            age_max=5,
+            root_type="primary",
+            registry_id="reg/rice-primary",
+            version=version,
+        )
+        return LocalCardSource([(card, native_model_dir)])
+
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=_source("v1"))
+    manifest = out / "scanA" / "scanA.predictions.json"
+    mtime1 = manifest.stat().st_mtime_ns
+
+    result2 = run_batch(inp, out, source=_source("v2"))
+    assert [s.status for s in result2.scans] == ["ok"]
+    assert manifest.stat().st_mtime_ns != mtime1
+
+
+def test_corrupt_previous_manifest_causes_repredict_not_failure(
+    all_roots_source, tmp_path
+):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanA", _RICE)
+    out = tmp_path / "out"
+    run_batch(inp, out, source=all_roots_source)
+    (out / "scanA" / "scanA.predictions.json").write_text('{"not": "a valid manifest"}')
+
+    result2 = run_batch(inp, out, source=all_roots_source)
+    assert [s.status for s in result2.scans] == ["ok"]
+
+
+def test_manifest_missing_sidecar_does_not_abort_other_scans(
+    all_roots_source, tmp_path
+):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    (inp / "run_manifest.json").write_text(
+        json.dumps(
+            {"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]}
+        )
+    )
+    out = tmp_path / "out"
+    result = run_batch(inp, out, source=all_roots_source)
+    statuses = {s.scan_key: s.status for s in result.scans}
+    assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -82,6 +82,23 @@ def test_duplicate_scan_key_raises(tmp_path: Path):
         discover_scans(tmp_path)
 
 
+def test_discover_scans_scopes_to_run_manifest(tmp_path: Path):
+    _write_scan(tmp_path, "scan_1009", _RICE)
+    _write_scan(tmp_path, "scan_1010", _RICE)  # leftover from a prior run, not in scope
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": ["scan_1009"]})
+    )
+    scans = discover_scans(tmp_path)
+    assert [s.scan_key for s in scans] == ["scan_1009"]
+
+
+def test_no_manifest_falls_back_to_unscoped_discovery(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    _write_scan(tmp_path, "scanB", _RICE)
+    scans = discover_scans(tmp_path)
+    assert sorted(s.scan_key for s in scans) == ["scanA", "scanB"]
+
+
 def test_batch_does_not_import_trait_extractor():
     import sleap_roots_predict.batch  # noqa: F401
 
@@ -347,6 +364,37 @@ def test_resume_mixed_skip_and_predict(all_roots_source, tmp_path: Path):
     statuses = {s.scan_key: s.status for s in result.scans}
     assert statuses["sDone"] == "skipped"
     assert statuses["sNew"] == "ok"
+
+
+def test_manifest_scan_key_with_no_sidecar_is_failed(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    (inp / "run_manifest.json").write_text(
+        json.dumps(
+            {"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]}
+        )
+    )
+    out = tmp_path / "out"
+    result = run_batch(inp, out, source=all_roots_source)
+    statuses = {s.scan_key: s.status for s in result.scans}
+    assert statuses["scanGOOD"] == "ok"
+    assert statuses["scanMISSING"] == "failed"
+
+
+def test_malformed_manifest_json_raises(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    (tmp_path / "run_manifest.json").write_text("{not valid json")
+    with pytest.raises(Exception):
+        discover_scans(tmp_path)
+
+
+def test_manifest_with_empty_scan_keys_raises(tmp_path: Path):
+    _write_scan(tmp_path, "scanA", _RICE)
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps({"pipeline_run_id": "run-1", "scan_keys": []})
+    )
+    with pytest.raises(Exception):
+        discover_scans(tmp_path)
 
 
 def test_extra_params_keys_ignored(tmp_path: Path):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -594,22 +594,6 @@ def test_corrupt_previous_manifest_causes_repredict_not_failure(
     assert [s.status for s in result2.scans] == ["ok"]
 
 
-def test_manifest_missing_sidecar_does_not_abort_other_scans(
-    all_roots_source, tmp_path
-):
-    inp = tmp_path / "in"
-    _real_scan(inp, "scanGOOD", _RICE)
-    (inp / "run_manifest.json").write_text(
-        json.dumps(
-            {"pipeline_run_id": "run-1", "scan_keys": ["scanGOOD", "scanMISSING"]}
-        )
-    )
-    out = tmp_path / "out"
-    result = run_batch(inp, out, source=all_roots_source)
-    statuses = {s.scan_key: s.status for s in result.scans}
-    assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}
-
-
 def test_scan_error_short_circuits_before_resolve(
     all_roots_source, tmp_path, monkeypatch
 ):
@@ -635,8 +619,9 @@ def test_scan_error_short_circuits_before_resolve(
     result = run_batch(inp, out, source=all_roots_source)
     statuses = {s.scan_key: s.status for s in result.scans}
     assert statuses == {"scanGOOD": "ok", "scanMISSING": "failed"}
-    # resolve() legitimately runs more than once for a successful scan (once for the
-    # identity-key comparison, once more inside worker.predict()) — what must never happen
-    # is a call for scanMISSING, whose ScanInput.params is None.
-    assert calls, "resolve() should have been called at least once, for scanGOOD"
+    # resolve() runs exactly twice for scanGOOD (once for the identity-key comparison
+    # in run_batch, once more inside worker.predict() -> get_predictors()) and never
+    # for scanMISSING (whose ScanInput.params is None) — pinning down both the "never
+    # called for an error'd scan" invariant and the documented call count together.
+    assert len(calls) == 2
     assert all(params is not None for params in calls)

--- a/uv.lock
+++ b/uv.lock
@@ -4151,15 +4151,15 @@ wheels = [
 
 [[package]]
 name = "sleap-roots-contracts"
-version = "0.1.0a6"
+version = "0.1.0a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/b5/3c3072c02e977a30f4713a0bae531ec651902192d206915d7ac0450efb79/sleap_roots_contracts-0.1.0a6.tar.gz", hash = "sha256:e4ae4598f771f22beccf78ea0f72acc922f87e39f1fed2f88f5796f38e29eed1", size = 27970, upload-time = "2026-07-31T22:06:33.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/dd/e512bb46a6209ed8c0e47d4861d8774fa94fc619ed4bc9b8bd675e377c61/sleap_roots_contracts-0.1.0a7.tar.gz", hash = "sha256:d3363ece42dc9052e6085016a54b52a921af01d75b325c9f9df52ced7466cd95", size = 28976, upload-time = "2026-08-04T21:24:13.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/35/d4b4f1d7ed702b1d70db54ab83461ede644ed7f95af7e99a774928cff80d/sleap_roots_contracts-0.1.0a6-py3-none-any.whl", hash = "sha256:5d779d8016db27ed19257603cb289165e75a14d1c9bc0aa2c546ef67f1c902ac", size = 35343, upload-time = "2026-07-31T22:06:32.093Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a8/f8bebd47b8c4d1a7d79a54c6ca5e499a42a40568a7b220cbba7a35195f64/sleap_roots_contracts-0.1.0a7-py3-none-any.whl", hash = "sha256:716f2055e893176ef60193f589789a528e3e397bffe08ab7577203c824815335", size = 36954, upload-time = "2026-08-04T21:24:12.299Z" },
 ]
 
 [[package]]
@@ -4238,7 +4238,7 @@ requires-dist = [
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'linux-cuda'", specifier = "==0.3.0" },
     { name = "sleap-nn", extras = ["torch-cuda128"], marker = "extra == 'windows-cuda'", specifier = "==0.3.0" },
     { name = "sleap-roots", marker = "extra == 'dev'", specifier = ">=0.1.4" },
-    { name = "sleap-roots-contracts", specifier = "==0.1.0a6" },
+    { name = "sleap-roots-contracts", specifier = "==0.1.0a7" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "sleap-roots-predict", extra = "cpu" } },
     { name = "torch", marker = "extra == 'linux-cuda'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "sleap-roots-predict", extra = "linux-cuda" } },


### PR DESCRIPTION
## Summary

Makes `sleap-roots-predict` consume `sleap-roots-contracts`' new `RunManifest` to scope `discover_scans` to exactly a run's `scan_keys`, and upgrades `run_batch`'s skip-if-done from a plain `Path.exists()` check to a real idempotency-key comparison — recomputed from artifacts already on disk, no new storage or contracts change needed. Resolves the `sleap-roots-predict` row of `sleap-roots-pipeline`#37's cross-repo idempotency chain.

## Changes

- Bump `sleap-roots-contracts` pin from `==0.1.0a6` to `==0.1.0a7` (`RunManifest` ships in a7).
- `discover_scans` reads an optional `run_manifest.json` from `input_dir`: when present, scopes discovery to exactly its `scan_keys` (an out-of-scope leftover sidecar is silently excluded; a manifest `scan_key` with no matching sidecar becomes an isolated failed scan); when absent, falls back unchanged to today's unscoped behavior; a malformed manifest raises before any scan is processed.
- `run_batch`'s skip-if-done now compares a recomputed idempotency key (`sleap_roots_contracts.identity.compute_idempotency_key`) for the current scan against the key recomputed from that scan's own previously-copied sidecar + previously-written `.predictions.json` — no new persistence anywhere.
- Restructures the per-scan loop so the existing `scan.error` short-circuit and per-scan `try/except` still isolate every new failure mode (a corrupt previous artifact re-predicts rather than being recorded as a batch failure; a manifest scan_key with no sidecar never reaches model resolution).
- **Accepted trade-off** (documented in the design doc): `resolve()` (a cheap, in-memory call) now runs once per non-error scan even when every scan is already done and will be skipped, since there's no way to know if models changed without listing them. What's actually cached per batch is `WarmModelWorker._cards` (the one-time `list_cards()` registry network call) — so a fully-resumed batch now touches the registry once instead of zero times, not once per `run_batch()` call as an earlier draft of this description imprecisely said.
- Docs updated: `CHANGELOG.md`, `API.md`, `README.md`, `openspec/project.md`.

**Post-review hardening** (from the `/review-pr` round below): added the debug-level log line the design doc promised for excluded out-of-scope sidecars (was missing from the original implementation); added a regression test pinning down that `resolve()` is never called for a `.error`-set scan; extracted two small shared helpers (`predictions_json_path`, `resolve_identity`) in `output_contract.py` so the `.predictions.json` filename and the `predict_code_sha`/`predict_container_digest` fallback logic each have one source of truth instead of being duplicated inline in `batch.py`; added a test for manifest-scoping combined with a sidecar stem/internal-`scan_key` mismatch; strengthened one repredict test's assertion to check the persisted value, not just the file's mtime.

## OpenSpec Change

- Change ID: `consume-run-manifest`
- Affected capabilities: `predict-container`
- Delta types: MODIFIED (scan discovery), RENAMED + MODIFIED (skip-if-exists resume → skip-if-done resume, idempotency-key verified)
- All `tasks.md` items complete: yes (36/36, including a post-review hardening group)
- Went through a 5-lens critical review round before implementation (spec quality, TDD/testing, implementation/build, docs, git workflow) — caught and fixed a real per-scan-isolation ordering bug before any code was written; see `docs/superpowers/specs/2026-08-14-consume-run-manifest-design.md` for full design rationale.

## Testing

- [x] CPU tests pass — 308 passed, 7 deselected (`pytest tests/`, `addopts` already filters `gpu`/`acceptance`/`wandb`/`parity` to match CI exactly)
- [x] GPU tests pass — 3 passed on this machine's NVIDIA RTX A5000 (`uv sync --extra dev --extra windows_cuda` then `pytest -m gpu tests/`)
- [x] New tests added: manifest-scoped discovery (present/absent/missing-scan/malformed), idempotency-key skip-if-done (unchanged/changed-params/changed-images_checksum/changed-code-sha/changed-model-ref/corrupt-previous-artifact/first-run), plus regression guards for every pre-existing failure-isolation test
- [x] Existing tests still cover affected paths — all 36 tests in `test_batch.py` green, including the highest-risk ones (`test_zero_resolved_models_is_failed`, `test_one_failing_scan_does_not_abort_batch`, `test_sidecar_copy_failure_leaves_no_manifest`, `test_resume_mixed_skip_and_predict`)

## Linting

- [x] Ruff passes
- [x] Codespell passes
- [x] Formatting passes (black)

## Build / Image

- [x] Wheel builds (`uv build`) — packaging changed (dependency bump)
- [ ] Docker image build — not run locally (Dockerfile itself unchanged; CI's `docker-build.yml` runs a build-only validation job on this PR automatically, confirmed to trigger on this file set)

## Downstream Compatibility

- [x] Output artifact format (`.slp`, `.predictions.json`) unchanged
- [x] No breaking change to the public API in `__init__.py`

## Breaking Changes

- [x] No breaking changes — every caller that never stages a `run_manifest.json` (the entire existing test suite, any standalone/local usage) is unaffected; an unchanged re-run still skips exactly as before

## Related Issues

Resolves the `sleap-roots-predict` row of talmolab/sleap-roots-pipeline#37

## Reviewer Notes

The accepted trade-off (resolve() now costs one registry round-trip per batch, even on a full resume) is the one behavior change worth double-checking — it was confirmed with the repo owner during the design review as inherent to correctly detecting a model-registry change, not a design flaw. See the design doc's "Accepted trade-off" section for the full reasoning and the alternative that was rejected (special-casing to skip resolve() when no other input changed, which would silently miss model-registry changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

