### PR TITLE
feat: Argo-ready exit semantics -- exit codes, empty-input guard, atomic writes, SIGTERM handling (predict #26)

### DIFF
--- a/API.md
+++ b/API.md
@@ -198,6 +198,7 @@ run_batch(
     batch_size: int = 4,
     predict_code_sha: Optional[str] = None,
     predict_container_digest: Optional[str] = None,
+    should_stop: Callable[[], bool] = lambda: False,
 ) -> BatchResult
 ```
 The container-oriented batch runner — also the `sleap-roots-predict` /
@@ -211,9 +212,14 @@ models **once** via a single resident `WarmModelWorker` (`source=None` → the p
 (`compute_idempotency_key`) against the prior run's own artifacts (no new storage — the key
 is recovered from the previously-copied sidecar and previously-written manifest), skipping
 only on an exact match and otherwise (re)predicting; writes the output-contract artifacts
-into `out_dir/{scan_key}/`, and copies the sidecar through so the output is a self-contained
-traits-input tree. Per-scan failures are isolated; `BatchResult.ok` is `False` iff any scan
-failed (the CLI exit code). See the `predict-container` OpenSpec spec.
+into `out_dir/{scan_key}/` (all writes atomic — temp file + rename), and copies the sidecar
+through so the output is a self-contained traits-input tree. `should_stop` is checked at
+each per-scan loop boundary; when it returns `True` the batch stops before the next scan
+(the CLI's `SIGTERM` handler wires this to graceful preemption). An empty (zero-scan) input
+raises rather than silently succeeding. Per-scan failures are isolated; `BatchResult.ok` is
+`False` iff any scan failed, which maps to CLI exit `3` — distinct from a staging-error or
+crash, which surfaces exit `1`. See the `predict-container` OpenSpec spec for the full
+exit-code contract.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -168,7 +168,10 @@ write_prediction_outputs(
 Write the named per-root `.slp` files and a combined `{scan_key}.predictions.json` into
 `out_dir` (created if missing); returns the `PredictionManifest`. `plant_qr_code` defaults
 to `scan_key`. Build identity falls back to `SRP_PREDICT_CODE_SHA` /
-`SRP_PREDICT_CONTAINER_DIGEST` then `""`. Re-runs overwrite in place.
+`SRP_PREDICT_CONTAINER_DIGEST` then `""`. Re-runs overwrite in place; a stale `.slp` from a
+changed model is removed only after every new file is written successfully. All writes
+(`.slp` and the manifest) are atomic — temp file + `os.replace` — so no reader ever
+observes a partially-written file; the manifest is written last.
 
 **Raises:** `ValueError` if `scan_key` is unsafe as a path segment, or `labels_by_root`
 and `refs_by_root` cover different root types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,14 +45,23 @@ All notable changes to this project are documented here. The format is based on
   `resolve()` (and its one-time model-registry fetch) now runs once per batch invocation even
   when every scan is already done, which it previously did not. Predicts (single-channel
   video), writes the output-contract artifacts into `out_dir/{scan_key}/`, and copies the
-  sidecar through so the output is a self-contained trait-extractor input tree. Per-scan
-  failures are isolated; the process exits non-zero iff any scan failed. The root `Dockerfile`
-  now ships a real exec-form `ENTRYPOINT ["python","-m","sleap_roots_predict"]` on the GPU
-  (`linux_cuda`) stack and bakes the build git sha (`SRP_PREDICT_CODE_SHA` build-arg → `ENV` →
-  manifest `predict_code_sha`); `docker-build.yml` tags `type=sha,format=long`. New public
-  export: `run_batch`. See the `predict-container` OpenSpec spec (closes #24, and the
-  `sleap-roots-predict` row of `sleap-roots-pipeline`#37). Model-derived channel handling (#25)
-  and Argo-readiness hardening (#26) are follow-ups.
+  sidecar through so the output is a self-contained trait-extractor input tree — the `.slp`,
+  manifest, and sidecar are all written atomically (temp file + rename), so no reader ever
+  observes a partially-written file. Per-scan failures are isolated. **Exit-code contract
+  (Argo-ready, #26):** `0` success, `3` partial (isolated scan failure(s), batch otherwise
+  completed), Python's default `1` for every other failure (a staging error — missing input
+  directory, duplicate `scan_key`, malformed `run_manifest.json`, or a now-rejected empty
+  input directory — or a genuine crash), `143` (`128+SIGTERM`) if a `SIGTERM` (Argo
+  preemption) stopped the batch at the next scan boundary; `2` is reserved for a CLI usage
+  error (`argparse`) and is never returned by the driver's own logic. **BREAKING**: an empty
+  (zero-scan) input directory previously exited `0` as a silent no-op — it now raises; the
+  previous `1`="some scan failed" / `2`="staging error" split is now `3`/default-`1`. The root
+  `Dockerfile` now ships a real exec-form `ENTRYPOINT ["python","-m","sleap_roots_predict"]`
+  on the GPU (`linux_cuda`) stack and bakes the build git sha (`SRP_PREDICT_CODE_SHA`
+  build-arg → `ENV` → manifest `predict_code_sha`); `docker-build.yml` tags
+  `type=sha,format=long`. New public export: `run_batch`. See the `predict-container`
+  OpenSpec spec (closes #24 and #26, and the `sleap-roots-predict` row of
+  `sleap-roots-pipeline`#37). Model-derived channel handling (#25) is a follow-up.
 - **A3-predict parity harness** (`sleap_roots_predict.parity`): resolves real human-labeled
   ground truth per production `ModelCard` (labels-registry lookup, bundled-labels path
   relinking, or basename search, in that priority order; unresolvable models are reported as

--- a/README.md
+++ b/README.md
@@ -208,13 +208,19 @@ Each scan is a directory of image frames with a co-located
 `{scan_key}.scan_metadata.json` sidecar (carrying the resolved `{species, mode, age}`
 params). If the input directory also has a `run_manifest.json` (staged by an upstream
 pipeline stage), discovery is scoped to exactly that manifest's `scan_keys` — a leftover
-sidecar from a prior run is silently excluded rather than reprocessed. The container loads
-models once, predicts every scan, and writes per scan
-`out/{scan_key}/{scan_key}.predictions.json` + named per-root `.slp` + a copy of the
-sidecar. Skip-if-done compares a recomputed idempotency key against the prior run's own
-artifacts (no new storage needed) and skips only on an exact match, (re)predicting
-otherwise; it exits non-zero if any scan failed. GPU is used when available
-(`nvidia.com/gpu`); it also runs CPU-only. The same entrypoint is available as a library:
+sidecar from a prior run is silently excluded rather than reprocessed. An empty (zero-scan)
+input directory raises rather than silently succeeding, so a misconfigured stage-in mount
+never looks like a completed batch. The container loads models once, predicts every scan,
+and writes per scan `out/{scan_key}/{scan_key}.predictions.json` + named per-root `.slp` +
+a copy of the sidecar, all written atomically (temp file + rename) so no reader ever
+observes a partially-written file. Skip-if-done compares a recomputed idempotency key
+against the prior run's own artifacts (no new storage needed) and skips only on an exact
+match, (re)predicting otherwise. A `SIGTERM` (Argo preemption) stops the batch at the next
+scan boundary rather than mid-scan. See the `predict-container` OpenSpec spec
+(`openspec/specs/predict-container/spec.md`) for the exact exit-code contract (`0`
+success / `3` partial / default `1` staging-error-or-crash / `143` `SIGTERM`-terminated;
+`2` is reserved for a CLI usage error). GPU is used when available (`nvidia.com/gpu`); it
+also runs CPU-only. The same entrypoint is available as a library:
 `from sleap_roots_predict import run_batch`, or `python -m sleap_roots_predict <in> <out>`.
 
 ## CI/CD

--- a/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
@@ -38,6 +38,21 @@ failure (staging error, empty-input, or crash, no longer split) / `143`=SIGTERM,
 untouched for `argparse` — identical to `sleap-roots#259`. Read `design.md`'s "Decisions" section
 for the full corrected reasoning; treat every `2` mentioned below as historical, not current.
 
+**Second amendment (2026-08-19), after `/review-openspec` round 1:** four more items surfaced and
+were resolved in the OpenSpec change's `design.md`/`tasks.md` (not re-litigated here in full —
+see those files): (1) two existing tests hardcode the pre-this-design exit-code scheme and needed
+naming explicitly so they'd be updated, not left contradicting new tests; (2) `sio.save_file`
+infers its output format from the destination filename's extension, so D3's `.slp` temp write
+must pass `format="slp"` explicitly rather than relying on a `.tmp`-suffixed temp name; (3) D4's
+`SIGTERM` handler registers cleanly on Windows but real `os.kill`-based delivery there invokes
+`TerminateProcess` instead of the handler — tests must call the handler directly, never via
+`os.kill` (the design below already did this correctly, just hadn't documented *why* it matters);
+(4) dropping the `except (FileNotFoundError, ValueError): return 2` clause (D1/D2) would also
+drop the clean log line for those two cases in favor of a raw traceback — decided to keep a narrow
+`except ...: log; raise` so the log line survives while the exit code still ends up as the default
+`1`. Also: three documentation spots (`README.md`, `API.md`, `CHANGELOG.md`) were found stale and
+now have explicit update tasks.
+
 ## What was already decided (we conform, not re-litigate)
 
 - **Per-scan isolation.** A scan-level error is caught, recorded `failed`, and the batch

--- a/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
@@ -36,7 +36,8 @@ D2 below are kept as a record of the original reasoning but are corrected in the
 `design.md` for this change: the scheme is now `0`=success / `3`=partial / default `1`=every other
 failure (staging error, empty-input, or crash, no longer split) / `143`=SIGTERM, with `2` left
 untouched for `argparse` — identical to `sleap-roots#259`. Read `design.md`'s "Decisions" section
-for the full corrected reasoning; treat every `2` mentioned below as historical, not current.
+for the full corrected reasoning; treat any `2`-as-aborted meaning below as historical — the
+`2`-reserved-for-`argparse` meaning is current and unchanged.
 
 **Second amendment (2026-08-19), after `/review-openspec` round 1:** four more items surfaced and
 were resolved in the OpenSpec change's `design.md`/`tasks.md` (not re-litigated here in full —

--- a/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
@@ -1,0 +1,221 @@
+# Argo-ready exit semantics + empty-input guard + write hardening
+
+## Context & goal
+
+The predict batch driver (`sleap_roots_predict/batch.py` `run_batch` + `__main__.py`, from
+predict #24/#27) is packaged as the `ghcr.io/talmolab/sleap-roots-predict` image and will be
+driven by A4's Argo `predictor` template (`sleap-roots-pipeline`). [predict #26](https://github.com/talmolab/sleap-roots-predict/issues/26)
+tracks three driver-side hardening items needed for that runtime: exit-code semantics vs Argo
+`retryStrategy`, an empty-input guard, and SIGTERM/write hardening for graceful preemption.
+
+None of these are defects in the current runner — they're the predict-side half of a hardening
+pass shared symmetrically with the traits driver ([sleap-roots #259](https://github.com/talmolab/sleap-roots/issues/259)).
+The A4 design doc (`sleap-roots-pipeline` `docs/superpowers/specs/2026-07-06-a4-request-driven-pipeline-design.md`
+§8, "Resumability & error handling") names this exact reconciliation as an open, not-yet-made
+decision for both producers ("**Producer Argo-readiness — reconcile *both* producers
+uniformly**... Resolve the exit-code / empty-input / SIGTERM policy the *same way for both* at
+wiring time"). This design is that decision, made from the predict side, since neither producer
+had it decided yet as of this writing (verified: sleap-roots#259 has no branch/PR). The bloomctl
+`batch-ingest-result` precedent ("zero exit on empty input") is **not** followed here — it's a
+different semantic context (an empty write-back call can legitimately mean "nothing new to write
+back"; an empty predict input dir means the stage-in mount was misconfigured, which is exactly
+the silent-green failure mode #26 exists to close).
+
+**Coordination note for the sleap-roots#259 session:** items 1 (exit codes) and 2 (empty-input)
+below are meant to match exactly across both repos. Item 3 is *not* expected to be symmetric —
+the traits driver's per-scan writes are already atomic (per its issue text), so it only needs the
+SIGTERM handler half.
+
+## What was already decided (we conform, not re-litigate)
+
+- **Per-scan isolation.** A scan-level error is caught, recorded `failed`, and the batch
+  continues (`run_batch`'s per-scan `try/except`). This slice does not change isolation — only
+  how the *aggregate* outcome is reported to the OS/Argo.
+- **Idempotency-key resume** (predict #35, merged 2026-08-18). `_previous_identity_key` already
+  treats any unreadable/corrupt previous manifest or sidecar as "changed, never as a failure" —
+  existence-only resume (the thing #26's original atomic-writes concern was about) no longer
+  exists. This closes the *silent-skip* half of item 3's original correctness concern (see
+  Decision 3 below) — confirmed by re-reading `batch.py`'s `_previous_identity_key` and its
+  docstring, not assumed.
+- **`out_scan_dir` layout**: `{scan_key}.predictions.json` + per-root `.slp` + copied-through
+  sidecar, one `out_dir/{scan_key}/` per scan (`output_contract.py`, `batch.py::_predict_one`).
+  Unchanged by this slice.
+
+## Decisions (the forks this slice resolves)
+
+### D1 — Exit codes: a dedicated `partial` code, distinct from a real crash
+
+Today: `0` = no scan failed, `1` = any scan failed *or* an uncaught exception (both collide on
+`1`) . A4 §8's own principle is to **distinguish scan-level error (mark failed, continue) from
+pod-level death (Argo retry + resume-skip)** — the current scheme can't express that distinction
+on the wire.
+
+New scheme:
+
+| Code | Meaning | Argo should... |
+|---|---|---|
+| `0` | Success — ≥1 scan discovered, none failed (`ok`/`skipped` only) | proceed normally |
+| `3` | **Partial** — ≥1 scan discovered and processed, ≥1 isolated scan failure, process did not crash | *not* retry the whole batch (per-scan isolation already ran); mark the step `partial` (Argo-template-side handling — out of scope here, see below) |
+| `2` | **Aborted** — pre-flight/staging error: missing input dir, duplicate `scan_key`, or zero scans discovered (D2) | do not retry blindly — the mount/config needs fixing, not a rerun |
+| *(none — Python default)* `1` | Uncaught exception (e.g. model-registry auth failure before the per-scan loop starts) — a genuine pod-level crash | Argo `retryStrategy` retries |
+
+This is a two-line change: `__main__.py`'s `return 0 if result.ok else 1` becomes
+`return 0 if result.ok else 3`, and the docstring/module comment updated to describe all four
+codes. `2` already exists (`FileNotFoundError`/`ValueError` staging errors); D2 below routes the
+new empty-input case through the same existing path, adding no new `except` clause.
+
+**Out of scope, flagged not implemented:** the Argo template still needs to interpret `3` as
+"partial, continue" rather than "step failed" (a `sleap-roots-pipeline` template change, e.g.
+`retryStrategy` conditioned on exit code, or `continueOn`). Noted per #26's own scope boundary.
+
+### D2 — Empty input becomes a staging error, not a silent no-op
+
+`run_batch` currently: `discover_scans` returns `[]` → logs a warning → returns
+`BatchResult(scans=[])` (`ok=True`) → CLI exits `0`. A misconfigured or empty `-v …:/in` mount
+today produces a green Argo node that emitted nothing.
+
+Fix: `run_batch` raises `ValueError(f"no scans discovered under {input_dir}")` in place of the
+current warn-and-return-empty branch, *before* constructing the `WarmModelWorker` (no needless
+model load). This reuses `__main__.py`'s existing `except (FileNotFoundError, ValueError)` →
+log + exit `2` path unchanged — no new exception type, no new CLI branch.
+
+This applies uniformly, including when a `run_manifest.json` is present and scopes discovery to
+zero `scan_keys` — a manifest declaring nothing to do is itself worth surfacing loudly rather
+than silently no-op'ing, consistent with the rest of this design's stance on empty input.
+
+**Not empty input, unaffected:** a manifest that lists scan_keys with no matching sidecar
+produces isolated per-scan `error` entries (`ScanInput.error` set) — `discover_scans` returns a
+*non-empty* list in that case, so it flows through the existing per-scan-failure path and ends in
+D1's `partial` (`3`), not the aborted (`2`) path. Only a *literally empty* discovered-scan list
+triggers D2.
+
+### D3 — Atomic writes: still worth it, as defense-in-depth (not a closed correctness hole)
+
+Re-investigated per the handoff's explicit instruction to re-verify this item's scope: the
+issue's original framing ("atomic writes + checksum-verified skip must ship together, or a
+SIGKILL-truncated manifest is silently treated as done") is **no longer accurate** — predict #35
+already replaced existence-only resume with the idempotency-key recompute, and a corrupt/partial
+manifest or sidecar is unconditionally treated as "changed" (never skipped) by
+`_previous_identity_key`. Tracing every write ordering in `_predict_one`/`write_prediction_outputs`
+confirms no remaining path where a truncated write is later mistaken for "done" by predict's own
+resume logic.
+
+The correctness hole is closed. What's *not* addressed by resume logic is a different, narrower
+concern: an **external reader** (not predict's own resume — e.g. a future direct read of
+`{scan}.predictions.json` or a `.slp` that races predict's write, outside the normal
+"Argo step completes, then the next step starts" ordering) could observe a torn/partial file.
+Given the fix is cheap (temp-file-in-same-dir + `os.replace`) and brings predict to parity with
+the traits driver's existing atomic writes, this ships as defense-in-depth, explicitly **not**
+because it closes a live correctness bug.
+
+Scope: `write_prediction_outputs`'s two write sites (`sio.save_file` for each `.slp`,
+`.write_text` for the manifest) both move to write-temp-then-`os.replace` in the same directory
+(guarantees the rename is atomic on the same filesystem — no cross-filesystem temp dirs). The
+manifest write stays strictly last (already documented as the resume commit-marker; unchanged).
+The sidecar copy in `batch.py::_predict_one` (`shutil.copyfile`, which happens *before* the
+manifest for the same reason) gets the same temp+rename treatment for consistency — it's the
+third file in the same "external reader could see a torn file" category, and the change is a few
+lines.
+
+The pre-write stale-`.slp` cleanup pass (removes orphaned artifacts from a changed model slug)
+stays unchanged — it doesn't gate resume (which only reads the manifest) and moving it doesn't
+change the correctness story either way.
+
+### D4 — SIGTERM handler: finish current scan, stop at the next boundary
+
+The image's exec-form `ENTRYPOINT ["python","-m","sleap_roots_predict"]` makes `python` PID 1
+with no signal handler, so Argo preemption waits out the full `terminationGracePeriodSeconds`
+before SIGKILL.
+
+Design: `main()` creates a `threading.Event`, installs a `signal.signal(signal.SIGTERM, ...)`
+handler that sets it (signal-handler-safe — just a flag write, no blocking calls), and passes
+`should_stop=event.is_set` into `run_batch` as a new optional keyword parameter (default a no-op
+returning `False`, so every existing caller/test is unaffected). `run_batch`'s per-scan loop
+checks `should_stop()` at the top of each iteration (a scan boundary, never mid-inference — there
+is no safe interrupt point inside sleap-nn/GPU inference) and breaks early, logging how many of
+the discovered scans were attempted.
+
+After `run_batch` returns, `main()` checks the event directly (no new `BatchResult` field needed
+— this is CLI-level signal reporting, not a batch-outcome concern): if set, log "terminated by
+SIGTERM after a partial batch" and return `143` (`128 + SIGTERM`, standard Unix convention for
+"killed by signal N"), overriding whatever D1 exit code the completed-so-far scans would
+otherwise produce. This makes the container's own reported exit code honestly reflect "I was
+asked to stop," distinct from `0`/`2`/`3`.
+
+**Known limitation, accepted:** worst-case latency is bounded by one scan's predict duration, not
+truly immediate. A pathologically long single scan can still exceed the grace period and get
+SIGKILLed anyway — accepted, since interrupting mid-inference isn't safely possible and D3's
+atomic writes mean a SIGKILL mid-scan still can't leave a torn artifact that looks done.
+
+## Architecture
+
+No new modules. Changes are localized:
+
+- `sleap_roots_predict/batch.py`: `run_batch` gains `should_stop: Callable[[], bool] = <no-op>`
+  (checked at loop top, D4); the empty-scans branch raises instead of returning (D2); `_predict_one`'s
+  sidecar copy becomes atomic (D3).
+- `sleap_roots_predict/__main__.py`: installs the `SIGTERM` handler + `threading.Event` around the
+  `run_batch` call (D4); exit-code logic changes from `0/1` to `0/2/3/(default 1)/143` (D1, D4);
+  docstring updated to enumerate all codes.
+- `sleap_roots_predict/output_contract.py`: `write_prediction_outputs`'s `.slp` and manifest
+  writes move to temp-then-`os.replace` (D3).
+
+## Data flow
+
+Unchanged at the scan level (discover → resolve → predict → write). What changes is only the
+*aggregate* signal surfaced after the loop (exit code) and the *durability* of each individual
+write (atomic vs. direct) — no change to `PredictionManifest`/`PredictionArtifact` shape, no
+change to what's discovered or how scans are matched to models.
+
+## Testing (real TDD, no mocks — mirrors existing suite's convention)
+
+- D1: `test___main__.py` (or equivalent) — a batch with one failed scan and otherwise-ok scans
+  exits `3`; an all-ok batch exits `0`; existing `FileNotFoundError`/duplicate-key cases still
+  exit `2`.
+- D2: `run_batch` over an empty (but existing) directory raises `ValueError`; CLI exits `2` with a
+  clear logged message. A `run_manifest.json` scoping to zero `scan_keys` also raises. A manifest
+  scoping to keys with no matching sidecar still produces isolated `failed` entries (exit `3`,
+  not `2`) — a regression test pinning this distinction.
+- D3: a write interrupted between temp-write and rename (simulate by asserting the temp file
+  never exists at the final path's name until the whole write succeeds) — assert no
+  partially-written file is ever visible under the final filename; existing round-trip tests
+  (`write_prediction_outputs` writes then is re-readable) must keep passing unchanged.
+- D4: `run_batch` with `should_stop` returning `True` after the first scan stops before the
+  second, and the first scan's outputs are complete and valid; CLI-level test sends `SIGTERM` to
+  a subprocess mid-batch (or, more practically given sandboxing constraints, a unit test on
+  `main()`'s signal-handling logic in isolation, with `run_batch` mocked... **actually avoid a
+  mock here** — real TDD is this repo's convention; prefer driving the handler + event logic
+  directly (call the registered handler function, assert the event becomes set, assert
+  `run_batch` observes `should_stop() is True` and stops) over a full subprocess-signal test if a
+  real subprocess test proves too flaky in CI.
+
+## OpenSpec scope
+
+Modifies the existing `predict-container` capability (established by predict #24/#27) — this is
+a behavior change to an already-specced capability (exit codes, empty-input handling, write
+durability, signal handling), not a new capability. One `openspec/changes/<id>/specs/predict-container/spec.md`
+delta with `MODIFIED Requirements` covering D1–D4.
+
+## Risks & assumptions
+
+- Assumes Argo's own template/`retryStrategy` will eventually be updated to treat exit `3`
+  specially (D1's "out of scope, flagged" item) — until that pipeline-repo change lands, exit `3`
+  behaves like any other non-zero exit under today's `retryStrategy` (i.e., Argo still retries the
+  whole batch on a `partial` result). This design does not regress that — it's already true today
+  under exit `1` — it just makes the *distinction* representable once the template catches up.
+- `os.replace` atomicity assumes the temp file and final path are on the same filesystem (same
+  parent directory) — true for the shared mount described in A4 §8.
+- The SIGTERM handler assumes CPython delivers signals promptly between bytecode instructions,
+  which holds for the pure-Python loop-boundary check but does not shorten a single blocking
+  native call (e.g. a long `sio.save_file` or model inference call) already in flight.
+
+## Out of scope
+
+- The Argo `WorkflowTemplate`/`retryStrategy` change to interpret exit code `3` as "partial,
+  continue" (`sleap-roots-pipeline` repo).
+- Matching this decision into the traits driver (`sleap-roots#259`) — tracked there, not
+  implemented here; this doc is written to be directly referenceable from that session.
+- SIGINT/Ctrl+C handling (Argo only sends SIGTERM; interactive use is out of this issue's scope).
+- Any change to per-scan retry-count/`MAX_SCAN_ATTEMPTS` semantics (A4 §8 mentions retry-then-isolate
+  as a *pipeline-level* concept — the pod is retried by Argo, not the individual scan by predict
+  itself).

--- a/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md
@@ -26,6 +26,18 @@ below are meant to match exactly across both repos. Item 3 is *not* expected to 
 the traits driver's per-scan writes are already atomic (per its issue text), so it only needs the
 SIGTERM handler half.
 
+**Amendment (2026-08-19), after checking in with the sleap-roots#259 session:** D1's original
+scheme below (`0`/`2`-aborted/`3`-partial/default-`1`-crash) is superseded. That session's own
+`review-openspec` pass caught that reusing an exit code for a driver-owned "aborted" bucket
+collides with `argparse`'s pre-existing usage-error `sys.exit(2)` — a bug this repo's CLI shares
+(`sleap_roots_predict/__main__.py` also parses via `argparse`, and its pre-existing `except
+(FileNotFoundError, ValueError): return 2` already collides with it, unnoticed until now). D1 and
+D2 below are kept as a record of the original reasoning but are corrected in the OpenSpec
+`design.md` for this change: the scheme is now `0`=success / `3`=partial / default `1`=every other
+failure (staging error, empty-input, or crash, no longer split) / `143`=SIGTERM, with `2` left
+untouched for `argparse` — identical to `sleap-roots#259`. Read `design.md`'s "Decisions" section
+for the full corrected reasoning; treat every `2` mentioned below as historical, not current.
+
 ## What was already decided (we conform, not re-litigate)
 
 - **Per-scan isolation.** A scan-level error is caught, recorded `failed`, and the batch
@@ -50,19 +62,21 @@ Today: `0` = no scan failed, `1` = any scan failed *or* an uncaught exception (b
 pod-level death (Argo retry + resume-skip)** — the current scheme can't express that distinction
 on the wire.
 
-New scheme:
+New scheme (**corrected 2026-08-19** — see the Amendment note above; the originally-drafted `2`
+= aborted code is dropped):
 
 | Code | Meaning | Argo should... |
 |---|---|---|
 | `0` | Success — ≥1 scan discovered, none failed (`ok`/`skipped` only) | proceed normally |
 | `3` | **Partial** — ≥1 scan discovered and processed, ≥1 isolated scan failure, process did not crash | *not* retry the whole batch (per-scan isolation already ran); mark the step `partial` (Argo-template-side handling — out of scope here, see below) |
-| `2` | **Aborted** — pre-flight/staging error: missing input dir, duplicate `scan_key`, or zero scans discovered (D2) | do not retry blindly — the mount/config needs fixing, not a rerun |
-| *(none — Python default)* `1` | Uncaught exception (e.g. model-registry auth failure before the per-scan loop starts) — a genuine pod-level crash | Argo `retryStrategy` retries |
+| *(none — Python default)* `1` | Every other failure: a pre-flight/staging error (missing input dir, duplicate `scan_key`, zero scans discovered — D2) or a genuine uncaught crash (e.g. model-registry auth failure before the per-scan loop starts) — no longer split into a separate code | Argo `retryStrategy` retries |
+| `2` | *(not used by this driver)* — reserved: `argparse` already calls `sys.exit(2)` on a CLI usage error, before `run_batch` ever runs | n/a — a CLI invocation problem, unrelated to a batch outcome |
 
 This is a two-line change: `__main__.py`'s `return 0 if result.ok else 1` becomes
-`return 0 if result.ok else 3`, and the docstring/module comment updated to describe all four
-codes. `2` already exists (`FileNotFoundError`/`ValueError` staging errors); D2 below routes the
-new empty-input case through the same existing path, adding no new `except` clause.
+`return 0 if result.ok else 3`, its `except (FileNotFoundError, ValueError): return 2` special
+case is **removed** (those exceptions now propagate uncaught, surfacing as the default `1`, like
+any other crash), and the docstring/module comment is updated to describe the three driver-owned
+codes plus the `argparse`-owned `2`.
 
 **Out of scope, flagged not implemented:** the Argo template still needs to interpret `3` as
 "partial, continue" rather than "step failed" (a `sleap-roots-pipeline` template change, e.g.
@@ -76,8 +90,8 @@ today produces a green Argo node that emitted nothing.
 
 Fix: `run_batch` raises `ValueError(f"no scans discovered under {input_dir}")` in place of the
 current warn-and-return-empty branch, *before* constructing the `WarmModelWorker` (no needless
-model load). This reuses `__main__.py`'s existing `except (FileNotFoundError, ValueError)` →
-log + exit `2` path unchanged — no new exception type, no new CLI branch.
+model load). **Corrected 2026-08-19:** `__main__.py` no longer catches this into a special exit
+code — it propagates like any other staging exception, surfacing as the default `1` (see D1).
 
 This applies uniformly, including when a `run_manifest.json` is present and scopes discovery to
 zero `scan_keys` — a manifest declaring nothing to do is itself worth surfacing loudly rather
@@ -86,7 +100,7 @@ than silently no-op'ing, consistent with the rest of this design's stance on emp
 **Not empty input, unaffected:** a manifest that lists scan_keys with no matching sidecar
 produces isolated per-scan `error` entries (`ScanInput.error` set) — `discover_scans` returns a
 *non-empty* list in that case, so it flows through the existing per-scan-failure path and ends in
-D1's `partial` (`3`), not the aborted (`2`) path. Only a *literally empty* discovered-scan list
+D1's `partial` (`3`), not the crash (`1`) path. Only a *literally empty* discovered-scan list
 triggers D2.
 
 ### D3 — Atomic writes: still worth it, as defense-in-depth (not a closed correctness hole)
@@ -140,7 +154,7 @@ After `run_batch` returns, `main()` checks the event directly (no new `BatchResu
 SIGTERM after a partial batch" and return `143` (`128 + SIGTERM`, standard Unix convention for
 "killed by signal N"), overriding whatever D1 exit code the completed-so-far scans would
 otherwise produce. This makes the container's own reported exit code honestly reflect "I was
-asked to stop," distinct from `0`/`2`/`3`.
+asked to stop," distinct from `0`/`3`/default `1`.
 
 **Known limitation, accepted:** worst-case latency is bounded by one scan's predict duration, not
 truly immediate. A pathologically long single scan can still exceed the grace period and get
@@ -155,8 +169,9 @@ No new modules. Changes are localized:
   (checked at loop top, D4); the empty-scans branch raises instead of returning (D2); `_predict_one`'s
   sidecar copy becomes atomic (D3).
 - `sleap_roots_predict/__main__.py`: installs the `SIGTERM` handler + `threading.Event` around the
-  `run_batch` call (D4); exit-code logic changes from `0/1` to `0/2/3/(default 1)/143` (D1, D4);
-  docstring updated to enumerate all codes.
+  `run_batch` call (D4); exit-code logic changes from `0/1` to `0/3/(default 1)/143` (D1, D4),
+  removing the special-cased `except (FileNotFoundError, ValueError): return 2` (D1); docstring
+  updated to enumerate the three driver-owned codes plus the `argparse`-owned `2`.
 - `sleap_roots_predict/output_contract.py`: `write_prediction_outputs`'s `.slp` and manifest
   writes move to temp-then-`os.replace` (D3).
 
@@ -170,12 +185,14 @@ change to what's discovered or how scans are matched to models.
 ## Testing (real TDD, no mocks — mirrors existing suite's convention)
 
 - D1: `test___main__.py` (or equivalent) — a batch with one failed scan and otherwise-ok scans
-  exits `3`; an all-ok batch exits `0`; existing `FileNotFoundError`/duplicate-key cases still
-  exit `2`.
-- D2: `run_batch` over an empty (but existing) directory raises `ValueError`; CLI exits `2` with a
-  clear logged message. A `run_manifest.json` scoping to zero `scan_keys` also raises. A manifest
-  scoping to keys with no matching sidecar still produces isolated `failed` entries (exit `3`,
-  not `2`) — a regression test pinning this distinction.
+  exits `3`; an all-ok batch exits `0`; existing `FileNotFoundError`/duplicate-key cases now exit
+  the default `1` (no longer a distinct `2` — a regression test pinning the removal, not just the
+  addition). A test asserting a CLI usage error (missing required argument) exits `2` via
+  `argparse`, documenting that this is unrelated to the driver's own `0`/`1`/`3` codes.
+- D2: `run_batch` over an empty (but existing) directory raises `ValueError`; CLI exits the
+  default `1` with a clear logged message. A `run_manifest.json` scoping to zero `scan_keys` also
+  raises. A manifest scoping to keys with no matching sidecar still produces isolated `failed`
+  entries (exit `3`, not `1`) — a regression test pinning this distinction.
 - D3: a write interrupted between temp-write and rename (simulate by asserting the temp file
   never exists at the final path's name until the whole write succeeds) — assert no
   partially-written file is ever visible under the final filename; existing round-trip tests

--- a/openspec/changes/harden-argo-exit-semantics/design.md
+++ b/openspec/changes/harden-argo-exit-semantics/design.md
@@ -46,19 +46,24 @@ doc for the "why not the alternative" reasoning.
       operationally load-bearing: A4's `retryStrategy`/`continueOn` only needs to special-case `3`
       (partial); every other nonzero code is retried the same way regardless of whether it's `1`
       or a separate `2`. Losing that distinction costs log readability, not Argo behavior.
-- **Empty input → raise:** previously reused the existing `except (FileNotFoundError, ValueError)`
-  → exit `2` path in `__main__.py`. Per the reversed decision above, that special case's exit code
-  is removed — `run_batch` still raises on empty input (unchanged goal), and any other staging
-  exception simply propagates, surfacing as Python's default `1`, identical to any other crash.
+- **Empty input → raise:** `run_batch` raises `ValueError` on zero discovered scans — a distinct
+  raise site from a `run_manifest.json` scoping discovery to zero `scan_keys` (that one fails
+  `RunManifest` validation inside `discover_scans` before it ever returns; see the spec delta's
+  "Note" under its empty-input scenario). Both land on the same exit code (below), but they are
+  two different code paths, not one.
 - **Revised again after `/review-openspec` round 1 (2026-08-19): keep the log line, drop only the
-  exit code.** The straightforward reading of "propagate uncaught" would also drop the clean
-  `"Batch aborted: %s"` log message these two exception types currently get, replacing it with a
-  raw Python traceback — a real log-aggregation regression the first draft of this design didn't
-  discuss. Decision: `__main__.py` keeps a narrow
+  special exit code.** The original plan to let staging exceptions "propagate uncaught" would also
+  have dropped the clean `"Batch aborted: %s"` log message `FileNotFoundError`/`ValueError` cases
+  currently get, replacing it with a raw Python traceback — a real log-aggregation regression the
+  first draft of this design didn't discuss. Decision: `__main__.py` keeps a narrow
   `except (FileNotFoundError, ValueError) as exc: log; raise` — the log line survives, the
   exception still propagates uncaught afterward, and the final exit code is still Python's default
-  `1`. Any *other* exception type (not one of these two known staging errors) is never caught at
-  all and gets the default traceback + exit `1`, unchanged.
+  `1`. Because `json.JSONDecodeError` and `pydantic.ValidationError` both subclass `ValueError`
+  (confirmed, not assumed), this one `except` clause actually covers **all four** staging-error
+  cases (missing directory, duplicate `scan_key`, malformed manifest, and zero-scans-discovered),
+  not just two — every one of them gets the clean log line. Only a genuine crash of some other
+  exception type (e.g. a wandb authentication failure) falls outside it and gets the default
+  traceback + exit `1`, unchanged.
 - **Atomic writes are defense-in-depth, not a correctness fix:** verified (not assumed) that
   predict #35's `_previous_identity_key` already treats a corrupt/truncated previous artifact as
   "changed," so a SIGKILL-truncated file was never silently treated as done under the *current*
@@ -73,15 +78,12 @@ doc for the "why not the alternative" reasoning.
 - **SIGTERM: stop at scan boundary, not mid-inference:** a `threading.Event` set by the signal
   handler, checked at the top of `run_batch`'s per-scan loop. Bounded worst-case latency = one
   scan's duration (accepted; there's no safe interrupt point inside sleap-nn/GPU inference).
-  - **Windows caveat found in `/review-openspec` round 1:** `signal.signal(signal.SIGTERM, ...)`
-    registers without error on Windows, but real cross-process delivery
-    (`os.kill(pid, signal.SIGTERM)`) is implemented via `TerminateProcess`, which kills the
-    process immediately **without invoking the registered handler** — unlike Linux/macOS, where
-    real delivery does invoke it. This repo's CI runs a Windows job, so the handler's *logic* is
-    unit-tested by invoking it directly (never via `os.kill`); real end-to-end SIGTERM delivery is
+  - **Windows caveat found in `/review-openspec` round 1** (canonical statement now lives in
+    `specs/predict-container/spec.md`'s "Graceful SIGTERM handling" requirement — summarized
+    here, not restated in full): real Windows `SIGTERM` delivery bypasses the registered handler
+    entirely, so tests must call the handler directly, never via `os.kill`. This repo's CI runs a
+    Windows job; the handler's *logic* is unit-tested directly, while real end-to-end delivery is
     only ever meaningfully validated on Linux (the actual Argo/Kubernetes runtime) or macOS.
-    Nobody should "improve" the test to use `os.kill` later — on Windows that would silently hang
-    or kill the CI job instead of failing cleanly.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/harden-argo-exit-semantics/design.md
+++ b/openspec/changes/harden-argo-exit-semantics/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Full design rationale, alternatives considered, and cross-repo coordination notes live in
+`docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md` (approved via
+`superpowers:brainstorming`). This file summarizes the decisions for OpenSpec purposes; see that
+doc for the "why not the alternative" reasoning.
+
+## Goals / Non-Goals
+
+- Goals: make the CLI's exit code distinguish "isolated scan failure(s), batch otherwise
+  completed" from "the process crashed"; make an empty input directory a loud error instead of a
+  silent no-op; add a `SIGTERM` handler for prompt-enough preemption; close the residual
+  torn-file-visible-to-an-external-reader window via atomic writes.
+- Non-Goals: changing the Argo `WorkflowTemplate`/`retryStrategy` itself (pipeline-repo concern);
+  applying this to the traits driver (a separate repo/session, `sleap-roots#259`); `SIGINT`
+  handling; per-scan retry-count/`MAX_SCAN_ATTEMPTS` semantics.
+
+## Decisions
+
+- **Exit codes:** `0`=success, `2`=aborted (staging error, incl. empty-input via a new raise in
+  `run_batch`), `3`=partial (new — replaces the old overloaded `1` for "some scan failed"),
+  default Python `1`=uncaught crash. `143` (`128+SIGTERM`) overrides all of the above when the
+  process was asked to stop early.
+  - Alternative considered: exit `0` on any completed run regardless of per-scan failures,
+    pushing failure detection entirely onto the written manifests. Rejected — throws away a
+    cheap wire-level signal Argo can act on without reading output files.
+- **Empty input → raise:** reuses the existing `except (FileNotFoundError, ValueError)` → exit
+  `2` path in `__main__.py`; no new exception type or CLI branch.
+- **Atomic writes are defense-in-depth, not a correctness fix:** verified (not assumed) that
+  predict #35's `_previous_identity_key` already treats a corrupt/truncated previous artifact as
+  "changed," so a SIGKILL-truncated file was never silently treated as done under the *current*
+  resume logic. Ships anyway — cheap, closes an external-reader race, brings parity with the
+  traits driver's existing atomic writes.
+- **SIGTERM: stop at scan boundary, not mid-inference:** a `threading.Event` set by the signal
+  handler, checked at the top of `run_batch`'s per-scan loop. Bounded worst-case latency = one
+  scan's duration (accepted; there's no safe interrupt point inside sleap-nn/GPU inference).
+
+## Risks / Trade-offs
+
+- Exit code `3` has no effect on Argo behavior until the pipeline-repo template is updated to
+  treat it as `partial` — until then it's simply "a non-zero code Argo retries," identical to
+  today's behavior under `1`. Not a regression, just not yet load-bearing on the Argo side.
+- `os.replace` atomicity requires the temp file and final path to share a filesystem (true for
+  the shared mount A4 assumes; would not hold if `out_dir` ever spanned mounts).
+
+## Migration Plan
+
+No data migration. Behavioral/CLI-contract change only:
+- Any caller depending on exit `1` meaning "some scan failed" must switch to checking for `3`
+  (or treat any non-zero as failure, which still works, just loses the new distinction).
+- Any caller depending on empty-input silently exiting `0` will now see it raise/exit `2` — a
+  deliberate **BREAKING** change per the issue's own ask.
+
+## Open Questions
+
+None outstanding — all four forks (exit codes, empty-input, atomic writes, SIGTERM) were resolved
+during brainstorming; see the linked design doc for the full decision trail.

--- a/openspec/changes/harden-argo-exit-semantics/design.md
+++ b/openspec/changes/harden-argo-exit-semantics/design.md
@@ -47,18 +47,41 @@ doc for the "why not the alternative" reasoning.
       (partial); every other nonzero code is retried the same way regardless of whether it's `1`
       or a separate `2`. Losing that distinction costs log readability, not Argo behavior.
 - **Empty input → raise:** previously reused the existing `except (FileNotFoundError, ValueError)`
-  → exit `2` path in `__main__.py`. Per the reversed decision above, that special case is removed
-  entirely — `run_batch` still raises on empty input (unchanged goal), but `__main__.py` no longer
-  catches `FileNotFoundError`/`ValueError` into a custom code; they (and any other staging
-  exception) simply propagate, surfacing as Python's default `1`, identical to any other crash.
+  → exit `2` path in `__main__.py`. Per the reversed decision above, that special case's exit code
+  is removed — `run_batch` still raises on empty input (unchanged goal), and any other staging
+  exception simply propagates, surfacing as Python's default `1`, identical to any other crash.
+- **Revised again after `/review-openspec` round 1 (2026-08-19): keep the log line, drop only the
+  exit code.** The straightforward reading of "propagate uncaught" would also drop the clean
+  `"Batch aborted: %s"` log message these two exception types currently get, replacing it with a
+  raw Python traceback — a real log-aggregation regression the first draft of this design didn't
+  discuss. Decision: `__main__.py` keeps a narrow
+  `except (FileNotFoundError, ValueError) as exc: log; raise` — the log line survives, the
+  exception still propagates uncaught afterward, and the final exit code is still Python's default
+  `1`. Any *other* exception type (not one of these two known staging errors) is never caught at
+  all and gets the default traceback + exit `1`, unchanged.
 - **Atomic writes are defense-in-depth, not a correctness fix:** verified (not assumed) that
   predict #35's `_previous_identity_key` already treats a corrupt/truncated previous artifact as
   "changed," so a SIGKILL-truncated file was never silently treated as done under the *current*
   resume logic. Ships anyway — cheap, closes an external-reader race, brings parity with the
   traits driver's existing atomic writes.
+  - **Implementation gotcha found in `/review-openspec` round 1:** `sio.save_file` infers its
+    output format purely from the destination filename's extension and raises if it doesn't
+    recognize one. A temp filename built by naively appending `.tmp` (this repo's existing
+    convention elsewhere, e.g. `parity.py`'s `write_report`) would turn `foo.slp` into
+    `foo.slp.tmp`, which `sio.save_file` can't dispatch. The `.slp` temp write must pass
+    `format="slp"` explicitly instead of relying on the temp name's extension.
 - **SIGTERM: stop at scan boundary, not mid-inference:** a `threading.Event` set by the signal
   handler, checked at the top of `run_batch`'s per-scan loop. Bounded worst-case latency = one
   scan's duration (accepted; there's no safe interrupt point inside sleap-nn/GPU inference).
+  - **Windows caveat found in `/review-openspec` round 1:** `signal.signal(signal.SIGTERM, ...)`
+    registers without error on Windows, but real cross-process delivery
+    (`os.kill(pid, signal.SIGTERM)`) is implemented via `TerminateProcess`, which kills the
+    process immediately **without invoking the registered handler** — unlike Linux/macOS, where
+    real delivery does invoke it. This repo's CI runs a Windows job, so the handler's *logic* is
+    unit-tested by invoking it directly (never via `os.kill`); real end-to-end SIGTERM delivery is
+    only ever meaningfully validated on Linux (the actual Argo/Kubernetes runtime) or macOS.
+    Nobody should "improve" the test to use `os.kill` later — on Windows that would silently hang
+    or kill the CI job instead of failing cleanly.
 
 ## Risks / Trade-offs
 
@@ -80,6 +103,10 @@ No data migration. Behavioral/CLI-contract change only:
   `retryStrategy`/`continueOn` logic yet).
 - Any caller depending on empty-input silently exiting `0` will now see it raise/exit `1` — a
   deliberate **BREAKING** change per the issue's own ask.
+- `README.md`'s "Running the predict container" section and `API.md`'s `run_batch` entry both
+  describe the old exit-code contract in prose (found stale in `/review-openspec` round 1); both
+  now have explicit update tasks (`tasks.md` 5.2/5.3), as does a `CHANGELOG.md` `[Unreleased]`
+  entry (5.4) for this **BREAKING** change.
 
 ## Open Questions
 
@@ -87,3 +114,9 @@ No data migration. Behavioral/CLI-contract change only:
   matching `sleap-roots#259` exactly — see the reversed decision above). Nothing else outstanding
   from the original four forks (exit codes, empty-input, atomic writes, SIGTERM); see the linked
   design doc for the full decision trail on those.
+- `/review-openspec` round 1 (2026-08-19) surfaced and resolved: two existing tests
+  (`test_cli_main_exit_codes`, `test_cli_missing_input_dir_returns_nonzero`) hardcoding the old
+  scheme, now named explicitly in `tasks.md` 1.1/1.3; the `sio.save_file` format-dispatch gotcha
+  (`tasks.md` 3.5); the Windows `SIGTERM`-delivery caveat (documented above); the log-line
+  preservation decision (documented above); and the three documentation gaps (above). Nothing
+  outstanding pending a round-2 re-review.

--- a/openspec/changes/harden-argo-exit-semantics/design.md
+++ b/openspec/changes/harden-argo-exit-semantics/design.md
@@ -17,15 +17,40 @@ doc for the "why not the alternative" reasoning.
 
 ## Decisions
 
-- **Exit codes:** `0`=success, `2`=aborted (staging error, incl. empty-input via a new raise in
-  `run_batch`), `3`=partial (new — replaces the old overloaded `1` for "some scan failed"),
-  default Python `1`=uncaught crash. `143` (`128+SIGTERM`) overrides all of the above when the
-  process was asked to stop early.
+- **Exit codes:** `0`=success, `3`=partial (new — replaces the old overloaded `1` for "some scan
+  failed"), default Python `1`=every other failure (staging error, empty-input, or a genuine
+  uncaught crash — no longer split out). `143` (`128+SIGTERM`) overrides all of the above when the
+  process was asked to stop early. `2` is deliberately left alone.
   - Alternative considered: exit `0` on any completed run regardless of per-scan failures,
     pushing failure detection entirely onto the written manifests. Rejected — throws away a
     cheap wire-level signal Argo can act on without reading output files.
-- **Empty input → raise:** reuses the existing `except (FileNotFoundError, ValueError)` → exit
-  `2` path in `__main__.py`; no new exception type or CLI branch.
+  - **Alternative considered and reversed after cross-repo reconciliation (2026-08-19): keep a
+    distinct `2`=aborted code for staging errors, separate from a generic `1`=crash.** This was
+    the original decision reached during this proposal's own brainstorming, before checking the
+    sibling `sleap-roots#259` proposal. Rejected once checked, because:
+    - `sleap_roots_predict/__main__.py` parses args via `argparse`, and
+      `argparse.ArgumentParser.error()` already calls `sys.exit(2)` on a bad invocation (verified
+      empirically: `python -m sleap_roots_predict` with missing args exits `2` today) — this
+      predates this proposal (shipped with #24's CLI) and was never previously flagged. Reusing
+      `2` for "aborted" (already true today for `FileNotFoundError`/`ValueError`, and this
+      proposal was about to extend it to empty-input too) makes a genuine CLI-usage
+      misconfiguration indistinguishable from a staging error at the exit-code level.
+    - The `sleap-roots#259` proposal's own `review-openspec` pass caught the identical bug in its
+      first draft (which had picked `2` for "partial") and fixed it by reserving `2` for
+      `argparse` and using `3` for the one code that's actually load-bearing for Argo. Diverging
+      from that here — keeping a *different* meaning for `2` in this repo — would mean the same
+      exit code means three different things across the two producers (argparse usage error in
+      both, PLUS "aborted" only in predict), which is exactly the confusion A4's design doc §8
+      asks to avoid by resolving this "the same way for both" producers.
+    - The diagnostic granularity lost (distinguishing "staging error" from "generic crash") isn't
+      operationally load-bearing: A4's `retryStrategy`/`continueOn` only needs to special-case `3`
+      (partial); every other nonzero code is retried the same way regardless of whether it's `1`
+      or a separate `2`. Losing that distinction costs log readability, not Argo behavior.
+- **Empty input → raise:** previously reused the existing `except (FileNotFoundError, ValueError)`
+  → exit `2` path in `__main__.py`. Per the reversed decision above, that special case is removed
+  entirely — `run_batch` still raises on empty input (unchanged goal), but `__main__.py` no longer
+  catches `FileNotFoundError`/`ValueError` into a custom code; they (and any other staging
+  exception) simply propagate, surfacing as Python's default `1`, identical to any other crash.
 - **Atomic writes are defense-in-depth, not a correctness fix:** verified (not assumed) that
   predict #35's `_previous_identity_key` already treats a corrupt/truncated previous artifact as
   "changed," so a SIGKILL-truncated file was never silently treated as done under the *current*
@@ -48,10 +73,17 @@ doc for the "why not the alternative" reasoning.
 No data migration. Behavioral/CLI-contract change only:
 - Any caller depending on exit `1` meaning "some scan failed" must switch to checking for `3`
   (or treat any non-zero as failure, which still works, just loses the new distinction).
-- Any caller depending on empty-input silently exiting `0` will now see it raise/exit `2` — a
+- Any caller depending on the current (pre-this-proposal) `except (FileNotFoundError,
+  ValueError): return 2` special-case must instead check for the default `1` — this drops a
+  distinction (`2` vs `1`) that existed since #24, not something this proposal introduces to
+  preserve. No known consumer depends on it (A4 hasn't wired predict's exit code into any Argo
+  `retryStrategy`/`continueOn` logic yet).
+- Any caller depending on empty-input silently exiting `0` will now see it raise/exit `1` — a
   deliberate **BREAKING** change per the issue's own ask.
 
 ## Open Questions
 
-None outstanding — all four forks (exit codes, empty-input, atomic writes, SIGTERM) were resolved
-during brainstorming; see the linked design doc for the full decision trail.
+- Cross-repo numeric alignment is now resolved (`0`/`1`/`3`/`143`, `2` reserved for `argparse`,
+  matching `sleap-roots#259` exactly — see the reversed decision above). Nothing else outstanding
+  from the original four forks (exit codes, empty-input, atomic writes, SIGTERM); see the linked
+  design doc for the full decision trail on those.

--- a/openspec/changes/harden-argo-exit-semantics/proposal.md
+++ b/openspec/changes/harden-argo-exit-semantics/proposal.md
@@ -11,31 +11,24 @@ waits out the full grace period before `SIGKILL`. These are tracked in
 with the traits driver's identical issue ([sleap-roots#259](https://github.com/talmolab/sleap-roots/issues/259))
 per the A4 design doc's §8.
 
-**Cross-repo reconciliation (2026-08-19):** the sibling `sleap-roots#259` proposal landed on
-`0`=success / `3`=partial / `1`=crash / `2` reserved for `argparse`, after its own
-`review-openspec` pass caught that reusing `2` for a driver-owned "aborted" code collides with
-`argparse`'s pre-existing usage-error exit code. This proposal adopts the identical scheme (see
-below) rather than keeping this repo's independently-drafted `0`/`2`/`3`/default-`1` split, so both
-producers report numerically identical codes for numerically identical situations — the load-bearing
-agreement A4-wiring time needs.
+**Cross-repo reconciliation (2026-08-19):** this proposal adopts the same `0`=success /
+`3`=partial / `1`=crash / `2`=reserved-for-`argparse` scheme as the sibling `sleap-roots#259`
+proposal, after that proposal's own `review-openspec` pass caught that reusing `2` for a
+driver-owned "aborted" code collides with `argparse`'s pre-existing usage-error exit code —
+see `design.md`'s "Alternative considered and reversed" for the full history.
 
 ## What Changes
 
-- **MODIFIED** `predict-container`: `run_batch`/`__main__.py` exit-code scheme —
+- **MODIFIED, BREAKING** `predict-container`: `run_batch`/`__main__.py` exit-code scheme —
   `0`=success, `3`=**new**, partial (isolated scan failure(s), no crash); every other failure
-  (staging error, empty-input, or any other uncaught exception) surfaces as Python's default `1`.
-  **Revised during cross-repo reconciliation** (see design.md): the first draft of this proposal
-  kept the CLI's existing `except (FileNotFoundError, ValueError): return 2` special-case and
-  routed the new empty-input guard through it too. That collides with `argparse`'s own
-  pre-existing `sys.exit(2)` on a CLI usage error (verified: `python -m sleap_roots_predict` with
-  no args already exits `2` today) — the exact bug the sibling `sleap-roots#259` proposal's own
-  review caught and fixed by leaving `2` alone. This proposal now does the same: drops the
-  special-cased `2`, folds staging/empty-input errors into the default `1` crash bucket, and
-  leaves `2` untouched for `argparse`.
-- **MODIFIED** `predict-container`: an empty (zero scans discovered) input directory now raises
-  (routed through the existing missing-directory/duplicate-`scan_key` abort path, itself no longer
-  special-cased to `2` — see above) instead of silently no-op'ing and exiting `0`. **BREAKING**
-  for any caller relying on the old no-op-on-empty behavior.
+  (staging error, empty-input, or any other uncaught exception) surfaces as Python's default `1`;
+  `2` is left untouched, reserved for `argparse`'s own usage-error exit. **Breaking** for any
+  caller that currently checks exit `1` for "some scan failed" (now `3`) or exit `2` for a staging
+  error (no longer a distinct code — see `design.md`'s Migration Plan).
+- **MODIFIED, BREAKING** `predict-container`: an empty (zero scans discovered) input directory now
+  raises (routed through the same staging-error path as the missing-directory/duplicate-`scan_key`
+  cases above) instead of silently no-op'ing and exiting `0`. Breaking for any caller relying on
+  the old no-op-on-empty behavior.
 - **ADDED** `predict-container`: a `SIGTERM` handler — the CLI stops at the next scan boundary,
   finishes the in-flight scan, and exits `143` (`128+SIGTERM`), rather than ignoring the signal
   until `SIGKILL`.
@@ -52,6 +45,9 @@ agreement A4-wiring time needs.
 - Affected specs: `predict-container`, `prediction-output`
 - Affected code: `sleap_roots_predict/batch.py`, `sleap_roots_predict/__main__.py`,
   `sleap_roots_predict/output_contract.py`
+- Affected docs: `README.md` ("Running the predict container" section — stale exit-code
+  language, undocumented empty-input behavior), `API.md` (`run_batch`'s exit-code parenthetical),
+  `CHANGELOG.md` (`[Unreleased]` "Predict container CLI" entry)
 - Out of scope (tracked elsewhere, not in this change): the `sleap-roots-pipeline` Argo
   `WorkflowTemplate`/`retryStrategy` change to interpret exit code `3`; applying this same
   convention to the traits driver (`sleap-roots#259`, separate repo); `SIGINT` handling; per-scan

--- a/openspec/changes/harden-argo-exit-semantics/proposal.md
+++ b/openspec/changes/harden-argo-exit-semantics/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The predict batch driver (`sleap_roots_predict/batch.py` + `__main__.py`) is driven by A4's Argo
+`predictor` template, but three of its current behaviors are wrong for that runtime: exit code
+`1` means both "a scan isolated-failed" and "the process crashed," so Argo's `retryStrategy`
+can't tell a poison scan (should end `partial`, not retry) from a real pod crash (should retry);
+an empty input directory silently exits `0` with nothing written, so a misconfigured mount
+produces a green node; and the exec-form entrypoint has no `SIGTERM` handler, so Argo preemption
+waits out the full grace period before `SIGKILL`. These are tracked in
+[predict #26](https://github.com/talmolab/sleap-roots-predict/issues/26), reconciled uniformly
+with the traits driver's identical issue ([sleap-roots#259](https://github.com/talmolab/sleap-roots/issues/259))
+per the A4 design doc's §8.
+
+## What Changes
+
+- **MODIFIED** `predict-container`: `run_batch`/`__main__.py` exit-code scheme —
+  `0`=success, `2`=aborted (staging error, now including empty-input), `3`=**new**, partial
+  (isolated scan failure(s), no crash); an uncaught exception keeps Python's default `1`.
+- **MODIFIED** `predict-container`: an empty (zero scans discovered) input directory now raises
+  (routed through the existing missing-directory/duplicate-`scan_key` abort path) instead of
+  silently no-op'ing and exiting `0`. **BREAKING** for any caller relying on the old no-op-on-empty
+  behavior.
+- **ADDED** `predict-container`: a `SIGTERM` handler — the CLI stops at the next scan boundary,
+  finishes the in-flight scan, and exits `143` (`128+SIGTERM`), rather than ignoring the signal
+  until `SIGKILL`.
+- **MODIFIED** `predict-container`: the copied-through scan-metadata sidecar is now written
+  atomically (temp file + rename), matching the manifest/`.slp` durability guarantee below.
+- **MODIFIED** `prediction-output`: `write_prediction_outputs` writes each `.slp` and the
+  `{scan_key}.predictions.json` manifest via temp-file-in-same-directory + `os.replace`, so no
+  external reader can observe a torn/partial file. This is defense-in-depth, not a fix for a live
+  correctness bug — predict #35's idempotency-key resume already treats any corrupt/truncated
+  previous artifact as "changed, re-predict," never as "done."
+
+## Impact
+
+- Affected specs: `predict-container`, `prediction-output`
+- Affected code: `sleap_roots_predict/batch.py`, `sleap_roots_predict/__main__.py`,
+  `sleap_roots_predict/output_contract.py`
+- Out of scope (tracked elsewhere, not in this change): the `sleap-roots-pipeline` Argo
+  `WorkflowTemplate`/`retryStrategy` change to interpret exit code `3`; applying this same
+  convention to the traits driver (`sleap-roots#259`, separate repo); `SIGINT` handling; per-scan
+  retry-count semantics.
+- Full design rationale: `docs/superpowers/specs/2026-08-18-argo-ready-exit-semantics-design.md`.

--- a/openspec/changes/harden-argo-exit-semantics/proposal.md
+++ b/openspec/changes/harden-argo-exit-semantics/proposal.md
@@ -11,15 +11,31 @@ waits out the full grace period before `SIGKILL`. These are tracked in
 with the traits driver's identical issue ([sleap-roots#259](https://github.com/talmolab/sleap-roots/issues/259))
 per the A4 design doc's §8.
 
+**Cross-repo reconciliation (2026-08-19):** the sibling `sleap-roots#259` proposal landed on
+`0`=success / `3`=partial / `1`=crash / `2` reserved for `argparse`, after its own
+`review-openspec` pass caught that reusing `2` for a driver-owned "aborted" code collides with
+`argparse`'s pre-existing usage-error exit code. This proposal adopts the identical scheme (see
+below) rather than keeping this repo's independently-drafted `0`/`2`/`3`/default-`1` split, so both
+producers report numerically identical codes for numerically identical situations — the load-bearing
+agreement A4-wiring time needs.
+
 ## What Changes
 
 - **MODIFIED** `predict-container`: `run_batch`/`__main__.py` exit-code scheme —
-  `0`=success, `2`=aborted (staging error, now including empty-input), `3`=**new**, partial
-  (isolated scan failure(s), no crash); an uncaught exception keeps Python's default `1`.
+  `0`=success, `3`=**new**, partial (isolated scan failure(s), no crash); every other failure
+  (staging error, empty-input, or any other uncaught exception) surfaces as Python's default `1`.
+  **Revised during cross-repo reconciliation** (see design.md): the first draft of this proposal
+  kept the CLI's existing `except (FileNotFoundError, ValueError): return 2` special-case and
+  routed the new empty-input guard through it too. That collides with `argparse`'s own
+  pre-existing `sys.exit(2)` on a CLI usage error (verified: `python -m sleap_roots_predict` with
+  no args already exits `2` today) — the exact bug the sibling `sleap-roots#259` proposal's own
+  review caught and fixed by leaving `2` alone. This proposal now does the same: drops the
+  special-cased `2`, folds staging/empty-input errors into the default `1` crash bucket, and
+  leaves `2` untouched for `argparse`.
 - **MODIFIED** `predict-container`: an empty (zero scans discovered) input directory now raises
-  (routed through the existing missing-directory/duplicate-`scan_key` abort path) instead of
-  silently no-op'ing and exiting `0`. **BREAKING** for any caller relying on the old no-op-on-empty
-  behavior.
+  (routed through the existing missing-directory/duplicate-`scan_key` abort path, itself no longer
+  special-cased to `2` — see above) instead of silently no-op'ing and exiting `0`. **BREAKING**
+  for any caller relying on the old no-op-on-empty behavior.
 - **ADDED** `predict-container`: a `SIGTERM` handler — the CLI stops at the next scan boundary,
   finishes the in-flight scan, and exits `143` (`128+SIGTERM`), rather than ignoring the signal
   until `SIGKILL`.

--- a/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
@@ -1,0 +1,127 @@
+## MODIFIED Requirements
+
+### Requirement: Per-scan failure isolation and batch exit code
+
+A scan whose processing fails SHALL be isolated: the runner records it with status `failed`,
+continues the batch, and still produces outputs for the other scans. `run_batch` SHALL return a
+`BatchResult` whose per-scan status is one of `ok` / `skipped` / `failed` and which reports
+`ok` (batch-level) iff no scan failed. A scan that resolves to **zero** models across all root
+types SHALL be treated as `failed` (rather than emitting an empty-artifacts manifest that the
+downstream trait-extractor would reject).
+
+The process SHALL exit with one of four distinct codes so an Argo step can distinguish an
+isolated per-scan failure from a genuine crash:
+- `0` — success: at least one scan was discovered and none failed.
+- `2` — aborted: a pre-flight/staging error before any scan ran — a missing input directory, two
+  sidecars sharing a `scan_key`, or **zero scans discovered** (an empty-but-present input
+  directory, or a `run_manifest.json` scoping discovery to zero `scan_keys`) — a batch that ran
+  with no scans is a misconfiguration, not a no-op.
+- `3` — partial: at least one scan was discovered and the batch ran to completion, but one or
+  more scans isolated-failed. The batch's own per-scan isolation already ran (the other scans'
+  outputs are written); this exit code exists so Argo does not conflate "retry the whole batch"
+  with "this is done, some scans need attention."
+- *(Python's default, produced by an uncaught exception, not an explicit `return`)* `1` — a
+  genuine pod-level crash (e.g. model-registry authentication failing before any scan is
+  attempted) that Argo's `retryStrategy` should retry.
+
+A `run_manifest.json`-scoped batch where every listed `scan_key` has no matching sidecar is
+**not** the zero-scans-discovered case: `discover_scans` still returns one (failed) entry per
+listed key, so that batch ends `partial` (`3`), not aborted (`2`).
+
+#### Scenario: One failing scan does not abort the batch
+
+- **WHEN** one scan in a multi-scan batch fails (e.g. its frames are unreadable or absent) and
+  the others are valid
+- **THEN** the valid scans' outputs are written, that scan's status is `failed`, and the
+  process exits `3`
+
+#### Scenario: A scan resolving to zero models is failed
+
+- **WHEN** a scan's params match no model for any root type
+- **THEN** the scan's status is `failed` (no empty-artifacts manifest is written for it), the
+  batch continues, and the process exits `3`
+
+#### Scenario: All scans succeed
+
+- **WHEN** every discovered scan predicts successfully
+- **THEN** the process exits `0`
+
+#### Scenario: Empty input directory is a staging error
+
+- **WHEN** a present-but-empty input directory contains no `*.scan_metadata.json` (including a
+  `run_manifest.json` that scopes discovery to zero `scan_keys`)
+- **THEN** `run_batch` raises before constructing a `WarmModelWorker`, writes nothing, and the CLI
+  exits `2`
+
+#### Scenario: Missing input directory is an error
+
+- **WHEN** the input directory path does not exist
+- **THEN** the runner raises (surfaced by the CLI as exit `2`), rather than reporting
+  success with no outputs
+
+#### Scenario: A manifest scoped to missing sidecars ends partial, not aborted
+
+- **WHEN** `run_manifest.json` lists one or more `scan_keys` with no matching sidecar anywhere
+  under the input directory, and no other scans are discovered
+- **THEN** `discover_scans` returns one failed entry per listed key (not an empty list), and the
+  process exits `3`, not `2`
+
+### Requirement: Per-scan outputs with scan-metadata pass-through
+
+For each predicted scan the runner SHALL write, into `<output_dir>/{scan_key}/`, the
+prediction-output artifacts defined by the `prediction-output` capability (the named per-root
+`.slp` files and the `{scan_key}.predictions.json` manifest, via `write_prediction_outputs`),
+and SHALL additionally copy the scan's `{scan_key}.scan_metadata.json` sidecar **verbatim**
+(a byte-for-byte binary copy) into the same directory, so `<output_dir>/{scan_key}/` is a
+self-contained trait-extractor input tree (manifest + sidecar + `.slp` co-located). The sidecar
+SHALL be copied **before** the manifest is written (the manifest is the resume marker), so the
+manifest never exists without its co-located sidecar. The copy SHALL be performed atomically
+(written to a temporary file in the same directory, then moved into place via `os.replace`), so
+no reader can ever observe a partially-written sidecar at the final path. The runner SHALL NOT
+author or modify the sidecar's contents (its `image_ids`/`images_checksum` remain the upstream
+downloader's responsibility).
+
+#### Scenario: Writes manifest, .slp, and the copied sidecar
+
+- **WHEN** a scan is predicted into `<output_dir>`
+- **THEN** `<output_dir>/{scan_key}/` contains `{scan_key}.predictions.json`, one
+  `{scan_key}.model*.root*.slp` per resolved root type, and a `{scan_key}.scan_metadata.json`
+  byte-identical to the input sidecar
+
+#### Scenario: Sidecar copy is atomic
+
+- **WHEN** the sidecar copy is interrupted before it completes
+- **THEN** no partially-written file is ever visible at the final `{scan_key}.scan_metadata.json`
+  path — a reader sees either nothing, a complete prior copy, or the complete new copy, never a
+  truncated one
+
+## ADDED Requirements
+
+### Requirement: Graceful SIGTERM handling for Argo preemption
+
+The CLI SHALL install a `SIGTERM` handler before running the batch. `run_batch` SHALL accept an
+optional keyword-only `should_stop: Callable[[], bool]` parameter (default a no-op returning
+`False`, so existing callers are unaffected) and SHALL check it at the top of each iteration of
+its per-scan loop, stopping before starting the next scan when it returns `True` — never
+interrupting a scan already in progress (there is no safe interrupt point inside sleap-nn/GPU
+inference). When the CLI's handler has fired, `main()` SHALL exit `143` (`128 + SIGTERM`)
+regardless of what exit code the completed-so-far scans would otherwise produce, so the
+container's reported exit code honestly reflects "asked to stop," distinct from a normal
+success/partial/aborted outcome.
+
+#### Scenario: Stops at the next scan boundary, not mid-scan
+
+- **WHEN** `should_stop` becomes `True` while the first of two scans is being predicted
+- **THEN** the first scan's outputs are written completely and validly, and the second scan is
+  not attempted
+
+#### Scenario: SIGTERM exit code overrides the batch outcome
+
+- **WHEN** the CLI's `SIGTERM` handler fires during a batch that would otherwise exit `0` or `3`
+- **THEN** the process exits `143` instead
+
+#### Scenario: No signal received leaves existing behavior unchanged
+
+- **WHEN** the batch runs to completion without `SIGTERM` ever being received
+- **THEN** the exit code is determined exactly as before (`0`/`2`/`3`/default `1`), unaffected by
+  the new handler's presence

--- a/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
@@ -9,24 +9,30 @@ continues the batch, and still produces outputs for the other scans. `run_batch`
 types SHALL be treated as `failed` (rather than emitting an empty-artifacts manifest that the
 downstream trait-extractor would reject).
 
-The process SHALL exit with one of four distinct codes so an Argo step can distinguish an
+The process SHALL exit with one of three driver-owned codes so an Argo step can distinguish an
 isolated per-scan failure from a genuine crash:
 - `0` — success: at least one scan was discovered and none failed.
-- `2` — aborted: a pre-flight/staging error before any scan ran — a missing input directory, two
-  sidecars sharing a `scan_key`, or **zero scans discovered** (an empty-but-present input
-  directory, or a `run_manifest.json` scoping discovery to zero `scan_keys`) — a batch that ran
-  with no scans is a misconfiguration, not a no-op.
 - `3` — partial: at least one scan was discovered and the batch ran to completion, but one or
   more scans isolated-failed. The batch's own per-scan isolation already ran (the other scans'
   outputs are written); this exit code exists so Argo does not conflate "retry the whole batch"
   with "this is done, some scans need attention."
-- *(Python's default, produced by an uncaught exception, not an explicit `return`)* `1` — a
-  genuine pod-level crash (e.g. model-registry authentication failing before any scan is
-  attempted) that Argo's `retryStrategy` should retry.
+- *(Python's default, produced by an uncaught exception, not an explicit `return`)* `1` — every
+  other failure: a pre-flight/staging error before any scan ran (a missing input directory, two
+  sidecars sharing a `scan_key`, or **zero scans discovered** — an empty-but-present input
+  directory, or a `run_manifest.json` scoping discovery to zero `scan_keys`), or a genuine
+  pod-level crash (e.g. model-registry authentication failing before any scan is attempted). Both
+  are "the batch could not meaningfully run" conditions and are not split into separate codes;
+  Argo's `retryStrategy` should retry either.
+
+Exit code `2` is deliberately NOT part of this convention: `argparse` already exits `2` on a CLI
+usage error (missing/extra positional arguments), before `run_batch` ever runs. This matches the
+identical convention adopted by the sibling `sleap-roots` trait-extractor driver
+(`sleap-roots#259`) — both producers report numerically identical codes for numerically identical
+situations, per A4's design doc §8 ask to resolve this "the same way for both."
 
 A `run_manifest.json`-scoped batch where every listed `scan_key` has no matching sidecar is
 **not** the zero-scans-discovered case: `discover_scans` still returns one (failed) entry per
-listed key, so that batch ends `partial` (`3`), not aborted (`2`).
+listed key, so that batch ends `partial` (`3`), not the crash/staging-error code (`1`).
 
 #### Scenario: One failing scan does not abort the batch
 
@@ -51,20 +57,27 @@ listed key, so that batch ends `partial` (`3`), not aborted (`2`).
 - **WHEN** a present-but-empty input directory contains no `*.scan_metadata.json` (including a
   `run_manifest.json` that scopes discovery to zero `scan_keys`)
 - **THEN** `run_batch` raises before constructing a `WarmModelWorker`, writes nothing, and the CLI
-  exits `2`
+  exits `1` (uncaught — not a special-cased code)
 
 #### Scenario: Missing input directory is an error
 
 - **WHEN** the input directory path does not exist
-- **THEN** the runner raises (surfaced by the CLI as exit `2`), rather than reporting
+- **THEN** the runner raises (surfaced by the CLI as exit `1`), rather than reporting
   success with no outputs
 
-#### Scenario: A manifest scoped to missing sidecars ends partial, not aborted
+#### Scenario: A manifest scoped to missing sidecars ends partial, not a crash
 
 - **WHEN** `run_manifest.json` lists one or more `scan_keys` with no matching sidecar anywhere
   under the input directory, and no other scans are discovered
 - **THEN** `discover_scans` returns one failed entry per listed key (not an empty list), and the
-  process exits `3`, not `2`
+  process exits `3`, not `1`
+
+#### Scenario: A CLI usage error is unrelated to the partial/crash codes
+
+- **WHEN** `python -m sleap_roots_predict` is invoked with a missing required argument
+- **THEN** the process exits `2` via `argparse`'s own pre-existing usage-error handling, before
+  `run_batch` ever runs, and this is unrelated to (does not collide in meaning with) the `0`/`1`/`3`
+  driver-owned codes
 
 ### Requirement: Per-scan outputs with scan-metadata pass-through
 
@@ -123,5 +136,5 @@ success/partial/aborted outcome.
 #### Scenario: No signal received leaves existing behavior unchanged
 
 - **WHEN** the batch runs to completion without `SIGTERM` ever being received
-- **THEN** the exit code is determined exactly as before (`0`/`2`/`3`/default `1`), unaffected by
+- **THEN** the exit code is determined exactly as before (`0`/`3`/default `1`), unaffected by
   the new handler's presence

--- a/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
@@ -18,14 +18,18 @@ isolated per-scan failure from a genuine crash:
   with "this is done, some scans need attention."
 - *(Python's default, produced by an uncaught exception, not an explicit `return`)* `1` — every
   other failure: a pre-flight/staging error before any scan ran (a missing input directory, two
-  sidecars sharing a `scan_key`, or **zero scans discovered** — an empty-but-present input
-  directory, or a `run_manifest.json` scoping discovery to zero `scan_keys`), or a genuine
-  pod-level crash (e.g. model-registry authentication failing before any scan is attempted). Both
+  sidecars sharing a `scan_key`, a `run_manifest.json` that fails to parse or validate — including
+  an empty `scan_keys` list, rejected by the "Scan discovery" requirement's own manifest
+  validation before discovery ever runs — or **zero scans discovered**: `discover_scans` returns
+  an empty list because no sidecar exists anywhere under a present input directory), or a genuine
+  pod-level crash (e.g. model-registry authentication failing before any scan is attempted). All
   are "the batch could not meaningfully run" conditions and are not split into separate codes;
-  Argo's `retryStrategy` should retry either. For the two known staging-error types (a missing
-  input directory, or two sidecars sharing a `scan_key`) the CLI SHALL log a clear one-line message
-  before the exception propagates; any other exception type is not specially logged and surfaces
-  Python's default traceback.
+  Argo's `retryStrategy` should retry any of them. The CLI SHALL log a clear one-line message
+  before propagating any `FileNotFoundError` or `ValueError` (which, since `json.JSONDecodeError`
+  and `pydantic.ValidationError` both subclass `ValueError`, covers all four staging-error cases
+  above — missing directory, duplicate `scan_key`, malformed manifest, and zero-scans-discovered);
+  any other exception type (a genuine pod-level crash outside those two types) is not specially
+  logged and surfaces Python's default traceback.
 
 Exit code `2` is deliberately NOT part of this convention: `argparse` already exits `2` on a CLI
 usage error (missing/extra positional arguments), before `run_batch` ever runs. This matches the
@@ -61,11 +65,11 @@ listed key, so that batch ends `partial` (`3`), not the crash/staging-error code
 - **THEN** `run_batch` raises before constructing a `WarmModelWorker`, writes nothing, and the CLI
   logs a clear message and exits `1`
 
-Note: a `run_manifest.json` that scopes discovery to zero `scan_keys` is a *different* raise path
-— it's rejected by the existing "A malformed manifest raises before any scan is processed"
-scenario in the "Scan discovery" requirement above (an empty `scan_keys` list fails `RunManifest`
-validation), not by this scenario's zero-scans-discovered check. Both land on exit `1` either way,
-so there's no behavioral difference, but they are two distinct raise sites, not one.
+Note: this is distinct from a `run_manifest.json` scoping discovery to zero `scan_keys`, which is
+rejected earlier by the "Scan discovery" requirement's own manifest validation (an empty
+`scan_keys` list fails `RunManifest` validation before `discover_scans` returns at all) — see the
+exit-code bullet above, which already separates the two raise sites. Both land on exit `1` either
+way; the mechanism differs, the outcome doesn't.
 
 #### Scenario: Missing input directory is an error
 

--- a/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/predict-container/spec.md
@@ -22,7 +22,10 @@ isolated per-scan failure from a genuine crash:
   directory, or a `run_manifest.json` scoping discovery to zero `scan_keys`), or a genuine
   pod-level crash (e.g. model-registry authentication failing before any scan is attempted). Both
   are "the batch could not meaningfully run" conditions and are not split into separate codes;
-  Argo's `retryStrategy` should retry either.
+  Argo's `retryStrategy` should retry either. For the two known staging-error types (a missing
+  input directory, or two sidecars sharing a `scan_key`) the CLI SHALL log a clear one-line message
+  before the exception propagates; any other exception type is not specially logged and surfaces
+  Python's default traceback.
 
 Exit code `2` is deliberately NOT part of this convention: `argparse` already exits `2` on a CLI
 usage error (missing/extra positional arguments), before `run_batch` ever runs. This matches the
@@ -54,16 +57,21 @@ listed key, so that batch ends `partial` (`3`), not the crash/staging-error code
 
 #### Scenario: Empty input directory is a staging error
 
-- **WHEN** a present-but-empty input directory contains no `*.scan_metadata.json` (including a
-  `run_manifest.json` that scopes discovery to zero `scan_keys`)
+- **WHEN** a present-but-empty input directory contains no `*.scan_metadata.json`
 - **THEN** `run_batch` raises before constructing a `WarmModelWorker`, writes nothing, and the CLI
-  exits `1` (uncaught — not a special-cased code)
+  logs a clear message and exits `1`
+
+Note: a `run_manifest.json` that scopes discovery to zero `scan_keys` is a *different* raise path
+— it's rejected by the existing "A malformed manifest raises before any scan is processed"
+scenario in the "Scan discovery" requirement above (an empty `scan_keys` list fails `RunManifest`
+validation), not by this scenario's zero-scans-discovered check. Both land on exit `1` either way,
+so there's no behavioral difference, but they are two distinct raise sites, not one.
 
 #### Scenario: Missing input directory is an error
 
 - **WHEN** the input directory path does not exist
-- **THEN** the runner raises (surfaced by the CLI as exit `1`), rather than reporting
-  success with no outputs
+- **THEN** the runner raises, the CLI logs a clear message before the exception propagates, and
+  the process exits `1`, rather than reporting success with no outputs
 
 #### Scenario: A manifest scoped to missing sidecars ends partial, not a crash
 
@@ -72,12 +80,11 @@ listed key, so that batch ends `partial` (`3`), not the crash/staging-error code
 - **THEN** `discover_scans` returns one failed entry per listed key (not an empty list), and the
   process exits `3`, not `1`
 
-#### Scenario: A CLI usage error is unrelated to the partial/crash codes
+#### Scenario: A CLI usage error exits via argparse, before the driver runs
 
 - **WHEN** `python -m sleap_roots_predict` is invoked with a missing required argument
 - **THEN** the process exits `2` via `argparse`'s own pre-existing usage-error handling, before
-  `run_batch` ever runs, and this is unrelated to (does not collide in meaning with) the `0`/`1`/`3`
-  driver-owned codes
+  `run_batch` ever runs
 
 ### Requirement: Per-scan outputs with scan-metadata pass-through
 
@@ -121,6 +128,11 @@ inference). When the CLI's handler has fired, `main()` SHALL exit `143` (`128 + 
 regardless of what exit code the completed-so-far scans would otherwise produce, so the
 container's reported exit code honestly reflects "asked to stop," distinct from a normal
 success/partial/aborted outcome.
+
+Note: on Windows, `signal.signal(signal.SIGTERM, ...)` registers without error, but real
+cross-process delivery (`os.kill`) invokes `TerminateProcess` rather than the registered handler
+— unlike Linux/macOS. Tests SHALL exercise the handler by calling it directly, never via
+`os.kill`, so this requirement is verifiable identically across this project's CI matrix.
 
 #### Scenario: Stops at the next scan boundary, not mid-scan
 

--- a/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
@@ -9,23 +9,28 @@ predict_container_digest=None)` that writes the named `.slp` files and the combi
 into `out_dir` (creating it if missing) and returns the resulting `PredictionManifest`.
 It SHALL raise `ValueError` when `labels_by_root` and `refs_by_root` do not cover the same
 set of root types. Re-running for the same `scan_key` into the same `out_dir` SHALL
-overwrite prior outputs in place: the manifest is replaced and any prior `.slp` for that
-`scan_key` (matched by the `{scan_key}.model…` prefix) is removed first, so a changed
-`model_id` slug does not leave orphaned files. The writer SHALL use `pathlib.Path`
-for path handling and emit path strings — `slp_path` and any path passed across the
-sleap-io / sleap-roots boundary — via `Path.as_posix()` (lab convention; keeps the
-manifest portable across POSIX and Windows). It SHALL NOT import or depend on
+overwrite prior outputs in place: any prior `.slp` for that `scan_key` (matched by the
+`{scan_key}.model…` prefix) that is no longer referenced by the new manifest is removed
+only *after* the new manifest has been committed, so a changed `model_id` slug does not
+leave orphaned files, and a failure during that removal can never leave a still-current
+manifest referencing a file the removal only partially deleted. The writer SHALL use
+`pathlib.Path` for path handling and emit path strings — `slp_path` and any path passed
+across the sleap-io / sleap-roots boundary — via `Path.as_posix()` (lab convention; keeps
+the manifest portable across POSIX and Windows). It SHALL NOT import or depend on
 `sleap-roots` at runtime.
 
 Both the `.slp` files and the `{scan_key}.predictions.json` manifest SHALL be written
 atomically: each is written to a temporary file in the same directory as its final path, then
 moved into place via `os.replace`, so no reader can ever observe a partially-written file at the
-final path. The manifest SHALL still be written last, after every `.slp` write completes,
-preserving its established role as the resume commit-marker. The `.slp` temp write SHALL pass an
-explicit format (e.g. `format="slp"`) to the underlying `sio.save_file` call rather than relying
-on the temp filename's extension — `sio.save_file` infers its output format purely from the
-destination filename when `format` is omitted, so a temp name that does not itself end in `.slp`
-(e.g. one built by appending a `.tmp` suffix) would otherwise fail with an unknown-format error.
+final path. The manifest SHALL be written after every `.slp` write completes but *before* the
+stale-`.slp` removal pass, preserving its role as the resume commit-marker: once the manifest
+commit succeeds, it is already correct and complete on its own, so the stale-removal pass that
+follows is purely cosmetic cleanup, never load-bearing for the manifest's correctness. The `.slp`
+temp write SHALL pass an explicit format (e.g. `format="slp"`) to the underlying `sio.save_file`
+call rather than relying on the temp filename's extension — `sio.save_file` infers its output
+format purely from the destination filename when `format` is omitted, so a temp name that does
+not itself end in `.slp` (e.g. one built by appending a `.tmp` suffix) would otherwise fail with
+an unknown-format error.
 
 #### Scenario: Writer returns a manifest and writes the artifacts
 
@@ -57,10 +62,18 @@ destination filename when `format` is omitted, so a temp name that does not itse
 - **THEN** no file exists at the final path with incomplete content — a reader sees either the
   complete prior version (if any) or nothing, never a truncated one
 
-#### Scenario: Manifest is still written last
+#### Scenario: Manifest write completes before the stale-.slp removal pass
 
 - **WHEN** `write_prediction_outputs` runs for a scan with one or more resolved root types
-- **THEN** every `.slp`'s atomic write completes before the manifest's atomic write begins
+- **THEN** every `.slp`'s atomic write completes before the manifest's atomic write begins, and
+  the manifest's atomic write completes before the stale-`.slp` removal pass runs
+
+#### Scenario: A stale-removal failure does not corrupt an already-committed manifest
+
+- **WHEN** the stale-`.slp` removal pass fails partway through (e.g. a locked file) after the new
+  manifest has already been committed
+- **THEN** the committed manifest still correctly references only this run's own artifacts,
+  regardless of which stale files the failed removal did or did not delete
 
 #### Scenario: The .slp temp write does not depend on the temp filename's extension
 

--- a/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
@@ -21,7 +21,11 @@ Both the `.slp` files and the `{scan_key}.predictions.json` manifest SHALL be wr
 atomically: each is written to a temporary file in the same directory as its final path, then
 moved into place via `os.replace`, so no reader can ever observe a partially-written file at the
 final path. The manifest SHALL still be written last, after every `.slp` write completes,
-preserving its established role as the resume commit-marker.
+preserving its established role as the resume commit-marker. The `.slp` temp write SHALL pass an
+explicit format (e.g. `format="slp"`) to the underlying `sio.save_file` call rather than relying
+on the temp filename's extension — `sio.save_file` infers its output format purely from the
+destination filename when `format` is omitted, so a temp name that does not itself end in `.slp`
+(e.g. one built by appending a `.tmp` suffix) would otherwise fail with an unknown-format error.
 
 #### Scenario: Writer returns a manifest and writes the artifacts
 
@@ -57,3 +61,10 @@ preserving its established role as the resume commit-marker.
 
 - **WHEN** `write_prediction_outputs` runs for a scan with one or more resolved root types
 - **THEN** every `.slp`'s atomic write completes before the manifest's atomic write begins
+
+#### Scenario: The .slp temp write does not depend on the temp filename's extension
+
+- **WHEN** the writer's temporary filename for a `.slp` write does not itself end in `.slp` (e.g.
+  a `.tmp`-suffixed name)
+- **THEN** the write still succeeds, because `format="slp"` is passed explicitly rather than
+  inferred from the filename

--- a/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
+++ b/openspec/changes/harden-argo-exit-semantics/specs/prediction-output/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Pure per-scan writer API
+
+The system SHALL provide
+`write_prediction_outputs(labels_by_root, refs_by_root, out_dir, *, scan_key,
+plant_qr_code=None, inference_config, output_params, predict_code_sha=None,
+predict_container_digest=None)` that writes the named `.slp` files and the combined JSON
+into `out_dir` (creating it if missing) and returns the resulting `PredictionManifest`.
+It SHALL raise `ValueError` when `labels_by_root` and `refs_by_root` do not cover the same
+set of root types. Re-running for the same `scan_key` into the same `out_dir` SHALL
+overwrite prior outputs in place: the manifest is replaced and any prior `.slp` for that
+`scan_key` (matched by the `{scan_key}.model…` prefix) is removed first, so a changed
+`model_id` slug does not leave orphaned files. The writer SHALL use `pathlib.Path`
+for path handling and emit path strings — `slp_path` and any path passed across the
+sleap-io / sleap-roots boundary — via `Path.as_posix()` (lab convention; keeps the
+manifest portable across POSIX and Windows). It SHALL NOT import or depend on
+`sleap-roots` at runtime.
+
+Both the `.slp` files and the `{scan_key}.predictions.json` manifest SHALL be written
+atomically: each is written to a temporary file in the same directory as its final path, then
+moved into place via `os.replace`, so no reader can ever observe a partially-written file at the
+final path. The manifest SHALL still be written last, after every `.slp` write completes,
+preserving its established role as the resume commit-marker.
+
+#### Scenario: Writer returns a manifest and writes the artifacts
+
+- **WHEN** `write_prediction_outputs` is called with aligned `labels_by_root` and
+  `refs_by_root`
+- **THEN** it writes the per-root `.slp` files and `{scan_key}.predictions.json` into
+  `out_dir` and returns a `PredictionManifest` describing them
+
+#### Scenario: Mismatched label and ref root types raise
+
+- **WHEN** `labels_by_root` and `refs_by_root` cover different root types
+- **THEN** the writer raises `ValueError`
+
+#### Scenario: Re-running overwrites prior outputs in place
+
+- **WHEN** `write_prediction_outputs` runs into an `out_dir` that already holds a prior
+  manifest and `.slp` files for the same `scan_key`
+- **THEN** it overwrites them in place and the reloaded manifest reflects the new run
+
+#### Scenario: A changed model on re-run does not orphan the prior .slp
+
+- **WHEN** a scan is re-run with a different model for a root type (a new `model_id` slug)
+- **THEN** the prior `.slp` for that `scan_key` is removed, leaving only the current run's
+  files
+
+#### Scenario: Atomic write leaves no partial file visible
+
+- **WHEN** a `.slp` or manifest write is interrupted before its final `os.replace` into place
+- **THEN** no file exists at the final path with incomplete content — a reader sees either the
+  complete prior version (if any) or nothing, never a truncated one
+
+#### Scenario: Manifest is still written last
+
+- **WHEN** `write_prediction_outputs` runs for a scan with one or more resolved root types
+- **THEN** every `.slp`'s atomic write completes before the manifest's atomic write begins

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -14,13 +14,24 @@ everywhere; this task list now does the same, so both producers use numerically 
 `test_cli_main_exit_codes` (asserts `main(...) == 1` for a failed batch) and
 `test_cli_missing_input_dir_returns_nonzero` (asserts `main(...) == 2`). Neither was named in
 the original 1.1/1.3 tasks, so implementing this section as originally written would have left
-the suite self-contradictory (the second case worse than a mere assertion mismatch — once 1.5
-removes the `except` clause, that test's `main()` call raises `FileNotFoundError` uncaught,
-an error, not a failure). Tasks 1.1 and 1.3 below now name both tests explicitly. Also decided:
-the log-quality regression from dropping the `except` clause (a missing-mount error would
-otherwise dump a raw traceback instead of a clean one-line log) is worth preserving — 1.5 now
-keeps a narrow `except (FileNotFoundError, ValueError)` that only logs before re-raising, so the
-final exit code is still Python's unhandled-exception default `1` but the log line survives.
+the suite self-contradictory. Tasks 1.1 and 1.3 below now name both tests explicitly. Also
+decided: the log-quality regression from dropping the `except` clause entirely (a missing-mount
+error would otherwise dump a raw traceback instead of a clean one-line log) is worth preserving
+— 1.5 keeps a narrow `except (FileNotFoundError, ValueError)` that only logs before re-raising.
+
+**Revised again after `/review-openspec` round 2:** two more corrections.
+1. Task 1.3's first draft prescribed `assert main(...) == 1` for the rewritten
+   `test_cli_missing_input_dir_returns_nonzero` — **wrong**, since a bare `raise` inside the new
+   `except` clause re-raises the exception rather than returning a value, so calling `main([...])`
+   directly (as every test in this file does) raises `FileNotFoundError` out of the call; it
+   never reaches a `return` statement to compare against `1`. Corrected below to
+   `pytest.raises(FileNotFoundError)` around the `main()` call.
+2. The `except (FileNotFoundError, ValueError)` clause actually covers **all four** staging-error
+   cases, not "two known staging-error types" as earlier drafts said: `json.JSONDecodeError` and
+   `pydantic.ValidationError` both subclass `ValueError` (confirmed empirically), so a malformed
+   `run_manifest.json` and the new zero-scans-discovered `ValueError` (section 2) both get the
+   clean log line too, alongside the missing-directory and duplicate-`scan_key` cases. Wording
+   below corrected accordingly.
 
 - [ ] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
       `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans,
@@ -29,18 +40,23 @@ final exit code is still Python's unhandled-exception default `1` but the log li
       same scenario and must agree.
 - [ ] 1.2 In the same file, write a failing test asserting `main()` still returns `0` for an
       all-ok/all-skipped batch (pins the unchanged success path).
-- [ ] 1.3 In the same file, write a failing test asserting the existing
-      `FileNotFoundError`/duplicate-`scan_key` abort paths now return the default `1` (not the old
-      `2`) — this is a **behavior-change** regression test, not a no-op pin: it must fail against
-      the current code (which still returns `2`) until task 1.5 removes the special case.
-      **Rewrite `test_cli_missing_input_dir_returns_nonzero`** (currently `assert main(...) == 2`)
-      to expect `main(...) == 1` (per the logged-then-propagated behavior decided above, the
-      exception is caught, logged, and re-raised inside `main()`, so this is still an assertion on
-      `main()`'s return/raise, not a bare `pytest.raises` around a raw exception — confirm the
-      exact shape once 1.5's implementation is written, and adjust the test to match rather than
-      leaving the stale `== 2` assertion in place). Also add a CLI-level test asserting the new
-      empty-input `ValueError` (from section 2) surfaces through `main()` as exit `1` too, for the
-      same logged-then-reraised reason.
+- [ ] 1.3 In the same file, write a failing test asserting a missing input directory now
+      propagates as an uncaught `FileNotFoundError` from `main()` (not a returned `2`) — this is a
+      **behavior-change** regression test, not a no-op pin: it must fail against the current code
+      (which still returns `2`) until task 1.5 removes the special case.
+      **Rewrite `test_cli_missing_input_dir_returns_nonzero`** (currently
+      `assert main(...) == 2`) to `with pytest.raises(FileNotFoundError): main([...])` — NOT
+      `assert main(...) == 1` (that assertion is unreachable: `main()` re-raises on this path, it
+      never returns). Optionally assert the clean log line was emitted too (e.g. via `caplog`).
+      Depends on task 1.5 landing first — write this test failing against today's code, confirm it
+      passes only after 1.5's `except ...: log; raise` change is in place.
+      **This section's CLI-level empty-input test has a cross-section dependency, noted here
+      explicitly (per `/review-openspec` round 2's commit-sequencing finding):** add a second test
+      asserting the new empty-input `ValueError` (implemented in task 2.4, section 2) also
+      propagates uncaught from `main()` the same way (`pytest.raises(ValueError)`). This sub-test
+      has nothing to exercise until section 2's `run_batch` change lands — sequence section 2's
+      commit before finalizing this one, or write both together in one commit if landing them
+      separately isn't worth the overhead for a change this size.
 - [ ] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
       module with a missing required argument) exits `2` via `argparse`, and that this is
       independent of the driver's own `0`/`1`/`3` codes (documents the boundary so a future change
@@ -49,12 +65,13 @@ final exit code is still Python's unhandled-exception default `1` but the log li
       `return 0 if result.ok else 3`. Replace the existing `except (FileNotFoundError, ValueError):
       return 2` clause with `except (FileNotFoundError, ValueError) as exc:
       logging.getLogger(__name__).error("Batch aborted: %s", exc); raise` — this keeps the
-      existing clean one-line log message for these two known staging-error types (a real
-      operational-log-quality regression if dropped entirely, per `/review-openspec` round 1) while
-      letting the exception continue on to Python's default unhandled-exception exit `1`, same as
-      any other uncaught crash. Update the module docstring and `main()`'s docstring to enumerate
-      the three driver-owned codes (`0`/`3`/default `1`) plus a note that `2` is reserved by
-      `argparse`, not by this driver. Run 1.1–1.4 green.
+      existing clean one-line log message for every `FileNotFoundError`/`ValueError`-raising
+      staging condition (missing directory, duplicate `scan_key`, malformed manifest, and
+      zero-scans-discovered — see the note above) while letting the exception continue on to
+      Python's default unhandled-exception exit `1`, same as any other uncaught crash type. Update
+      the module docstring and `main()`'s docstring to enumerate the three driver-owned codes
+      (`0`/`3`/default `1`) plus a note that `2` is reserved by `argparse`, not by this driver.
+      Run 1.1–1.4 green.
 
 ## 2. Empty-input guard (D2): raise instead of silent no-op
 
@@ -63,10 +80,10 @@ final exit code is still Python's unhandled-exception default `1` but the log li
       *before* any `WarmModelWorker`/model-source interaction (assert via a source stub that
       records whether it was ever called).
 - [ ] 2.2 In `tests/test_batch.py`, write a failing test asserting a `run_manifest.json` present
-      but scoping to zero `scan_keys` also raises via the same path (pydantic validation of
-      `RunManifest` may already reject an empty `scan_keys` list — confirm which layer raises
-      and assert that one; do not add a redundant check if `RunManifest` itself already enforces
-      non-empty `scan_keys`).
+      but scoping to zero `scan_keys` also raises (via `RunManifest`'s own validation inside
+      `discover_scans` — a distinct raise site from 2.1's zero-scans-discovered check, both
+      landing on the same CLI exit code; confirm which layer raises and assert that one; do not
+      add a redundant check if `RunManifest` itself already enforces non-empty `scan_keys`).
 - [ ] 2.3 In `tests/test_batch.py`, write a regression test asserting a `run_manifest.json` that
       lists `scan_keys` with **no** matching sidecar still returns a non-empty `BatchResult` with
       `failed` entries via `run_batch` directly (i.e. does NOT raise the empty-input `ValueError`)
@@ -79,6 +96,8 @@ final exit code is still Python's unhandled-exception default `1` but the log li
       section) accordingly. Run 2.1–2.3 green; also re-run the existing "Empty input directory is
       a no-op" test from `test_batch.py` if present and update/replace it to assert the new
       raising behavior (do not leave a stale test asserting the old no-op contract).
+      **Land this commit before finalizing task 1.3's cross-section empty-input sub-test** (see
+      the note there).
 
 ## 3. Atomic writes (D3): `.slp`, manifest, and sidecar copy
 
@@ -87,9 +106,18 @@ from the destination filename's extension (confirmed by reading `sleap_io`'s sou
 `ValueError: Unknown format` if it doesn't recognize one. This repo's own existing atomic-write
 precedent (`sleap_roots_predict/parity.py`'s `write_report`, `foo.json` → `foo.json.tmp`) would
 break `.slp` writes if copy-pasted verbatim, since `foo.slp.tmp` no longer ends in `.slp`. Task
-3.4 below calls this out explicitly so it's designed in from the start, not discovered as a test
-failure partway through.
+3.5 below calls this out explicitly so it's designed in from the start, not discovered as a test
+failure partway through. This constraint is also now recorded directly in
+`specs/prediction-output/spec.md` (not just here), since `tasks.md`/`design.md` become historical
+after archiving and the persisted spec is what a future maintainer changing the temp-naming
+scheme would actually consult.
 
+- [ ] 3.0 In `tests/test_output_contract.py`, write a failing test asserting `write_prediction_outputs`
+      succeeds even when its internal `.slp` temp filename does not itself end in `.slp` (e.g. by
+      monkeypatching the temp-path construction, or simply asserting success once 3.5 is
+      implemented with a `.tmp`-suffixed temp name) — pins that `format="slp"` is passed explicitly
+      rather than relied-upon-via-extension (see the note above and the corresponding new scenario
+      in `specs/prediction-output/spec.md`).
 - [ ] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
       `write_prediction_outputs`, no file ever exists at a `.slp`'s final path except either
       fully absent or fully written (e.g. by monkeypatching `os.replace` to raise once before it's
@@ -109,25 +137,25 @@ failure partway through.
       rather than relying on the temp filename's extension** (see the note above; do not use a
       bare `.tmp`-suffix-appended name unless it still ends in `.slp`), then `os.replace` into the
       final path; same pattern for the manifest's `.write_text`, keeping the manifest write
-      strictly last. Run 3.1–3.3 green; confirm all existing round-trip tests in
+      strictly last. Run 3.0–3.3 green; confirm all existing round-trip tests in
       `test_output_contract.py` still pass unchanged.
 - [ ] 3.6 Implement the same atomic pattern for the sidecar copy in
       `sleap_roots_predict/batch.py::_predict_one` (replace the direct `shutil.copyfile` with
       copy-to-temp + `os.replace`; a plain file copy has no format-inference concern, unlike 3.5).
-      Run 3.4 green. Land 3.5 and 3.6 as separate commits — independent write sites, no shared
-      code path (per `/review-openspec` round 1's commit-strategy feedback).
+      Run 3.4 green; also confirm the existing `test_sidecar_copy_failure_leaves_no_manifest`
+      (which monkeypatches `batch_mod.shutil.copyfile`) still passes — the copy-to-temp step still
+      calls `shutil.copyfile` internally, so it should, but verify rather than assume. Land 3.5 and
+      3.6 as separate commits — independent write sites, no shared code path (per
+      `/review-openspec` round 1's commit-strategy feedback).
 
 ## 4. SIGTERM handler (D4): stop at scan boundary, exit 143
 
-**Note found in `/review-openspec` round 1:** on Windows, `signal.signal(signal.SIGTERM, ...)`
-registers without error, but real cross-process delivery (`os.kill(pid, signal.SIGTERM)`) is
-implemented via `TerminateProcess`, which kills the process immediately **without invoking the
-registered handler** — unlike Linux/macOS, where real delivery does invoke it. The plan below
-already avoids this trap (4.3 tests the handler by calling it directly, never via `os.kill`), so
-there is no CI risk today — but if a future change "improves" that test to be more "realistic"
-via `os.kill`, it would silently hang/kill the `windows-latest` CI job instead of failing
-cleanly. `design.md` and the spec now document this platform split explicitly so the constraint
-in 4.3 doesn't get quietly removed later.
+**Note found in `/review-openspec` round 1:** on Windows, real cross-process `SIGTERM` delivery
+does not invoke a registered Python handler (see `specs/predict-container/spec.md`'s "Graceful
+SIGTERM handling" requirement for the full explanation — that's the canonical statement of this
+constraint; this note is just a pointer, not a restatement). The plan below already avoids the
+trap (4.3 tests the handler by calling it directly, never via `os.kill`) — don't "improve" that
+test to use `os.kill` later; on Windows CI that would silently hang or kill the job.
 
 - [ ] 4.1 In `tests/test_batch.py`, write a failing test asserting `run_batch(..., should_stop=fn)`
       stops after the first scan (of two) when `fn` returns `True` starting from the second
@@ -142,11 +170,13 @@ in 4.3 doesn't get quietly removed later.
       note — `main()` must expose a seam for this, e.g. a small `_install_sigterm_handler() ->
       threading.Event` helper it calls, so a test can call that helper directly rather than
       needing to invoke all of `main()` to obtain the handler); invoke the handler directly (never
-      `os.kill` — see the Windows note above), assert the event becomes set, assert `main()`
-      returns `143` when the event is already set going into its post-`run_batch` check — without
-      mocking `run_batch` itself (real TDD). **Save `signal.getsignal(signal.SIGTERM)` before the
-      test and restore it in a `finally`/fixture teardown**, so the handler registered by this test
-      doesn't leak into later tests or interact with CI's job-level timeout kill.
+      `os.kill` — see the Windows note above), assert the event becomes set, and assert `main()`
+      returns `143` when the event is already set going into its post-`run_batch` check — cover
+      this against **both** a would-otherwise-be-`0` batch and a would-otherwise-be-`3` batch, to
+      pin that `143` overrides either outcome, not just the success case — without mocking
+      `run_batch` itself (real TDD). **Save `signal.getsignal(signal.SIGTERM)` before the test and
+      restore it in a `finally`/fixture teardown**, so the handler registered by this test doesn't
+      leak into later tests or interact with CI's job-level timeout kill.
 - [ ] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
       `run_batch`, checked at the top of the per-scan `for` loop (`if should_stop(): logger.warning(...);
       break`). Run 4.1–4.2 green.
@@ -157,6 +187,10 @@ in 4.3 doesn't get quietly removed later.
       into `run_batch`, and after `run_batch` returns, checks the event first — if set, log and
       `return 143` before falling through to the normal `0`/`3` logic (`2` is never part of this
       fallthrough — `argparse` exits `2` on its own, before `run_batch` runs). Run 4.3 green.
+      **Land 4.4 and 4.5 as separate commits** — `run_batch`'s `should_stop` hook
+      (`sleap_roots_predict/batch.py`) and `__main__.py`'s signal-handler plumbing are independent
+      write sites in different files with no shared code path, the same shape as 3.5/3.6 (per
+      `/review-openspec` round 2's commit-strategy feedback).
 
 ## 5. Docs and closeout
 
@@ -178,10 +212,14 @@ in 4.3 doesn't get quietly removed later.
       specifically to exit `3`, not "the CLI exit code" in general (a crash never reaches
       `BatchResult` construction at all). Reword to something like "(maps to CLI exit `3`, distinct
       from a staging-error/crash `1`)".
-- [ ] 5.4 Add a `CHANGELOG.md` entry under `[Unreleased]`: amend the existing "Predict container
-      CLI" bullet's "Per-scan failures are isolated; the process exits non-zero iff any scan
-      failed" sentence to describe the final `0`/`3`/default-`1`/`143` scheme and the
-      empty-input-now-raises change, and drop/update its closing "Argo-readiness hardening (#26)
-      are follow-ups" note now that #26 has landed alongside it.
+- [ ] 5.4 Amend the existing `CHANGELOG.md` `[Unreleased]` "Predict container CLI" entry — it needs
+      updates for **all three** behavior changes in this proposal, not just the exit-code one
+      (found incomplete in `/review-openspec` round 2, which only scoped this to D1/D2):
+      (a) replace "Per-scan failures are isolated; the process exits non-zero iff any scan failed"
+      with the final `0`/`3`/default-`1`/`143` scheme and the empty-input-now-raises change (D1/D2);
+      (b) add a mention that `.slp`/manifest/sidecar writes are now atomic (temp+rename) (D3);
+      (c) add a mention of the new `SIGTERM` handler and its `143` exit (D4); (d) drop/update the
+      closing "Argo-readiness hardening (#26) are follow-ups" note now that #26 has landed
+      alongside this entry rather than following it.
 - [ ] 5.5 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
 - [ ] 5.6 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -1,16 +1,32 @@
-## 1. Exit codes (D1): partial (3) distinct from crash (default 1)
+## 1. Exit codes (D1): partial (3) distinct from crash (default 1); drop the special-cased 2
 
-- [ ] 1.1 In `tests/test_batch.py`, write a failing test asserting `main()` returns `3` (not `1`)
-      for a batch with one failed scan among otherwise-ok scans.
-- [ ] 1.2 In `tests/test_batch.py`, write a failing test asserting `main()` still returns `0` for
-      an all-ok/all-skipped batch (pins the unchanged success path).
-- [ ] 1.3 In `tests/test_batch.py`, write a failing test asserting the existing
-      `FileNotFoundError`/duplicate-`scan_key` abort paths still return `2` (regression pin — no
-      behavior change here, but exercised alongside the new codes so the four-way split is
-      tested together).
-- [ ] 1.4 Implement: change `sleap_roots_predict/__main__.py`'s `return 0 if result.ok else 1` to
-      `return 0 if result.ok else 3`; update the module docstring and `main()`'s docstring to
-      enumerate all four codes (`0`/`2`/`3`/default `1`). Run 1.1–1.3 green.
+**Revised 2026-08-19 after cross-repo reconciliation with `sleap-roots#259`:** the original plan
+here kept a distinct `2` = "aborted" code (reusing the existing `except (FileNotFoundError,
+ValueError): return 2` in `__main__.py`) alongside the new `3` = partial. That collides with
+`argparse`'s own pre-existing `sys.exit(2)` on a CLI usage error — verified: `python -m
+sleap_roots_predict` with a missing argument already exits `2` today, via a code path this
+special-case never accounted for. The sibling `sleap-roots#259` proposal hit the identical bug
+in its first draft and fixed it by dropping the special code and reserving `2` for `argparse`
+everywhere; this task list now does the same, so both producers use numerically identical codes.
+
+- [ ] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
+      `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans.
+- [ ] 1.2 In the same file, write a failing test asserting `main()` still returns `0` for an
+      all-ok/all-skipped batch (pins the unchanged success path).
+- [ ] 1.3 In the same file, write a failing test asserting the existing
+      `FileNotFoundError`/duplicate-`scan_key` abort paths now return the default `1` (not the old
+      `2`) — this is a **behavior-change** regression test, not a no-op pin: it must fail against
+      the current code (which still returns `2`) until task 1.4 removes the special case.
+- [ ] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
+      module with a missing required argument) exits `2` via `argparse`, and that this is
+      independent of the driver's own `0`/`1`/`3` codes (documents the boundary so a future change
+      can't quietly blur it again).
+- [ ] 1.5 Implement: in `sleap_roots_predict/__main__.py`, change `return 0 if result.ok else 1` to
+      `return 0 if result.ok else 3`, and **remove** the `except (FileNotFoundError, ValueError):
+      return 2` clause entirely — let those exceptions propagate uncaught (Python's default exit
+      `1`). Update the module docstring and `main()`'s docstring to enumerate the three
+      driver-owned codes (`0`/`3`/default `1`) plus a note that `2` is reserved by `argparse`, not
+      by this driver. Run 1.1–1.4 green.
 
 ## 2. Empty-input guard (D2): raise instead of silent no-op
 
@@ -75,8 +91,9 @@
 - [ ] 4.5 Implement: in `sleap_roots_predict/__main__.py`'s `main()`, create a `threading.Event`,
       register a `signal.signal(signal.SIGTERM, ...)` handler that sets it, pass
       `should_stop=event.is_set` into `run_batch`, and after `run_batch` returns, check the event
-      first — if set, log and `return 143` before falling through to the normal 0/2/3 logic. Run
-      4.3 green.
+      first — if set, log and `return 143` before falling through to the normal 0/3 logic (`2` is
+      never part of this fallthrough — `argparse` exits `2` on its own, before `run_batch` runs).
+      Run 4.3 green.
 
 ## 5. Docs and closeout
 

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -9,24 +9,52 @@ special-case never accounted for. The sibling `sleap-roots#259` proposal hit the
 in its first draft and fixed it by dropping the special code and reserving `2` for `argparse`
 everywhere; this task list now does the same, so both producers use numerically identical codes.
 
+**Revised again after `/review-openspec` round 1:** the reviewer found that
+`tests/test_batch.py` already has two tests hardcoding the *old* scheme —
+`test_cli_main_exit_codes` (asserts `main(...) == 1` for a failed batch) and
+`test_cli_missing_input_dir_returns_nonzero` (asserts `main(...) == 2`). Neither was named in
+the original 1.1/1.3 tasks, so implementing this section as originally written would have left
+the suite self-contradictory (the second case worse than a mere assertion mismatch — once 1.5
+removes the `except` clause, that test's `main()` call raises `FileNotFoundError` uncaught,
+an error, not a failure). Tasks 1.1 and 1.3 below now name both tests explicitly. Also decided:
+the log-quality regression from dropping the `except` clause (a missing-mount error would
+otherwise dump a raw traceback instead of a clean one-line log) is worth preserving — 1.5 now
+keeps a narrow `except (FileNotFoundError, ValueError)` that only logs before re-raising, so the
+final exit code is still Python's unhandled-exception default `1` but the log line survives.
+
 - [ ] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
-      `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans.
+      `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans,
+      **and update `test_cli_main_exit_codes`'s existing `assert main(...) == 1` (failed-batch
+      case) to `== 3`** — do not leave the old assertion alongside the new test; they cover the
+      same scenario and must agree.
 - [ ] 1.2 In the same file, write a failing test asserting `main()` still returns `0` for an
       all-ok/all-skipped batch (pins the unchanged success path).
 - [ ] 1.3 In the same file, write a failing test asserting the existing
       `FileNotFoundError`/duplicate-`scan_key` abort paths now return the default `1` (not the old
       `2`) — this is a **behavior-change** regression test, not a no-op pin: it must fail against
-      the current code (which still returns `2`) until task 1.4 removes the special case.
+      the current code (which still returns `2`) until task 1.5 removes the special case.
+      **Rewrite `test_cli_missing_input_dir_returns_nonzero`** (currently `assert main(...) == 2`)
+      to expect `main(...) == 1` (per the logged-then-propagated behavior decided above, the
+      exception is caught, logged, and re-raised inside `main()`, so this is still an assertion on
+      `main()`'s return/raise, not a bare `pytest.raises` around a raw exception — confirm the
+      exact shape once 1.5's implementation is written, and adjust the test to match rather than
+      leaving the stale `== 2` assertion in place). Also add a CLI-level test asserting the new
+      empty-input `ValueError` (from section 2) surfaces through `main()` as exit `1` too, for the
+      same logged-then-reraised reason.
 - [ ] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
       module with a missing required argument) exits `2` via `argparse`, and that this is
       independent of the driver's own `0`/`1`/`3` codes (documents the boundary so a future change
       can't quietly blur it again).
 - [ ] 1.5 Implement: in `sleap_roots_predict/__main__.py`, change `return 0 if result.ok else 1` to
-      `return 0 if result.ok else 3`, and **remove** the `except (FileNotFoundError, ValueError):
-      return 2` clause entirely — let those exceptions propagate uncaught (Python's default exit
-      `1`). Update the module docstring and `main()`'s docstring to enumerate the three
-      driver-owned codes (`0`/`3`/default `1`) plus a note that `2` is reserved by `argparse`, not
-      by this driver. Run 1.1–1.4 green.
+      `return 0 if result.ok else 3`. Replace the existing `except (FileNotFoundError, ValueError):
+      return 2` clause with `except (FileNotFoundError, ValueError) as exc:
+      logging.getLogger(__name__).error("Batch aborted: %s", exc); raise` — this keeps the
+      existing clean one-line log message for these two known staging-error types (a real
+      operational-log-quality regression if dropped entirely, per `/review-openspec` round 1) while
+      letting the exception continue on to Python's default unhandled-exception exit `1`, same as
+      any other uncaught crash. Update the module docstring and `main()`'s docstring to enumerate
+      the three driver-owned codes (`0`/`3`/default `1`) plus a note that `2` is reserved by
+      `argparse`, not by this driver. Run 1.1–1.4 green.
 
 ## 2. Empty-input guard (D2): raise instead of silent no-op
 
@@ -41,8 +69,9 @@ everywhere; this task list now does the same, so both producers use numerically 
       non-empty `scan_keys`).
 - [ ] 2.3 In `tests/test_batch.py`, write a regression test asserting a `run_manifest.json` that
       lists `scan_keys` with **no** matching sidecar still returns a non-empty `BatchResult` with
-      `failed` entries (exit `3` via `main()`), not the empty-input `ValueError` path — pins the
-      D2/D1 boundary described in the spec delta.
+      `failed` entries via `run_batch` directly (i.e. does NOT raise the empty-input `ValueError`)
+      — pins the D2/D1 boundary described in the spec delta at the `run_batch` level, distinct
+      from the CLI-level `main()` exit-code tests in section 1.
 - [ ] 2.4 Implement: in `sleap_roots_predict/batch.py::run_batch`, replace the
       `if not scans: logger.warning(...); return result` branch with
       `raise ValueError(f"no scans discovered under {input_dir.as_posix()}")`, placed before
@@ -53,24 +82,52 @@ everywhere; this task list now does the same, so both producers use numerically 
 
 ## 3. Atomic writes (D3): `.slp`, manifest, and sidecar copy
 
+**Note found in `/review-openspec` round 1:** `sio.save_file` infers the output format purely
+from the destination filename's extension (confirmed by reading `sleap_io`'s source) and raises
+`ValueError: Unknown format` if it doesn't recognize one. This repo's own existing atomic-write
+precedent (`sleap_roots_predict/parity.py`'s `write_report`, `foo.json` → `foo.json.tmp`) would
+break `.slp` writes if copy-pasted verbatim, since `foo.slp.tmp` no longer ends in `.slp`. Task
+3.4 below calls this out explicitly so it's designed in from the start, not discovered as a test
+failure partway through.
+
 - [ ] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
       `write_prediction_outputs`, no file ever exists at a `.slp`'s final path except either
-      fully absent or fully written (e.g. by monkeypatching the write step to raise after the
-      temp file is created but before the rename, then asserting the final path does not exist).
+      fully absent or fully written (e.g. by monkeypatching `os.replace` to raise once before it's
+      actually called, then asserting the final path does not exist and any temp file is cleaned
+      up or at least never mistaken for the final artifact).
 - [ ] 3.2 In `tests/test_output_contract.py`, write the equivalent failing test for
       `{scan_key}.predictions.json` (temp file created, final path untouched until rename).
-- [ ] 3.3 In `tests/test_batch.py`, write a failing test for the sidecar copy in
-      `batch.py::_predict_one` with the same interrupted-before-rename assertion.
-- [ ] 3.4 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
-      `write_prediction_outputs`: write each `.slp` via `sio.save_file` to a temp path in the
-      same directory, then `os.replace` into the final path; same pattern for the manifest's
-      `.write_text`, keeping the manifest write strictly last. Run 3.1–3.2 green; confirm all
-      existing round-trip tests in `test_output_contract.py` still pass unchanged.
-- [ ] 3.5 Implement the same atomic pattern for the sidecar copy in
+- [ ] 3.3 In `tests/test_output_contract.py`, write a failing test asserting every `.slp`'s atomic
+      write completes (final `os.replace` observed) before the manifest's atomic write begins —
+      pins the "manifest is still written last" ordering invariant the spec requires, distinct
+      from the interrupted-write tests in 3.1/3.2 (e.g. via a call-order spy wrapping `os.replace`).
+- [ ] 3.4 In `tests/test_batch.py`, write a failing test for the sidecar copy in
+      `batch.py::_predict_one` with the same interrupted-before-rename assertion as 3.1.
+- [ ] 3.5 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
+      `write_prediction_outputs`: write each `.slp` to a temp path in the same directory via
+      `sio.save_file(labels, tmp_path.as_posix(), format="slp")` — **pass `format="slp"` explicitly
+      rather than relying on the temp filename's extension** (see the note above; do not use a
+      bare `.tmp`-suffix-appended name unless it still ends in `.slp`), then `os.replace` into the
+      final path; same pattern for the manifest's `.write_text`, keeping the manifest write
+      strictly last. Run 3.1–3.3 green; confirm all existing round-trip tests in
+      `test_output_contract.py` still pass unchanged.
+- [ ] 3.6 Implement the same atomic pattern for the sidecar copy in
       `sleap_roots_predict/batch.py::_predict_one` (replace the direct `shutil.copyfile` with
-      copy-to-temp + `os.replace`). Run 3.3 green.
+      copy-to-temp + `os.replace`; a plain file copy has no format-inference concern, unlike 3.5).
+      Run 3.4 green. Land 3.5 and 3.6 as separate commits — independent write sites, no shared
+      code path (per `/review-openspec` round 1's commit-strategy feedback).
 
 ## 4. SIGTERM handler (D4): stop at scan boundary, exit 143
+
+**Note found in `/review-openspec` round 1:** on Windows, `signal.signal(signal.SIGTERM, ...)`
+registers without error, but real cross-process delivery (`os.kill(pid, signal.SIGTERM)`) is
+implemented via `TerminateProcess`, which kills the process immediately **without invoking the
+registered handler** — unlike Linux/macOS, where real delivery does invoke it. The plan below
+already avoids this trap (4.3 tests the handler by calling it directly, never via `os.kill`), so
+there is no CI risk today — but if a future change "improves" that test to be more "realistic"
+via `os.kill`, it would silently hang/kill the `windows-latest` CI job instead of failing
+cleanly. `design.md` and the spec now document this platform split explicitly so the constraint
+in 4.3 doesn't get quietly removed later.
 
 - [ ] 4.1 In `tests/test_batch.py`, write a failing test asserting `run_batch(..., should_stop=fn)`
       stops after the first scan (of two) when `fn` returns `True` starting from the second
@@ -80,26 +137,51 @@ everywhere; this task list now does the same, so both producers use numerically 
       `should_stop` (no argument passed) is unaffected — processes all scans exactly as before
       (regression pin for existing callers/tests).
 - [ ] 4.3 Add a test (`test_batch.py` or a new `tests/test_main.py` if signal-handling tests don't
-      fit `test_batch.py`'s existing scope) driving `__main__.py`'s handler registration and event
-      logic directly: invoke the registered `SIGTERM` handler function, assert the shared event
-      becomes set, assert `main()` returns `143` in that case — without mocking `run_batch` itself
-      (real TDD; only the signal delivery is simulated by calling the handler directly rather than
-      `os.kill`, since a real cross-process signal test is unnecessary to exercise this logic).
+      fit `test_batch.py`'s existing scope) that: obtains the registered `SIGTERM` handler and its
+      backing `threading.Event` independently of running a full batch (see 4.5's implementation
+      note — `main()` must expose a seam for this, e.g. a small `_install_sigterm_handler() ->
+      threading.Event` helper it calls, so a test can call that helper directly rather than
+      needing to invoke all of `main()` to obtain the handler); invoke the handler directly (never
+      `os.kill` — see the Windows note above), assert the event becomes set, assert `main()`
+      returns `143` when the event is already set going into its post-`run_batch` check — without
+      mocking `run_batch` itself (real TDD). **Save `signal.getsignal(signal.SIGTERM)` before the
+      test and restore it in a `finally`/fixture teardown**, so the handler registered by this test
+      doesn't leak into later tests or interact with CI's job-level timeout kill.
 - [ ] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
       `run_batch`, checked at the top of the per-scan `for` loop (`if should_stop(): logger.warning(...);
       break`). Run 4.1–4.2 green.
-- [ ] 4.5 Implement: in `sleap_roots_predict/__main__.py`'s `main()`, create a `threading.Event`,
-      register a `signal.signal(signal.SIGTERM, ...)` handler that sets it, pass
-      `should_stop=event.is_set` into `run_batch`, and after `run_batch` returns, check the event
-      first — if set, log and `return 143` before falling through to the normal 0/3 logic (`2` is
-      never part of this fallthrough — `argparse` exits `2` on its own, before `run_batch` runs).
-      Run 4.3 green.
+- [ ] 4.5 Implement: add a small `_install_sigterm_handler() -> threading.Event` helper in
+      `sleap_roots_predict/__main__.py` that creates the `Event`, registers a
+      `signal.signal(signal.SIGTERM, ...)` handler that sets it, and returns the `Event` — giving
+      4.3 a seam to call directly. `main()` calls this helper, passes `should_stop=event.is_set`
+      into `run_batch`, and after `run_batch` returns, checks the event first — if set, log and
+      `return 143` before falling through to the normal `0`/`3` logic (`2` is never part of this
+      fallthrough — `argparse` exits `2` on its own, before `run_batch` runs). Run 4.3 green.
 
 ## 5. Docs and closeout
 
-- [ ] 5.1 Update `sleap_roots_predict/__main__.py`'s module docstring (already touched in 1.4) and
+- [ ] 5.1 Update `sleap_roots_predict/__main__.py`'s module docstring (already touched in 1.5) and
       `sleap_roots_predict/batch.py`'s `run_batch` docstring (`Raises:`/behavior description) to
       match the final implemented behavior — re-read both after 1–4 land to catch any drift from
       the design doc's phrasing.
-- [ ] 5.2 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
-- [ ] 5.3 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.
+- [ ] 5.2 Update `README.md`'s "Running the predict container" section: replace "it exits
+      non-zero if any scan failed" with a one-line pointer to the exit-code contract (`0`=success,
+      `3`=partial, default `1`=staging-error-or-crash, `143`=`SIGTERM`, `2` reserved for
+      `argparse`) rather than re-describing the table in prose — point at the `predict-container`
+      OpenSpec spec as the source of truth (matches this repo's existing single-sourcing
+      convention for `resolve_params`/`choose_models`/output-contract, per `openspec/project.md`).
+      Add a sentence documenting that an empty (zero-scan) input directory now raises/exits
+      non-zero instead of the old silent no-op — this behavior is currently undocumented anywhere
+      in `README.md`.
+- [ ] 5.3 Fix `API.md`'s `run_batch` section: the parenthetical "`BatchResult.ok` is `False` iff
+      any scan failed (the CLI exit code)" is misleading post-change — `ok=False` now maps
+      specifically to exit `3`, not "the CLI exit code" in general (a crash never reaches
+      `BatchResult` construction at all). Reword to something like "(maps to CLI exit `3`, distinct
+      from a staging-error/crash `1`)".
+- [ ] 5.4 Add a `CHANGELOG.md` entry under `[Unreleased]`: amend the existing "Predict container
+      CLI" bullet's "Per-scan failures are isolated; the process exits non-zero iff any scan
+      failed" sentence to describe the final `0`/`3`/default-`1`/`143` scheme and the
+      empty-input-now-raises change, and drop/update its closing "Argo-readiness hardening (#26)
+      are follow-ups" note now that #26 has landed alongside it.
+- [ ] 5.5 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
+- [ ] 5.6 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -1,0 +1,88 @@
+## 1. Exit codes (D1): partial (3) distinct from crash (default 1)
+
+- [ ] 1.1 In `tests/test_batch.py`, write a failing test asserting `main()` returns `3` (not `1`)
+      for a batch with one failed scan among otherwise-ok scans.
+- [ ] 1.2 In `tests/test_batch.py`, write a failing test asserting `main()` still returns `0` for
+      an all-ok/all-skipped batch (pins the unchanged success path).
+- [ ] 1.3 In `tests/test_batch.py`, write a failing test asserting the existing
+      `FileNotFoundError`/duplicate-`scan_key` abort paths still return `2` (regression pin — no
+      behavior change here, but exercised alongside the new codes so the four-way split is
+      tested together).
+- [ ] 1.4 Implement: change `sleap_roots_predict/__main__.py`'s `return 0 if result.ok else 1` to
+      `return 0 if result.ok else 3`; update the module docstring and `main()`'s docstring to
+      enumerate all four codes (`0`/`2`/`3`/default `1`). Run 1.1–1.3 green.
+
+## 2. Empty-input guard (D2): raise instead of silent no-op
+
+- [ ] 2.1 In `tests/test_batch.py`, write a failing test asserting `run_batch` raises `ValueError`
+      over a present-but-empty input directory (no `*.scan_metadata.json`), and that it raises
+      *before* any `WarmModelWorker`/model-source interaction (assert via a source stub that
+      records whether it was ever called).
+- [ ] 2.2 In `tests/test_batch.py`, write a failing test asserting a `run_manifest.json` present
+      but scoping to zero `scan_keys` also raises via the same path (pydantic validation of
+      `RunManifest` may already reject an empty `scan_keys` list — confirm which layer raises
+      and assert that one; do not add a redundant check if `RunManifest` itself already enforces
+      non-empty `scan_keys`).
+- [ ] 2.3 In `tests/test_batch.py`, write a regression test asserting a `run_manifest.json` that
+      lists `scan_keys` with **no** matching sidecar still returns a non-empty `BatchResult` with
+      `failed` entries (exit `3` via `main()`), not the empty-input `ValueError` path — pins the
+      D2/D1 boundary described in the spec delta.
+- [ ] 2.4 Implement: in `sleap_roots_predict/batch.py::run_batch`, replace the
+      `if not scans: logger.warning(...); return result` branch with
+      `raise ValueError(f"no scans discovered under {input_dir.as_posix()}")`, placed before
+      `WarmModelWorker(source=source)` is constructed. Update `run_batch`'s docstring (`Raises:`
+      section) accordingly. Run 2.1–2.3 green; also re-run the existing "Empty input directory is
+      a no-op" test from `test_batch.py` if present and update/replace it to assert the new
+      raising behavior (do not leave a stale test asserting the old no-op contract).
+
+## 3. Atomic writes (D3): `.slp`, manifest, and sidecar copy
+
+- [ ] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
+      `write_prediction_outputs`, no file ever exists at a `.slp`'s final path except either
+      fully absent or fully written (e.g. by monkeypatching the write step to raise after the
+      temp file is created but before the rename, then asserting the final path does not exist).
+- [ ] 3.2 In `tests/test_output_contract.py`, write the equivalent failing test for
+      `{scan_key}.predictions.json` (temp file created, final path untouched until rename).
+- [ ] 3.3 In `tests/test_batch.py`, write a failing test for the sidecar copy in
+      `batch.py::_predict_one` with the same interrupted-before-rename assertion.
+- [ ] 3.4 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
+      `write_prediction_outputs`: write each `.slp` via `sio.save_file` to a temp path in the
+      same directory, then `os.replace` into the final path; same pattern for the manifest's
+      `.write_text`, keeping the manifest write strictly last. Run 3.1–3.2 green; confirm all
+      existing round-trip tests in `test_output_contract.py` still pass unchanged.
+- [ ] 3.5 Implement the same atomic pattern for the sidecar copy in
+      `sleap_roots_predict/batch.py::_predict_one` (replace the direct `shutil.copyfile` with
+      copy-to-temp + `os.replace`). Run 3.3 green.
+
+## 4. SIGTERM handler (D4): stop at scan boundary, exit 143
+
+- [ ] 4.1 In `tests/test_batch.py`, write a failing test asserting `run_batch(..., should_stop=fn)`
+      stops after the first scan (of two) when `fn` returns `True` starting from the second
+      iteration, and that the first scan's outputs are complete and valid (reloadable manifest +
+      `.slp`).
+- [ ] 4.2 In `tests/test_batch.py`, write a failing test asserting `run_batch` with the default
+      `should_stop` (no argument passed) is unaffected — processes all scans exactly as before
+      (regression pin for existing callers/tests).
+- [ ] 4.3 Add a test (`test_batch.py` or a new `tests/test_main.py` if signal-handling tests don't
+      fit `test_batch.py`'s existing scope) driving `__main__.py`'s handler registration and event
+      logic directly: invoke the registered `SIGTERM` handler function, assert the shared event
+      becomes set, assert `main()` returns `143` in that case — without mocking `run_batch` itself
+      (real TDD; only the signal delivery is simulated by calling the handler directly rather than
+      `os.kill`, since a real cross-process signal test is unnecessary to exercise this logic).
+- [ ] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
+      `run_batch`, checked at the top of the per-scan `for` loop (`if should_stop(): logger.warning(...);
+      break`). Run 4.1–4.2 green.
+- [ ] 4.5 Implement: in `sleap_roots_predict/__main__.py`'s `main()`, create a `threading.Event`,
+      register a `signal.signal(signal.SIGTERM, ...)` handler that sets it, pass
+      `should_stop=event.is_set` into `run_batch`, and after `run_batch` returns, check the event
+      first — if set, log and `return 143` before falling through to the normal 0/2/3 logic. Run
+      4.3 green.
+
+## 5. Docs and closeout
+
+- [ ] 5.1 Update `sleap_roots_predict/__main__.py`'s module docstring (already touched in 1.4) and
+      `sleap_roots_predict/batch.py`'s `run_batch` docstring (`Raises:`/behavior description) to
+      match the final implemented behavior — re-read both after 1–4 land to catch any drift from
+      the design doc's phrasing.
+- [ ] 5.2 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
+- [ ] 5.3 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -33,6 +33,12 @@ error would otherwise dump a raw traceback instead of a clean one-line log) is w
    clean log line too, alongside the missing-directory and duplicate-`scan_key` cases. Wording
    below corrected accordingly.
 
+**Revised again after `/review-openspec` round 3:** task 1.3's escape hatch ("or write both
+together in one commit if landing them separately isn't worth the overhead") was ambiguous about
+scope and inconsistent with this document's own precedent elsewhere (3.5/3.6 and 4.4/4.5 both
+mandate a split for independent write sites, with no such opt-out) — removed. Section 2's commit
+lands before section 1's is now the only path, stated plainly below.
+
 - [ ] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
       `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans,
       **and update `test_cli_main_exit_codes`'s existing `assert main(...) == 1` (failed-batch
@@ -54,9 +60,9 @@ error would otherwise dump a raw traceback instead of a clean one-line log) is w
       explicitly (per `/review-openspec` round 2's commit-sequencing finding):** add a second test
       asserting the new empty-input `ValueError` (implemented in task 2.4, section 2) also
       propagates uncaught from `main()` the same way (`pytest.raises(ValueError)`). This sub-test
-      has nothing to exercise until section 2's `run_batch` change lands — sequence section 2's
-      commit before finalizing this one, or write both together in one commit if landing them
-      separately isn't worth the overhead for a change this size.
+      has nothing to exercise until section 2's `run_batch` change lands — **section 2's commit
+      lands before section 1's commit is finalized**, reversing the numeric order of the sections
+      (call this out explicitly when sequencing the PR, so nobody lands 1 before 2 out of habit).
 - [ ] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
       module with a missing required argument) exits `2` via `argparse`, and that this is
       independent of the driver's own `0`/`1`/`3` codes (documents the boundary so a future change
@@ -88,7 +94,9 @@ error would otherwise dump a raw traceback instead of a clean one-line log) is w
       lists `scan_keys` with **no** matching sidecar still returns a non-empty `BatchResult` with
       `failed` entries via `run_batch` directly (i.e. does NOT raise the empty-input `ValueError`)
       — pins the D2/D1 boundary described in the spec delta at the `run_batch` level, distinct
-      from the CLI-level `main()` exit-code tests in section 1.
+      from the CLI-level `main()` exit-code tests in section 1. This scenario is already
+      substantially covered by the existing `test_manifest_scan_key_with_no_sidecar_is_failed`;
+      confirm it already passes rather than writing a near-duplicate.
 - [ ] 2.4 Implement: in `sleap_roots_predict/batch.py::run_batch`, replace the
       `if not scans: logger.warning(...); return result` branch with
       `raise ValueError(f"no scans discovered under {input_dir.as_posix()}")`, placed before
@@ -96,8 +104,7 @@ error would otherwise dump a raw traceback instead of a clean one-line log) is w
       section) accordingly. Run 2.1–2.3 green; also re-run the existing "Empty input directory is
       a no-op" test from `test_batch.py` if present and update/replace it to assert the new
       raising behavior (do not leave a stale test asserting the old no-op contract).
-      **Land this commit before finalizing task 1.3's cross-section empty-input sub-test** (see
-      the note there).
+      **This commit lands before section 1's commit** (see the note under task 1.3).
 
 ## 3. Atomic writes (D3): `.slp`, manifest, and sidecar copy
 
@@ -112,12 +119,15 @@ failure partway through. This constraint is also now recorded directly in
 after archiving and the persisted spec is what a future maintainer changing the temp-naming
 scheme would actually consult.
 
-- [ ] 3.0 In `tests/test_output_contract.py`, write a failing test asserting `write_prediction_outputs`
-      succeeds even when its internal `.slp` temp filename does not itself end in `.slp` (e.g. by
-      monkeypatching the temp-path construction, or simply asserting success once 3.5 is
-      implemented with a `.tmp`-suffixed temp name) — pins that `format="slp"` is passed explicitly
-      rather than relied-upon-via-extension (see the note above and the corresponding new scenario
-      in `specs/prediction-output/spec.md`).
+- [ ] 3.0 In `tests/test_output_contract.py`, write a failing test that spies on `sio.save_file`
+      (e.g. `monkeypatch.setattr(output_contract_mod.sio, "save_file", spy)` wrapping the real
+      function) and asserts it is called with `format="slp"` explicitly for every `.slp` write —
+      this is genuinely red today (the current code passes no `format` kwarg at all) and pins the
+      invariant independently of whatever temp-filename scheme 3.5 ends up using. (**Revised in
+      `/review-openspec` round 3** — the original wording here, "monkeypatch the temp-path
+      construction, or simply assert success once 3.5 lands," named no concrete seam and would
+      have been redundant with every existing round-trip test in this file, which would already
+      fail with "Unknown format" if 3.5 used a `.tmp`-suffixed name without `format=`.)
 - [ ] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
       `write_prediction_outputs`, no file ever exists at a `.slp`'s final path except either
       fully absent or fully written (e.g. by monkeypatching `os.replace` to raise once before it's
@@ -130,7 +140,10 @@ scheme would actually consult.
       pins the "manifest is still written last" ordering invariant the spec requires, distinct
       from the interrupted-write tests in 3.1/3.2 (e.g. via a call-order spy wrapping `os.replace`).
 - [ ] 3.4 In `tests/test_batch.py`, write a failing test for the sidecar copy in
-      `batch.py::_predict_one` with the same interrupted-before-rename assertion as 3.1.
+      `batch.py::_predict_one` with the same interrupted-before-rename assertion as 3.1 — note
+      `batch.py` does not currently `import os` (unlike `output_contract.py`, which already does),
+      so patch via `monkeypatch.setattr("os.replace", ...)` (patches the module globally) rather
+      than `monkeypatch.setattr(batch_mod.os, "replace", ...)`, which would raise `AttributeError`.
 - [ ] 3.5 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
       `write_prediction_outputs`: write each `.slp` to a temp path in the same directory via
       `sio.save_file(labels, tmp_path.as_posix(), format="slp")` — **pass `format="slp"` explicitly
@@ -174,9 +187,14 @@ test to use `os.kill` later; on Windows CI that would silently hang or kill the 
       returns `143` when the event is already set going into its post-`run_batch` check — cover
       this against **both** a would-otherwise-be-`0` batch and a would-otherwise-be-`3` batch, to
       pin that `143` overrides either outcome, not just the success case — without mocking
-      `run_batch` itself (real TDD). **Save `signal.getsignal(signal.SIGTERM)` before the test and
-      restore it in a `finally`/fixture teardown**, so the handler registered by this test doesn't
-      leak into later tests or interact with CI's job-level timeout kill.
+      `run_batch` itself (real TDD; if triggering the event needs to happen strictly between
+      `run_batch` returning and `main()`'s post-check, use a delegating spy that calls the real
+      `run_batch` and then sets the event as a side effect, mirroring this file's existing
+      `spy_resolve`/`_Counting(orig)` pattern in `test_scan_error_short_circuits_before_resolve`/
+      `test_run_batch_constructs_single_worker` rather than inventing a new technique). **Save
+      `signal.getsignal(signal.SIGTERM)` before the test and restore it in a `finally`/fixture
+      teardown**, so the handler registered by this test doesn't leak into later tests or interact
+      with CI's job-level timeout kill.
 - [ ] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
       `run_batch`, checked at the top of the per-scan `for` loop (`if should_stop(): logger.warning(...);
       break`). Run 4.1–4.2 green.

--- a/openspec/changes/harden-argo-exit-semantics/tasks.md
+++ b/openspec/changes/harden-argo-exit-semantics/tasks.md
@@ -39,14 +39,14 @@ scope and inconsistent with this document's own precedent elsewhere (3.5/3.6 and
 mandate a split for independent write sites, with no such opt-out) — removed. Section 2's commit
 lands before section 1's is now the only path, stated plainly below.
 
-- [ ] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
+- [x] 1.1 In `tests/test_batch.py` (or `test___main__.py`), write a failing test asserting
       `main()` returns `3` (not `1`) for a batch with one failed scan among otherwise-ok scans,
       **and update `test_cli_main_exit_codes`'s existing `assert main(...) == 1` (failed-batch
       case) to `== 3`** — do not leave the old assertion alongside the new test; they cover the
       same scenario and must agree.
-- [ ] 1.2 In the same file, write a failing test asserting `main()` still returns `0` for an
+- [x] 1.2 In the same file, write a failing test asserting `main()` still returns `0` for an
       all-ok/all-skipped batch (pins the unchanged success path).
-- [ ] 1.3 In the same file, write a failing test asserting a missing input directory now
+- [x] 1.3 In the same file, write a failing test asserting a missing input directory now
       propagates as an uncaught `FileNotFoundError` from `main()` (not a returned `2`) — this is a
       **behavior-change** regression test, not a no-op pin: it must fail against the current code
       (which still returns `2`) until task 1.5 removes the special case.
@@ -63,11 +63,11 @@ lands before section 1's is now the only path, stated plainly below.
       has nothing to exercise until section 2's `run_batch` change lands — **section 2's commit
       lands before section 1's commit is finalized**, reversing the numeric order of the sections
       (call this out explicitly when sequencing the PR, so nobody lands 1 before 2 out of habit).
-- [ ] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
+- [x] 1.4 In the same file, write a failing test asserting a CLI usage error (invoke `main()`/the
       module with a missing required argument) exits `2` via `argparse`, and that this is
       independent of the driver's own `0`/`1`/`3` codes (documents the boundary so a future change
       can't quietly blur it again).
-- [ ] 1.5 Implement: in `sleap_roots_predict/__main__.py`, change `return 0 if result.ok else 1` to
+- [x] 1.5 Implement: in `sleap_roots_predict/__main__.py`, change `return 0 if result.ok else 1` to
       `return 0 if result.ok else 3`. Replace the existing `except (FileNotFoundError, ValueError):
       return 2` clause with `except (FileNotFoundError, ValueError) as exc:
       logging.getLogger(__name__).error("Batch aborted: %s", exc); raise` — this keeps the
@@ -81,23 +81,23 @@ lands before section 1's is now the only path, stated plainly below.
 
 ## 2. Empty-input guard (D2): raise instead of silent no-op
 
-- [ ] 2.1 In `tests/test_batch.py`, write a failing test asserting `run_batch` raises `ValueError`
+- [x] 2.1 In `tests/test_batch.py`, write a failing test asserting `run_batch` raises `ValueError`
       over a present-but-empty input directory (no `*.scan_metadata.json`), and that it raises
       *before* any `WarmModelWorker`/model-source interaction (assert via a source stub that
       records whether it was ever called).
-- [ ] 2.2 In `tests/test_batch.py`, write a failing test asserting a `run_manifest.json` present
+- [x] 2.2 In `tests/test_batch.py`, write a failing test asserting a `run_manifest.json` present
       but scoping to zero `scan_keys` also raises (via `RunManifest`'s own validation inside
       `discover_scans` — a distinct raise site from 2.1's zero-scans-discovered check, both
       landing on the same CLI exit code; confirm which layer raises and assert that one; do not
       add a redundant check if `RunManifest` itself already enforces non-empty `scan_keys`).
-- [ ] 2.3 In `tests/test_batch.py`, write a regression test asserting a `run_manifest.json` that
+- [x] 2.3 In `tests/test_batch.py`, write a regression test asserting a `run_manifest.json` that
       lists `scan_keys` with **no** matching sidecar still returns a non-empty `BatchResult` with
       `failed` entries via `run_batch` directly (i.e. does NOT raise the empty-input `ValueError`)
       — pins the D2/D1 boundary described in the spec delta at the `run_batch` level, distinct
       from the CLI-level `main()` exit-code tests in section 1. This scenario is already
       substantially covered by the existing `test_manifest_scan_key_with_no_sidecar_is_failed`;
       confirm it already passes rather than writing a near-duplicate.
-- [ ] 2.4 Implement: in `sleap_roots_predict/batch.py::run_batch`, replace the
+- [x] 2.4 Implement: in `sleap_roots_predict/batch.py::run_batch`, replace the
       `if not scans: logger.warning(...); return result` branch with
       `raise ValueError(f"no scans discovered under {input_dir.as_posix()}")`, placed before
       `WarmModelWorker(source=source)` is constructed. Update `run_batch`'s docstring (`Raises:`
@@ -119,7 +119,7 @@ failure partway through. This constraint is also now recorded directly in
 after archiving and the persisted spec is what a future maintainer changing the temp-naming
 scheme would actually consult.
 
-- [ ] 3.0 In `tests/test_output_contract.py`, write a failing test that spies on `sio.save_file`
+- [x] 3.0 In `tests/test_output_contract.py`, write a failing test that spies on `sio.save_file`
       (e.g. `monkeypatch.setattr(output_contract_mod.sio, "save_file", spy)` wrapping the real
       function) and asserts it is called with `format="slp"` explicitly for every `.slp` write —
       this is genuinely red today (the current code passes no `format` kwarg at all) and pins the
@@ -128,23 +128,23 @@ scheme would actually consult.
       construction, or simply assert success once 3.5 lands," named no concrete seam and would
       have been redundant with every existing round-trip test in this file, which would already
       fail with "Unknown format" if 3.5 used a `.tmp`-suffixed name without `format=`.)
-- [ ] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
+- [x] 3.1 In `tests/test_output_contract.py`, write a failing test asserting that during
       `write_prediction_outputs`, no file ever exists at a `.slp`'s final path except either
       fully absent or fully written (e.g. by monkeypatching `os.replace` to raise once before it's
       actually called, then asserting the final path does not exist and any temp file is cleaned
       up or at least never mistaken for the final artifact).
-- [ ] 3.2 In `tests/test_output_contract.py`, write the equivalent failing test for
+- [x] 3.2 In `tests/test_output_contract.py`, write the equivalent failing test for
       `{scan_key}.predictions.json` (temp file created, final path untouched until rename).
-- [ ] 3.3 In `tests/test_output_contract.py`, write a failing test asserting every `.slp`'s atomic
+- [x] 3.3 In `tests/test_output_contract.py`, write a failing test asserting every `.slp`'s atomic
       write completes (final `os.replace` observed) before the manifest's atomic write begins —
       pins the "manifest is still written last" ordering invariant the spec requires, distinct
       from the interrupted-write tests in 3.1/3.2 (e.g. via a call-order spy wrapping `os.replace`).
-- [ ] 3.4 In `tests/test_batch.py`, write a failing test for the sidecar copy in
+- [x] 3.4 In `tests/test_batch.py`, write a failing test for the sidecar copy in
       `batch.py::_predict_one` with the same interrupted-before-rename assertion as 3.1 — note
       `batch.py` does not currently `import os` (unlike `output_contract.py`, which already does),
       so patch via `monkeypatch.setattr("os.replace", ...)` (patches the module globally) rather
       than `monkeypatch.setattr(batch_mod.os, "replace", ...)`, which would raise `AttributeError`.
-- [ ] 3.5 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
+- [x] 3.5 Implement atomic writes in `sleap_roots_predict/output_contract.py`'s
       `write_prediction_outputs`: write each `.slp` to a temp path in the same directory via
       `sio.save_file(labels, tmp_path.as_posix(), format="slp")` — **pass `format="slp"` explicitly
       rather than relying on the temp filename's extension** (see the note above; do not use a
@@ -152,7 +152,7 @@ scheme would actually consult.
       final path; same pattern for the manifest's `.write_text`, keeping the manifest write
       strictly last. Run 3.0–3.3 green; confirm all existing round-trip tests in
       `test_output_contract.py` still pass unchanged.
-- [ ] 3.6 Implement the same atomic pattern for the sidecar copy in
+- [x] 3.6 Implement the same atomic pattern for the sidecar copy in
       `sleap_roots_predict/batch.py::_predict_one` (replace the direct `shutil.copyfile` with
       copy-to-temp + `os.replace`; a plain file copy has no format-inference concern, unlike 3.5).
       Run 3.4 green; also confirm the existing `test_sidecar_copy_failure_leaves_no_manifest`
@@ -170,14 +170,14 @@ constraint; this note is just a pointer, not a restatement). The plan below alre
 trap (4.3 tests the handler by calling it directly, never via `os.kill`) — don't "improve" that
 test to use `os.kill` later; on Windows CI that would silently hang or kill the job.
 
-- [ ] 4.1 In `tests/test_batch.py`, write a failing test asserting `run_batch(..., should_stop=fn)`
+- [x] 4.1 In `tests/test_batch.py`, write a failing test asserting `run_batch(..., should_stop=fn)`
       stops after the first scan (of two) when `fn` returns `True` starting from the second
       iteration, and that the first scan's outputs are complete and valid (reloadable manifest +
       `.slp`).
-- [ ] 4.2 In `tests/test_batch.py`, write a failing test asserting `run_batch` with the default
+- [x] 4.2 In `tests/test_batch.py`, write a failing test asserting `run_batch` with the default
       `should_stop` (no argument passed) is unaffected — processes all scans exactly as before
       (regression pin for existing callers/tests).
-- [ ] 4.3 Add a test (`test_batch.py` or a new `tests/test_main.py` if signal-handling tests don't
+- [x] 4.3 Add a test (`test_batch.py` or a new `tests/test_main.py` if signal-handling tests don't
       fit `test_batch.py`'s existing scope) that: obtains the registered `SIGTERM` handler and its
       backing `threading.Event` independently of running a full batch (see 4.5's implementation
       note — `main()` must expose a seam for this, e.g. a small `_install_sigterm_handler() ->
@@ -195,10 +195,10 @@ test to use `os.kill` later; on Windows CI that would silently hang or kill the 
       `signal.getsignal(signal.SIGTERM)` before the test and restore it in a `finally`/fixture
       teardown**, so the handler registered by this test doesn't leak into later tests or interact
       with CI's job-level timeout kill.
-- [ ] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
+- [x] 4.4 Implement: add `should_stop: Callable[[], bool] = lambda: False` (keyword-only) to
       `run_batch`, checked at the top of the per-scan `for` loop (`if should_stop(): logger.warning(...);
       break`). Run 4.1–4.2 green.
-- [ ] 4.5 Implement: add a small `_install_sigterm_handler() -> threading.Event` helper in
+- [x] 4.5 Implement: add a small `_install_sigterm_handler() -> threading.Event` helper in
       `sleap_roots_predict/__main__.py` that creates the `Event`, registers a
       `signal.signal(signal.SIGTERM, ...)` handler that sets it, and returns the `Event` — giving
       4.3 a seam to call directly. `main()` calls this helper, passes `should_stop=event.is_set`
@@ -212,11 +212,11 @@ test to use `os.kill` later; on Windows CI that would silently hang or kill the 
 
 ## 5. Docs and closeout
 
-- [ ] 5.1 Update `sleap_roots_predict/__main__.py`'s module docstring (already touched in 1.5) and
+- [x] 5.1 Update `sleap_roots_predict/__main__.py`'s module docstring (already touched in 1.5) and
       `sleap_roots_predict/batch.py`'s `run_batch` docstring (`Raises:`/behavior description) to
       match the final implemented behavior — re-read both after 1–4 land to catch any drift from
       the design doc's phrasing.
-- [ ] 5.2 Update `README.md`'s "Running the predict container" section: replace "it exits
+- [x] 5.2 Update `README.md`'s "Running the predict container" section: replace "it exits
       non-zero if any scan failed" with a one-line pointer to the exit-code contract (`0`=success,
       `3`=partial, default `1`=staging-error-or-crash, `143`=`SIGTERM`, `2` reserved for
       `argparse`) rather than re-describing the table in prose — point at the `predict-container`
@@ -225,12 +225,12 @@ test to use `os.kill` later; on Windows CI that would silently hang or kill the 
       Add a sentence documenting that an empty (zero-scan) input directory now raises/exits
       non-zero instead of the old silent no-op — this behavior is currently undocumented anywhere
       in `README.md`.
-- [ ] 5.3 Fix `API.md`'s `run_batch` section: the parenthetical "`BatchResult.ok` is `False` iff
+- [x] 5.3 Fix `API.md`'s `run_batch` section: the parenthetical "`BatchResult.ok` is `False` iff
       any scan failed (the CLI exit code)" is misleading post-change — `ok=False` now maps
       specifically to exit `3`, not "the CLI exit code" in general (a crash never reaches
       `BatchResult` construction at all). Reword to something like "(maps to CLI exit `3`, distinct
       from a staging-error/crash `1`)".
-- [ ] 5.4 Amend the existing `CHANGELOG.md` `[Unreleased]` "Predict container CLI" entry — it needs
+- [x] 5.4 Amend the existing `CHANGELOG.md` `[Unreleased]` "Predict container CLI" entry — it needs
       updates for **all three** behavior changes in this proposal, not just the exit-code one
       (found incomplete in `/review-openspec` round 2, which only scoped this to D1/D2):
       (a) replace "Per-scan failures are isolated; the process exits non-zero iff any scan failed"
@@ -239,5 +239,5 @@ test to use `os.kill` later; on Windows CI that would silently hang or kill the 
       (c) add a mention of the new `SIGTERM` handler and its `143` exit (D4); (d) drop/update the
       closing "Argo-readiness hardening (#26) are follow-ups" note now that #26 has landed
       alongside this entry rather than following it.
-- [ ] 5.5 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
-- [ ] 5.6 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.
+- [x] 5.5 Run `/lint` and `/test` (full suite, non-gpu/wandb/acceptance markers) — all green.
+- [x] 5.6 Run `openspec validate harden-argo-exit-semantics --strict` — resolve every issue.

--- a/sleap_roots_predict/__main__.py
+++ b/sleap_roots_predict/__main__.py
@@ -1,7 +1,12 @@
 """CLI entrypoint: ``python -m sleap_roots_predict <input_dir> <output_dir>``.
 
-Warm-batch predict over a directory of staged scans. Exit code is ``0`` when no
-scan failed and ``1`` otherwise, so an Argo step sees a real batch result.
+Warm-batch predict over a directory of staged scans. Exit codes: ``0`` success (no
+scan failed); ``3`` partial (the batch ran to completion but one or more scans
+isolated-failed); Python's default ``1`` for every other failure (a pre-flight
+staging error — missing input directory, duplicate ``scan_key``, malformed
+``run_manifest.json``, or zero scans discovered — or a genuine crash). ``2`` is
+reserved by ``argparse`` for a CLI usage error and is never returned by this
+driver's own logic.
 """
 
 import argparse
@@ -17,7 +22,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         argv: Optional argument vector (defaults to ``sys.argv[1:]``).
 
     Returns:
-        ``0`` if no scan failed, ``1`` otherwise.
+        ``0`` on success, ``3`` on a partial batch (isolated scan failures). A
+        pre-flight staging error or other crash propagates uncaught, surfacing
+        Python's default exit ``1`` (see the module docstring).
     """
     parser = argparse.ArgumentParser(
         prog="sleap_roots_predict",
@@ -45,10 +52,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         result = run_batch(args.input_dir, args.output_dir)
     except (FileNotFoundError, ValueError) as exc:
-        # Batch-level staging error (missing input mount / duplicate scan_key): a clean
-        # logged message + non-zero exit rather than a raw traceback.
+        # A pre-flight staging error (missing input mount, duplicate scan_key,
+        # malformed run_manifest.json, or zero scans discovered — the latter two
+        # also raise ValueError, so they land here too). Log a clean message, then
+        # re-raise so the process still exits via Python's default unhandled-
+        # exception code (1), identical to any other crash.
         logging.getLogger(__name__).error("Batch aborted: %s", exc)
-        return 2
+        raise
 
     n_ok = sum(1 for s in result.scans if s.status == "ok")
     n_skip = sum(1 for s in result.scans if s.status == "skipped")
@@ -56,7 +66,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     logging.getLogger(__name__).info(
         "Batch complete: %d ok, %d skipped, %d failed", n_ok, n_skip, n_fail
     )
-    return 0 if result.ok else 1
+    return 0 if result.ok else 3
 
 
 if __name__ == "__main__":

--- a/sleap_roots_predict/__main__.py
+++ b/sleap_roots_predict/__main__.py
@@ -4,15 +4,39 @@ Warm-batch predict over a directory of staged scans. Exit codes: ``0`` success (
 scan failed); ``3`` partial (the batch ran to completion but one or more scans
 isolated-failed); Python's default ``1`` for every other failure (a pre-flight
 staging error — missing input directory, duplicate ``scan_key``, malformed
-``run_manifest.json``, or zero scans discovered — or a genuine crash). ``2`` is
+``run_manifest.json``, or zero scans discovered — or a genuine crash); ``143``
+(``128 + SIGTERM``) if the process was asked to stop early (Argo preemption),
+overriding whatever the completed-so-far scans would otherwise produce. ``2`` is
 reserved by ``argparse`` for a CLI usage error and is never returned by this
 driver's own logic.
 """
 
 import argparse
 import logging
+import signal
 import sys
+import threading
 from typing import Optional, Sequence
+
+
+def _install_sigterm_handler() -> threading.Event:
+    """Register a ``SIGTERM`` handler and return the event it sets.
+
+    The handler only sets a flag (signal-handler-safe — no blocking calls).
+    Exposed as its own function so a test can obtain the registered handler and
+    its event without running a full batch. On Windows, real cross-process
+    ``SIGTERM`` delivery (``os.kill``) bypasses the registered handler entirely
+    (it invokes ``TerminateProcess`` instead) — tests must invoke the handler
+    directly, never via ``os.kill``; real end-to-end delivery is only ever
+    meaningfully validated on Linux (the actual Argo/Kubernetes runtime) or macOS.
+    """
+    event = threading.Event()
+
+    def _handler(signum, frame):
+        event.set()
+
+    signal.signal(signal.SIGTERM, _handler)
+    return event
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -49,8 +73,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Lazy import: `--help` exits inside parse_args above, so it never pulls in torch.
     from sleap_roots_predict.batch import run_batch
 
+    stop_event = _install_sigterm_handler()
+
     try:
-        result = run_batch(args.input_dir, args.output_dir)
+        result = run_batch(
+            args.input_dir, args.output_dir, should_stop=stop_event.is_set
+        )
     except (FileNotFoundError, ValueError) as exc:
         # A pre-flight staging error (missing input mount, duplicate scan_key,
         # malformed run_manifest.json, or zero scans discovered — the latter two
@@ -59,6 +87,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         # exception code (1), identical to any other crash.
         logging.getLogger(__name__).error("Batch aborted: %s", exc)
         raise
+
+    if stop_event.is_set():
+        logging.getLogger(__name__).warning(
+            "Terminated by SIGTERM after a partial batch"
+        )
+        return 143
 
     n_ok = sum(1 for s in result.scans if s.status == "ok")
     n_skip = sum(1 for s in result.scans if s.status == "skipped")

--- a/sleap_roots_predict/__main__.py
+++ b/sleap_roots_predict/__main__.py
@@ -46,9 +46,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         argv: Optional argument vector (defaults to ``sys.argv[1:]``).
 
     Returns:
-        ``0`` on success, ``3`` on a partial batch (isolated scan failures). A
-        pre-flight staging error or other crash propagates uncaught, surfacing
-        Python's default exit ``1`` (see the module docstring).
+        ``0`` on success, ``3`` on a partial batch (isolated scan failures), or
+        ``143`` if terminated by ``SIGTERM``. A pre-flight staging error or other
+        crash propagates uncaught, surfacing Python's default exit ``1`` (see the
+        module docstring).
     """
     parser = argparse.ArgumentParser(
         prog="sleap_roots_predict",

--- a/sleap_roots_predict/__main__.py
+++ b/sleap_roots_predict/__main__.py
@@ -74,34 +74,41 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Lazy import: `--help` exits inside parse_args above, so it never pulls in torch.
     from sleap_roots_predict.batch import run_batch
 
+    prev_sigterm_handler = signal.getsignal(signal.SIGTERM)
     stop_event = _install_sigterm_handler()
-
     try:
-        result = run_batch(
-            args.input_dir, args.output_dir, should_stop=stop_event.is_set
-        )
-    except (FileNotFoundError, ValueError) as exc:
-        # A pre-flight staging error (missing input mount, duplicate scan_key,
-        # malformed run_manifest.json, or zero scans discovered — the latter two
-        # also raise ValueError, so they land here too). Log a clean message, then
-        # re-raise so the process still exits via Python's default unhandled-
-        # exception code (1), identical to any other crash.
-        logging.getLogger(__name__).error("Batch aborted: %s", exc)
-        raise
+        try:
+            result = run_batch(
+                args.input_dir, args.output_dir, should_stop=stop_event.is_set
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            # A pre-flight staging error (missing input mount, duplicate scan_key,
+            # malformed run_manifest.json, or zero scans discovered — the latter two
+            # also raise ValueError, so they land here too). Log a clean message,
+            # then re-raise so the process still exits via Python's default
+            # unhandled-exception code (1), identical to any other crash.
+            logging.getLogger(__name__).error("Batch aborted: %s", exc)
+            raise
 
-    if stop_event.is_set():
-        logging.getLogger(__name__).warning(
-            "Terminated by SIGTERM after a partial batch"
-        )
-        return 143
+        if stop_event.is_set():
+            logging.getLogger(__name__).warning(
+                "Terminated by SIGTERM after a partial batch"
+            )
+            return 143
 
-    n_ok = sum(1 for s in result.scans if s.status == "ok")
-    n_skip = sum(1 for s in result.scans if s.status == "skipped")
-    n_fail = sum(1 for s in result.scans if s.status == "failed")
-    logging.getLogger(__name__).info(
-        "Batch complete: %d ok, %d skipped, %d failed", n_ok, n_skip, n_fail
-    )
-    return 0 if result.ok else 3
+        n_ok = sum(1 for s in result.scans if s.status == "ok")
+        n_skip = sum(1 for s in result.scans if s.status == "skipped")
+        n_fail = sum(1 for s in result.scans if s.status == "failed")
+        logging.getLogger(__name__).info(
+            "Batch complete: %d ok, %d skipped, %d failed", n_ok, n_skip, n_fail
+        )
+        return 0 if result.ok else 3
+    finally:
+        # Restore whatever handler was registered before this call, on every exit
+        # path (return or raise) -- a real single-shot CLI invocation is about to
+        # terminate anyway, but leaving the handler installed is a hazard for any
+        # longer-lived process embedding main() (and a real test-isolation risk).
+        signal.signal(signal.SIGTERM, prev_sigterm_handler)
 
 
 if __name__ == "__main__":

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -279,7 +279,8 @@ def run_batch(
     (no new storage — see :func:`_previous_identity_key`); an exact match skips,
     anything else (including no previous artifacts at all) predicts and overwrites.
     A per-scan error is isolated (recorded ``failed``, batch continues). An empty
-    (but present) input directory is a no-op.
+    (but present) input directory is a batch-level staging error (raises), not a
+    no-op — a misconfigured or empty stage-in mount should never look like success.
 
     Args:
         input_dir: Directory of staged scans.
@@ -293,16 +294,16 @@ def run_batch(
 
     Raises:
         FileNotFoundError: If ``input_dir`` does not exist.
-        ValueError: If two sidecars share a ``scan_key`` (a batch-level staging error,
-            surfaced before any prediction).
+        ValueError: If two sidecars share a ``scan_key``, or if zero scans are
+            discovered under a present ``input_dir`` (both batch-level staging
+            errors, surfaced before any prediction or model-source interaction).
     """
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
     scans = discover_scans(input_dir)
-    result = BatchResult()
     if not scans:
-        logger.warning("No scans discovered under %s", input_dir.as_posix())
-        return result
+        raise ValueError(f"no scans discovered under {input_dir.as_posix()}")
+    result = BatchResult()
 
     resolved_code_sha = resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA")
     worker = WarmModelWorker(source=source)

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -388,8 +388,12 @@ def _predict_one(
     # partially-written sidecar.
     sidecar_dst = out_scan_dir / f"{scan.scan_key}{_SIDECAR_SUFFIX}"
     tmp_sidecar_dst = sidecar_dst.with_name(sidecar_dst.name + ".tmp")
-    shutil.copyfile(scan.sidecar_path, tmp_sidecar_dst)
-    os.replace(tmp_sidecar_dst, sidecar_dst)
+    try:
+        shutil.copyfile(scan.sidecar_path, tmp_sidecar_dst)
+        os.replace(tmp_sidecar_dst, sidecar_dst)
+    except Exception:
+        tmp_sidecar_dst.unlink(missing_ok=True)
+        raise
     write_prediction_outputs(
         labels,
         refs,

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -9,6 +9,7 @@ writes the prediction-output artifacts, and copies the sidecar through so each
 
 import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -369,10 +370,13 @@ def _predict_one(
     # Copy the sidecar BEFORE the manifest: write_prediction_outputs writes the manifest
     # last as the resume commit-marker, so the sidecar must already be present when it
     # lands — else a crash in between leaves a manifest with no sidecar that resume skips
-    # forever and the trait-extractor then rejects (an incomplete input tree).
-    shutil.copyfile(
-        scan.sidecar_path, out_scan_dir / f"{scan.scan_key}{_SIDECAR_SUFFIX}"
-    )
+    # forever and the trait-extractor then rejects (an incomplete input tree). The copy
+    # itself is atomic (temp file + os.replace), so no reader ever observes a
+    # partially-written sidecar.
+    sidecar_dst = out_scan_dir / f"{scan.scan_key}{_SIDECAR_SUFFIX}"
+    tmp_sidecar_dst = sidecar_dst.with_name(sidecar_dst.name + ".tmp")
+    shutil.copyfile(scan.sidecar_path, tmp_sidecar_dst)
+    os.replace(tmp_sidecar_dst, sidecar_dst)
     write_prediction_outputs(
         labels,
         refs,

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -269,6 +270,7 @@ def run_batch(
     source: ModelCardSource | None = None,
     predict_code_sha: str | None = None,
     predict_container_digest: str | None = None,
+    should_stop: Callable[[], bool] = lambda: False,
 ) -> BatchResult:
     """Predict every scan under ``input_dir``, writing outputs under ``output_dir``.
 
@@ -289,6 +291,10 @@ def run_batch(
         source: Model-card source; ``None`` uses the production WandbRegistrySource.
         predict_code_sha: Provenance sha (falls back to ``SRP_PREDICT_CODE_SHA``).
         predict_container_digest: Provenance digest (env fallback).
+        should_stop: Checked at the top of each per-scan loop iteration; when it
+            returns ``True`` the batch stops before starting the next scan (never
+            interrupting a scan already in progress). Defaults to a no-op, so
+            existing callers are unaffected.
 
     Returns:
         A :class:`BatchResult` with one :class:`ScanResult` per scan.
@@ -309,6 +315,13 @@ def run_batch(
     resolved_code_sha = resolve_identity(predict_code_sha, "SRP_PREDICT_CODE_SHA")
     worker = WarmModelWorker(source=source)
     for scan in scans:
+        if should_stop():
+            logger.warning(
+                "Stopping early: requested after %d/%d scans",
+                len(result.scans),
+                len(scans),
+            )
+            break
         if scan.error is not None:
             logger.error("Scan %s failed: %s", scan.scan_key, scan.error)
             result.scans.append(ScanResult(scan.scan_key, "failed", scan.error))

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -141,9 +141,14 @@ def write_prediction_outputs(
     filename convention; loaded downstream via ``Series.load`` with the manifest's
     explicit paths) and then a single combined ``{scan_key}.predictions.json``
     serializing a :class:`PredictionManifest`. Re-running for the same ``scan_key``
-    into the same ``out_dir`` overwrites the prior outputs in place, first removing
-    any stale ``.slp`` for that scan (so a changed model slug does not orphan files).
-    Path strings are emitted via ``Path.as_posix()``. Does not import ``sleap-roots``.
+    into the same ``out_dir`` overwrites the prior outputs in place; any stale
+    ``.slp`` for that scan (from a changed model slug) is removed only once every
+    new ``.slp`` and the manifest have been written successfully, so a failed
+    write never deletes a still-valid prior artifact. Each ``.slp`` and the
+    manifest are written atomically (temp file in the same directory, then
+    ``os.replace``), so no reader ever observes a partially-written file; the
+    manifest is written last, after every ``.slp``'s write completes. Path
+    strings are emitted via ``Path.as_posix()``. Does not import ``sleap-roots``.
 
     Args:
         labels_by_root: Predicted ``sio.Labels`` per root type (from the worker's
@@ -177,29 +182,27 @@ def write_prediction_outputs(
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    # Idempotent re-run: remove this scan's prior `.slp` artifacts first. Their
-    # filenames embed the model slug, so a model/version/override change would
-    # otherwise orphan the old files (unreferenced by the new manifest, yet matched
-    # by glob-based consumers). Scoped by the validated (separator-free) scan_key
-    # prefix, so other scans in the same directory are untouched.
-    slp_prefix = f"{scan_key}.model"
-    for stale in list(out.iterdir()):
-        if stale.name.startswith(slp_prefix) and stale.name.endswith(".slp"):
-            stale.unlink()
-
     artifacts: list[PredictionArtifact] = []
+    written_filenames: set[str] = set()
     for root_type in sorted(refs_by_root):
         ref = refs_by_root[root_type]
         slug = slugify_model_id(ref)
         filename = f"{scan_key}.model{slug}.root{root_type}.slp"
+        written_filenames.add(filename)
         slp_path = out / filename
         tmp_slp_path = slp_path.with_name(slp_path.name + ".tmp")
-        # format="slp" is passed explicitly rather than relied upon via the temp
-        # filename's extension: sio.save_file infers format from the filename when
-        # format is omitted, and the ".tmp"-suffixed temp name no longer ends in
-        # ".slp".
-        sio.save_file(labels_by_root[root_type], tmp_slp_path.as_posix(), format="slp")
-        os.replace(tmp_slp_path, slp_path)
+        try:
+            # format="slp" is passed explicitly rather than relied upon via the temp
+            # filename's extension: sio.save_file infers format from the filename
+            # when format is omitted, and the ".tmp"-suffixed temp name no longer
+            # ends in ".slp".
+            sio.save_file(
+                labels_by_root[root_type], tmp_slp_path.as_posix(), format="slp"
+            )
+            os.replace(tmp_slp_path, slp_path)
+        except Exception:
+            tmp_slp_path.unlink(missing_ok=True)
+            raise
         data = slp_path.read_bytes()
         artifacts.append(
             PredictionArtifact(
@@ -211,6 +214,24 @@ def write_prediction_outputs(
                 file_size=len(data),
             )
         )
+
+    # Idempotent re-run: remove this scan's now-superseded `.slp` artifacts only
+    # after every new one above has been written successfully. Their filenames
+    # embed the model slug, so a model/version/override change would otherwise
+    # orphan the old files (unreferenced by the new manifest, yet matched by
+    # glob-based consumers) -- but running this sweep *before* the new writes (as
+    # earlier code did) could delete a prior run's still-valid artifacts before
+    # their replacements were confirmed written, if a later root type's write then
+    # failed. Scoped by the validated (separator-free) scan_key prefix, so other
+    # scans in the same directory are untouched.
+    slp_prefix = f"{scan_key}.model"
+    for stale in list(out.iterdir()):
+        if (
+            stale.name.startswith(slp_prefix)
+            and stale.name.endswith(".slp")
+            and stale.name not in written_filenames
+        ):
+            stale.unlink()
 
     manifest = PredictionManifest(
         scan_key=scan_key,
@@ -227,8 +248,14 @@ def write_prediction_outputs(
     # established role as the resume commit-marker.
     manifest_path = predictions_json_path(out, scan_key)
     tmp_manifest_path = manifest_path.with_name(manifest_path.name + ".tmp")
-    tmp_manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
-    os.replace(tmp_manifest_path, manifest_path)
+    try:
+        tmp_manifest_path.write_text(
+            manifest.model_dump_json(indent=2), encoding="utf-8"
+        )
+        os.replace(tmp_manifest_path, manifest_path)
+    except Exception:
+        tmp_manifest_path.unlink(missing_ok=True)
+        raise
     return manifest
 
 
@@ -266,7 +293,8 @@ def predict_and_write_batch(
 
     The worker's resident ``Predictor``s are reused across scans (models loaded
     once), so a batch amortizes model-load cost. Each scan is written into
-    ``out_dir/{scan_key}/`` via :func:`write_prediction_outputs`.
+    ``out_dir/{scan_key}/`` via :func:`write_prediction_outputs` (atomic writes;
+    see that function's docstring).
 
     Args:
         worker: A ``WarmModelWorker`` kept resident across the batch.

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -193,7 +193,13 @@ def write_prediction_outputs(
         slug = slugify_model_id(ref)
         filename = f"{scan_key}.model{slug}.root{root_type}.slp"
         slp_path = out / filename
-        sio.save_file(labels_by_root[root_type], slp_path.as_posix())
+        tmp_slp_path = slp_path.with_name(slp_path.name + ".tmp")
+        # format="slp" is passed explicitly rather than relied upon via the temp
+        # filename's extension: sio.save_file infers format from the filename when
+        # format is omitted, and the ".tmp"-suffixed temp name no longer ends in
+        # ".slp".
+        sio.save_file(labels_by_root[root_type], tmp_slp_path.as_posix(), format="slp")
+        os.replace(tmp_slp_path, slp_path)
         data = slp_path.read_bytes()
         artifacts.append(
             PredictionArtifact(
@@ -217,9 +223,12 @@ def write_prediction_outputs(
             predict_container_digest, "SRP_PREDICT_CONTAINER_DIGEST"
         ),
     )
-    predictions_json_path(out, scan_key).write_text(
-        manifest.model_dump_json(indent=2), encoding="utf-8"
-    )
+    # Written last (after every .slp's atomic write completes), preserving its
+    # established role as the resume commit-marker.
+    manifest_path = predictions_json_path(out, scan_key)
+    tmp_manifest_path = manifest_path.with_name(manifest_path.name + ".tmp")
+    tmp_manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    os.replace(tmp_manifest_path, manifest_path)
     return manifest
 
 

--- a/sleap_roots_predict/output_contract.py
+++ b/sleap_roots_predict/output_contract.py
@@ -215,24 +215,6 @@ def write_prediction_outputs(
             )
         )
 
-    # Idempotent re-run: remove this scan's now-superseded `.slp` artifacts only
-    # after every new one above has been written successfully. Their filenames
-    # embed the model slug, so a model/version/override change would otherwise
-    # orphan the old files (unreferenced by the new manifest, yet matched by
-    # glob-based consumers) -- but running this sweep *before* the new writes (as
-    # earlier code did) could delete a prior run's still-valid artifacts before
-    # their replacements were confirmed written, if a later root type's write then
-    # failed. Scoped by the validated (separator-free) scan_key prefix, so other
-    # scans in the same directory are untouched.
-    slp_prefix = f"{scan_key}.model"
-    for stale in list(out.iterdir()):
-        if (
-            stale.name.startswith(slp_prefix)
-            and stale.name.endswith(".slp")
-            and stale.name not in written_filenames
-        ):
-            stale.unlink()
-
     manifest = PredictionManifest(
         scan_key=scan_key,
         plant_qr_code=plant_qr_code or scan_key,
@@ -244,8 +226,11 @@ def write_prediction_outputs(
             predict_container_digest, "SRP_PREDICT_CONTAINER_DIGEST"
         ),
     )
-    # Written last (after every .slp's atomic write completes), preserving its
-    # established role as the resume commit-marker.
+    # Written after every .slp's atomic write completes but *before* the stale-.slp
+    # sweep below, preserving its established role as the resume commit-marker: once
+    # this succeeds, the manifest is already correct and complete on its own, so a
+    # failure in the purely-cosmetic sweep that follows can never leave a
+    # still-current manifest referencing artifacts the sweep only partially deleted.
     manifest_path = predictions_json_path(out, scan_key)
     tmp_manifest_path = manifest_path.with_name(manifest_path.name + ".tmp")
     try:
@@ -256,6 +241,27 @@ def write_prediction_outputs(
     except Exception:
         tmp_manifest_path.unlink(missing_ok=True)
         raise
+
+    # Idempotent re-run: remove this scan's now-superseded `.slp` artifacts only
+    # after the manifest above is already committed. Their filenames embed the
+    # model slug, so a model/version/override change would otherwise orphan the old
+    # files (unreferenced by the new manifest, yet matched by glob-based consumers)
+    # -- but running this sweep any earlier (before every new write, or even before
+    # the manifest) risks a partial failure here or in a later write leaving a
+    # still-current manifest that references a mix of deleted and non-deleted
+    # files. With the manifest already correct at this point, a sweep failure is
+    # inert disk clutter, not a correctness hazard. Scoped by the validated
+    # (separator-free) scan_key prefix, so other scans in the same directory are
+    # untouched.
+    slp_prefix = f"{scan_key}.model"
+    for stale in list(out.iterdir()):
+        if (
+            stale.name.startswith(slp_prefix)
+            and stale.name.endswith(".slp")
+            and stale.name not in written_filenames
+        ):
+            stale.unlink()
+
     return manifest
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -330,7 +330,15 @@ def test_cli_main_exit_codes(scan_input_dir: Path, tmp_path: Path, monkeypatch):
     state["ok"] = True
     assert main([str(scan_input_dir), str(tmp_path / "o1")]) == 0
     state["ok"] = False
-    assert main([str(scan_input_dir), str(tmp_path / "o2")]) == 1
+    assert main([str(scan_input_dir), str(tmp_path / "o2")]) == 3
+
+
+def test_cli_usage_error_exits_2_via_argparse():
+    from sleap_roots_predict.__main__ import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main([])  # missing both required positional arguments
+    assert exc_info.value.code == 2
 
 
 @pytest.mark.wandb
@@ -372,12 +380,25 @@ def test_missing_input_dir_raises(tmp_path):
         run_batch(tmp_path / "does_not_exist", tmp_path / "out")
 
 
-def test_cli_missing_input_dir_returns_nonzero(tmp_path):
+def test_cli_missing_input_dir_propagates_as_default_exit_1(tmp_path, caplog):
     from sleap_roots_predict.__main__ import main
 
-    # discover_scans raises FileNotFoundError before the worker is built (no network),
-    # and main converts it to a clean non-zero exit.
-    assert main([str(tmp_path / "nope"), str(tmp_path / "out")]) == 2
+    # discover_scans raises FileNotFoundError before the worker is built (no
+    # network); main logs a clean message then re-raises, so the process exits via
+    # Python's default unhandled-exception code (1), not a special-cased return.
+    with caplog.at_level("ERROR"):
+        with pytest.raises(FileNotFoundError):
+            main([str(tmp_path / "nope"), str(tmp_path / "out")])
+    assert any("Batch aborted" in r.message for r in caplog.records)
+
+
+def test_cli_empty_input_propagates_as_default_exit_1(tmp_path):
+    from sleap_roots_predict.__main__ import main
+
+    empty = tmp_path / "empty_in"
+    empty.mkdir()
+    with pytest.raises(ValueError, match="no scans discovered"):
+        main([str(empty), str(tmp_path / "out")])
 
 
 def test_sidecar_copy_failure_leaves_no_manifest(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -418,6 +418,22 @@ def test_sidecar_copy_failure_leaves_no_manifest(
     assert not (out / "scanCPTEST0" / "scanCPTEST0.predictions.json").exists()
 
 
+def test_sidecar_copy_leaves_no_partial_file_if_replace_fails(
+    scan_input_dir: Path, all_roots_source, tmp_path: Path, monkeypatch
+):
+    # batch.py has no local `os` reference to patch (unlike output_contract.py),
+    # so patch the global `os.replace` rather than a module attribute.
+    monkeypatch.setattr(
+        "os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("simulated interruption")),
+    )
+    out = tmp_path / "out"
+    result = run_batch(scan_input_dir, out, source=all_roots_source)
+    assert [s.status for s in result.scans] == ["failed"]
+    assert not (out / "scanCPTEST0" / "scanCPTEST0.scan_metadata.json").exists()
+    assert not (out / "scanCPTEST0" / "scanCPTEST0.predictions.json").exists()
+
+
 def test_unreadable_json_sidecar_is_error(tmp_path: Path):
     d = tmp_path / "scanBad"
     d.mkdir()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -323,7 +323,7 @@ def test_cli_main_exit_codes(scan_input_dir: Path, tmp_path: Path, monkeypatch):
 
     state = {"ok": True}
 
-    def fake_run_batch(inp, out):
+    def fake_run_batch(inp, out, **kwargs):
         return _Res(state["ok"])
 
     monkeypatch.setattr("sleap_roots_predict.batch.run_batch", fake_run_batch)
@@ -339,6 +339,89 @@ def test_cli_usage_error_exits_2_via_argparse():
     with pytest.raises(SystemExit) as exc_info:
         main([])  # missing both required positional arguments
     assert exc_info.value.code == 2
+
+
+def test_install_sigterm_handler_sets_event_when_invoked():
+    import signal
+
+    from sleap_roots_predict.__main__ import _install_sigterm_handler
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        event = _install_sigterm_handler()
+        assert not event.is_set()
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+        assert event.is_set()
+    finally:
+        signal.signal(signal.SIGTERM, prev_handler)
+
+
+def test_sigterm_overrides_success_exit_code(
+    scan_input_dir: Path, all_roots_source, tmp_path: Path, monkeypatch
+):
+    import signal
+
+    import sleap_roots_predict.batch as batch_mod
+    from sleap_roots_predict.__main__ import main
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        real_run_batch = batch_mod.run_batch
+
+        def _run_then_signal(*args, **kwargs):
+            # Delegating spy: run the real batch, then trigger the SIGTERM handler
+            # main() already installed, strictly between run_batch returning and
+            # main()'s post-run_batch check -- mirrors this file's existing
+            # spy_resolve/_Counting(orig) wrap-and-delegate pattern. `source` is
+            # injected so this hits the offline test fixture, not the live registry.
+            kwargs.setdefault("source", all_roots_source)
+            result = real_run_batch(*args, **kwargs)
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+            return result
+
+        monkeypatch.setattr(batch_mod, "run_batch", _run_then_signal)
+        assert main([str(scan_input_dir), str(tmp_path / "out")]) == 143
+    finally:
+        signal.signal(signal.SIGTERM, prev_handler)
+
+
+def test_sigterm_overrides_partial_exit_code(
+    all_roots_source, tmp_path: Path, monkeypatch
+):
+    import signal
+
+    import sleap_roots_predict.batch as batch_mod
+    from sleap_roots_predict.__main__ import main
+
+    inp = tmp_path / "in"
+    _real_scan(inp, "scanGOOD", _RICE)
+    bad = inp / "scanBAD"
+    bad.mkdir()
+    (bad / "scanBAD.scan_metadata.json").write_text(
+        json.dumps(
+            {
+                "scan_key": "scanBAD",
+                "image_ids": ["a"],
+                "images_checksum": "sha256:x",
+                "params": _RICE,
+            }
+        )
+    )
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        real_run_batch = batch_mod.run_batch
+
+        def _run_then_signal(*args, **kwargs):
+            kwargs.setdefault("source", all_roots_source)
+            result = real_run_batch(*args, **kwargs)
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+            return result
+
+        monkeypatch.setattr(batch_mod, "run_batch", _run_then_signal)
+        assert main([str(inp), str(tmp_path / "out")]) == 143
+    finally:
+        signal.signal(signal.SIGTERM, prev_handler)
 
 
 @pytest.mark.wandb

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from sleap_roots_predict.batch import BatchResult, discover_scans, run_batch
+from sleap_roots_predict.batch import discover_scans, run_batch
 
 
 def _write_scan(root: Path, scan_key: str, params, *, stem=None, extra_files=()):
@@ -511,6 +511,22 @@ def test_cli_empty_input_propagates_as_default_exit_1(tmp_path):
         main([str(empty), str(tmp_path / "out")])
 
 
+def test_main_restores_prior_sigterm_handler_on_staging_error(tmp_path):
+    # main() installs its own SIGTERM handler before running the batch; a staging
+    # error (re-raised, not returned) must not leave that handler installed --
+    # otherwise a real SIGTERM to whatever process later calls main() again (or
+    # to the pytest process itself) is silently swallowed by an orphaned handler
+    # closing over a dead threading.Event nobody reads.
+    import signal
+
+    from sleap_roots_predict.__main__ import main
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    with pytest.raises(FileNotFoundError):
+        main([str(tmp_path / "nope"), str(tmp_path / "out")])
+    assert signal.getsignal(signal.SIGTERM) is prev_handler
+
+
 def test_sidecar_copy_failure_leaves_no_manifest(
     scan_input_dir: Path, all_roots_source, tmp_path: Path, monkeypatch
 ):
@@ -542,6 +558,7 @@ def test_sidecar_copy_leaves_no_partial_file_if_replace_fails(
     assert [s.status for s in result.scans] == ["failed"]
     assert not (out / "scanCPTEST0" / "scanCPTEST0.scan_metadata.json").exists()
     assert not (out / "scanCPTEST0" / "scanCPTEST0.predictions.json").exists()
+    assert not list((out / "scanCPTEST0").glob("*.tmp"))  # temp copy is cleaned up
 
 
 def test_unreadable_json_sidecar_is_error(tmp_path: Path):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -287,12 +287,30 @@ def test_zero_resolved_models_is_failed(rice_source, tmp_path: Path):
     assert not (out / "scanZ" / "scanZ.predictions.json").exists()
 
 
-def test_empty_input_is_noop(tmp_path: Path):
+def test_empty_input_raises(tmp_path: Path):
     empty = tmp_path / "empty_in"
     empty.mkdir()
-    result = run_batch(empty, tmp_path / "out")
-    assert isinstance(result, BatchResult)
-    assert result.ok and result.scans == []
+    with pytest.raises(ValueError, match="no scans discovered"):
+        run_batch(empty, tmp_path / "out")
+
+
+def test_empty_input_raises_before_worker_interaction(tmp_path: Path):
+    calls = {"n": 0}
+
+    class _RecordingSource:
+        def list_cards(self):
+            calls["n"] += 1
+            return []
+
+        def materialize(self, ref):
+            calls["n"] += 1
+            raise AssertionError("materialize should never be called")
+
+    empty = tmp_path / "empty_in"
+    empty.mkdir()
+    with pytest.raises(ValueError):
+        run_batch(empty, tmp_path / "out", source=_RecordingSource())
+    assert calls["n"] == 0
 
 
 def test_cli_main_exit_codes(scan_input_dir: Path, tmp_path: Path, monkeypatch):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -375,6 +375,33 @@ def test_run_batch_constructs_single_worker(all_roots_source, tmp_path, monkeypa
     assert counter["n"] == 1  # one resident worker for the whole batch
 
 
+def test_should_stop_stops_after_first_scan(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "s1", _RICE)
+    _real_scan(inp, "s2", _RICE)
+    out = tmp_path / "out"
+    calls = {"n": 0}
+
+    def _stop():
+        calls["n"] += 1
+        return calls["n"] > 1  # False the first time (before s1), True thereafter
+
+    result = run_batch(inp, out, source=all_roots_source, should_stop=_stop)
+    assert [s.scan_key for s in result.scans] == ["s1"]
+    assert result.scans[0].status == "ok"
+    assert (out / "s1" / "s1.predictions.json").exists()
+    assert list((out / "s1").glob("*.slp"))
+    assert not (out / "s2").exists()
+
+
+def test_should_stop_default_is_unaffected(all_roots_source, tmp_path: Path):
+    inp = tmp_path / "in"
+    _real_scan(inp, "s1", _RICE)
+    _real_scan(inp, "s2", _RICE)
+    result = run_batch(inp, tmp_path / "out", source=all_roots_source)
+    assert [s.status for s in result.scans] == ["ok", "ok"]
+
+
 def test_missing_input_dir_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         run_batch(tmp_path / "does_not_exist", tmp_path / "out")

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -361,6 +361,120 @@ def test_writer_does_not_import_sleap_roots():
     assert result.returncode == 0, result.stderr
 
 
+# --- Task 3 (predict #26): atomic .slp/manifest writes -----------------------
+
+
+def test_slp_write_passes_format_explicitly(rice_source, video, tmp_path, monkeypatch):
+    """The .slp temp write passes format="slp" rather than relying on the
+    temp filename's extension (sio.save_file otherwise infers format from it)."""
+    import sleap_roots_predict.output_contract as oc_mod
+
+    worker = WarmModelWorker(rice_source)
+    real_save_file = oc_mod.sio.save_file
+    formats_seen = []
+
+    def _spy(labels_obj, path, **kwargs):
+        formats_seen.append(kwargs.get("format"))
+        return real_save_file(labels_obj, path, **kwargs)
+
+    monkeypatch.setattr(oc_mod.sio, "save_file", _spy)
+    write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    assert formats_seen  # at least one .slp was written
+    assert all(fmt == "slp" for fmt in formats_seen)
+
+
+def test_slp_write_leaves_no_partial_file_if_replace_fails(
+    rice_source, video, tmp_path, monkeypatch
+):
+    """An interrupted .slp write leaves no file at the final path."""
+    import sleap_roots_predict.output_contract as oc_mod
+
+    worker = WarmModelWorker(rice_source)
+    monkeypatch.setattr(
+        oc_mod.os,
+        "replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("simulated interruption")),
+    )
+    with pytest.raises(OSError):
+        write_prediction_outputs(
+            worker.predict(_params(), video),
+            worker.resolve(_params()),
+            tmp_path,
+            scan_key="scan0731",
+            inference_config=worker.inference_config(),
+            output_params=worker.output_params(),
+        )
+    assert not list(tmp_path.glob("*.slp"))
+
+
+def test_manifest_write_leaves_no_partial_file_if_replace_fails(
+    rice_source, video, tmp_path, monkeypatch
+):
+    """An interrupted manifest write leaves no manifest at the final path, but
+    the already-succeeded .slp writes are unaffected."""
+    import sleap_roots_predict.output_contract as oc_mod
+
+    worker = WarmModelWorker(rice_source)
+    real_replace = oc_mod.os.replace
+
+    def _replace(src, dst):
+        if str(dst).endswith(".predictions.json"):
+            raise OSError("simulated interruption")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(oc_mod.os, "replace", _replace)
+    with pytest.raises(OSError):
+        write_prediction_outputs(
+            worker.predict(_params(), video),
+            worker.resolve(_params()),
+            tmp_path,
+            scan_key="scan0731",
+            inference_config=worker.inference_config(),
+            output_params=worker.output_params(),
+        )
+    assert not (tmp_path / "scan0731.predictions.json").exists()
+    assert list(tmp_path.glob("*.rootprimary.slp"))
+    assert list(tmp_path.glob("*.rootlateral.slp"))
+
+
+def test_manifest_replace_happens_after_all_slp_replaces(
+    rice_source, video, tmp_path, monkeypatch
+):
+    """The manifest's atomic write completes only after every .slp's does."""
+    import sleap_roots_predict.output_contract as oc_mod
+
+    worker = WarmModelWorker(rice_source)
+    real_replace = oc_mod.os.replace
+    call_order = []
+
+    def _replace(src, dst):
+        call_order.append(str(dst))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(oc_mod.os, "replace", _replace)
+    write_prediction_outputs(
+        worker.predict(_params(), video),
+        worker.resolve(_params()),
+        tmp_path,
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    manifest_calls = [
+        i for i, p in enumerate(call_order) if p.endswith(".predictions.json")
+    ]
+    assert len(manifest_calls) == 1
+    assert manifest_calls[0] == len(call_order) - 1  # last call
+    assert manifest_calls[0] > 0  # at least one .slp replace happened first
+
+
 # --- Task 5: fail-soft build identity ---------------------------------------
 
 

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -374,6 +374,53 @@ def test_failed_write_does_not_delete_prior_valid_artifacts(
     assert (tmp_path / "scan0731.predictions.json").read_text() == old_manifest_text
 
 
+def test_stale_sweep_failure_does_not_leave_manifest_pointing_at_deleted_files(
+    rice_source, video, tmp_path, monkeypatch
+):
+    """The manifest is committed *before* the stale-.slp sweep runs, so if the
+    sweep itself fails partway (e.g. a locked file), the already-current
+    manifest still correctly references only this run's own artifacts -- the
+    sweep is purely best-effort cleanup once the manifest is correct, never a
+    step the manifest's correctness depends on."""
+    worker = WarmModelWorker(rice_source)
+    kwargs = dict(
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    write_prediction_outputs(
+        worker.predict(_params(), video), worker.resolve(_params()), tmp_path, **kwargs
+    )
+
+    override = {
+        "primary": ModelRef(
+            registry_id="reg/rice-lateral",
+            version="v1",
+            sleap_nn_version="0.3.0",
+            root_type="primary",
+        )
+    }
+
+    def _boom_unlink(self, *a, **k):
+        raise OSError("simulated interruption")
+
+    monkeypatch.setattr(Path, "unlink", _boom_unlink)
+    with pytest.raises(OSError):
+        write_prediction_outputs(
+            worker.predict(_params(), video, overrides=override),
+            worker.resolve(_params(), override),
+            tmp_path,
+            **kwargs,
+        )
+
+    manifest = PredictionManifest.model_validate_json(
+        (tmp_path / "scan0731.predictions.json").read_text()
+    )
+    primary_art = next(a for a in manifest.artifacts if a.root_type == "primary")
+    assert primary_art.model.registry_id == "reg/rice-lateral"
+    assert (tmp_path / primary_art.slp_path).exists()
+
+
 def test_manifest_records_worker_provenance(rice_source, video, tmp_path):
     """The writer stores the worker's inference config + output params verbatim."""
     worker = WarmModelWorker(rice_source, peak_threshold=0.15)

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -319,6 +319,61 @@ def test_rerun_with_changed_model_prunes_stale_slp(rice_source, video, tmp_path)
     assert len(list(tmp_path.glob("*.rootprimary.slp"))) == 1
 
 
+def test_failed_write_does_not_delete_prior_valid_artifacts(
+    rice_source, video, tmp_path, monkeypatch
+):
+    """If a later .slp write fails, the prior run's still-valid artifacts (which
+    a changed model ref would otherwise mark stale) are left untouched -- the
+    old files must not be deleted before every new one is confirmed written."""
+    import sleap_roots_predict.output_contract as oc_mod
+
+    worker = WarmModelWorker(rice_source)
+    kwargs = dict(
+        scan_key="scan0731",
+        inference_config=worker.inference_config(),
+        output_params=worker.output_params(),
+    )
+    # Run 1: succeeds fully.
+    write_prediction_outputs(
+        worker.predict(_params(), video), worker.resolve(_params()), tmp_path, **kwargs
+    )
+    old_primary_slp = next(tmp_path.glob("*.rootprimary.slp"))
+    old_manifest_text = (tmp_path / "scan0731.predictions.json").read_text()
+
+    # Run 2: primary now resolves to a different model (a new slug, so it would
+    # supersede and mark the old primary .slp stale), but the lateral write is
+    # interrupted before this run can complete.
+    override = {
+        "primary": ModelRef(
+            registry_id="reg/rice-lateral",
+            version="v1",
+            sleap_nn_version="0.3.0",
+            root_type="primary",
+        )
+    }
+    real_save_file = oc_mod.sio.save_file
+
+    def _boom_on_lateral(labels_obj, path, **kw):
+        if "rootlateral" in str(path):
+            raise OSError("simulated interruption")
+        return real_save_file(labels_obj, path, **kw)
+
+    monkeypatch.setattr(oc_mod.sio, "save_file", _boom_on_lateral)
+    with pytest.raises(OSError):
+        write_prediction_outputs(
+            worker.predict(_params(), video, overrides=override),
+            worker.resolve(_params(), override),
+            tmp_path,
+            **kwargs,
+        )
+
+    # Run 1's artifacts are untouched -- nothing was deleted before run 2's new
+    # writes were confirmed complete, so a resumed batch still sees a fully
+    # valid, internally-consistent (manifest, .slp) pair from run 1.
+    assert old_primary_slp.exists()
+    assert (tmp_path / "scan0731.predictions.json").read_text() == old_manifest_text
+
+
 def test_manifest_records_worker_provenance(rice_source, video, tmp_path):
     """The writer stores the worker's inference config + output params verbatim."""
     worker = WarmModelWorker(rice_source, peak_threshold=0.15)
@@ -412,6 +467,9 @@ def test_slp_write_leaves_no_partial_file_if_replace_fails(
             output_params=worker.output_params(),
         )
     assert not list(tmp_path.glob("*.slp"))
+    assert not list(
+        tmp_path.glob("*.tmp")
+    )  # the failed write's temp file is cleaned up
 
 
 def test_manifest_write_leaves_no_partial_file_if_replace_fails(
@@ -442,6 +500,9 @@ def test_manifest_write_leaves_no_partial_file_if_replace_fails(
     assert not (tmp_path / "scan0731.predictions.json").exists()
     assert list(tmp_path.glob("*.rootprimary.slp"))
     assert list(tmp_path.glob("*.rootlateral.slp"))
+    assert not list(
+        tmp_path.glob("*.tmp")
+    )  # the failed manifest write's temp file is gone
 
 
 def test_manifest_replace_happens_after_all_slp_replaces(


### PR DESCRIPTION
## Summary

Hardens the predict batch driver (`sleap_roots_predict/batch.py` + `__main__.py` + `output_contract.py`) for Argo/Kubernetes deployment: a new exit-code scheme that distinguishes isolated scan failures from real crashes, an empty-input guard, atomic writes, and a `SIGTERM` handler for graceful preemption.

## Changes

- **Exit codes**: `0`=success, `3`=partial (new — isolated scan failure(s), batch otherwise completed), Python's default `1`=every other failure (staging error or crash), `143`=terminated by `SIGTERM`. `2` is reserved for `argparse`'s own usage-error exit and is never returned by the driver's own logic.
- **Empty-input guard**: a present-but-empty input directory (or a `run_manifest.json` scoping discovery to zero `scan_keys`) now raises instead of silently no-op'ing and exiting `0`.
- **Atomic writes**: `.slp` files, the `{scan_key}.predictions.json` manifest, and the copied-through scan-metadata sidecar are all written via temp-file-in-same-directory + `os.replace`, so no reader can ever observe a partially-written file. The manifest is committed before the stale-`.slp` cleanup sweep runs, so a sweep failure can never leave a still-current manifest referencing partially-deleted files. Defense-in-depth, not a fix for a live correctness bug — predict #35's idempotency-key resume already treats any corrupt/truncated previous artifact as "changed, re-predict."
- **`SIGTERM` handler**: `run_batch` gains a `should_stop: Callable[[], bool]` keyword (default a no-op, existing callers unaffected), checked at each per-scan loop boundary. `main()` installs a handler before running the batch and returns `143` if it fired, overriding whatever the completed-so-far scans would otherwise produce, and always restores the prior handler on exit (return or raise).

Add `README.md`/`API.md`/`CHANGELOG.md` updates describing the final scheme.

## OpenSpec Change

- Change ID: `harden-argo-exit-semantics`
- Affected capabilities: `predict-container` (MODIFIED: exit codes, empty-input, atomic sidecar copy; ADDED: SIGTERM handling), `prediction-output` (MODIFIED: atomic `.slp`/manifest writes)
- Delta types: ADDED, MODIFIED
- All `tasks.md` items complete: yes (27/27)
- Went through 4 rounds of adversarial `/review-openspec` before implementation, and 3 rounds of adversarial `/review-pr` after — see `openspec/changes/harden-argo-exit-semantics/design.md` for the full decision trail, including reconciliation with the sibling `sleap-roots#259` proposal.

## Testing

- [x] CPU tests pass (`uv run pytest -m "not gpu" tests/`) — 323 passed
- [x] GPU tests pass locally on a CUDA machine (NVIDIA RTX A5000) — `uv sync --extra dev --extra windows_cuda && uv run pytest -m gpu tests/` — 3 passed. **Correction:** an earlier version of this PR description said GPU tests weren't run because "no CUDA/MPS accelerator" was available on this machine — that was wrong. The environment had only been synced with the `cpu` extra, so `torch.cuda.is_available()` correctly returned `False` for that CPU-only build regardless of hardware; it was never a real hardware check. `nvidia-smi` confirms a real GPU is present, and re-syncing `windows_cuda` and re-running confirms all 3 GPU tests pass.
- [x] New tests added for every new/changed function and behavior (empty-input raise, exit-code matrix, atomic-write interruption + ordering + cleanup-on-failure, `should_stop`, SIGTERM handler + override + handler-restore-on-every-exit-path, stale-sweep-after-manifest-commit)
- [x] Existing tests still cover affected paths — two pre-existing tests (`test_cli_main_exit_codes`, `test_cli_missing_input_dir_returns_nonzero`) were rewritten in place to match the new contract rather than left contradicting it

## Linting

- [x] Ruff passes
- [x] Codespell passes
- [x] Formatting passes (`black --check`)

## Build / Image

- [x] Wheel builds (`uv build`)
- [ ] Docker image — not rebuilt locally; `Dockerfile` and dependencies are unchanged by this PR (CI's own Docker build job passes)

## Downstream Compatibility

- [x] Output artifact format (`.slp`, `{scan}.predictions.json`, sidecar) unchanged — same schema, only the write mechanism (atomic vs. direct) and internal ordering (manifest committed before stale cleanup) changed
- [x] No breaking change to `sleap_roots_predict/__init__.py`'s public exports — `run_batch` gains an additive, defaulted `should_stop` keyword

## Breaking Changes

- [x] Breaking changes documented below with migration path

**Exit-code contract change** (CLI/container consumers only, not the Python API's return values):
- A caller checking exit `1` for "some scan failed" must check `3` instead (or treat any non-zero as failure, which still works but loses the new distinction).
- A caller checking exit `2` for a staging error (missing input dir, duplicate `scan_key`) must check the default `1` instead — `2` is no longer driver-owned.
- A caller relying on an empty input directory silently exiting `0` will now see it raise / exit `1`.

No known consumer depends on any of these today — A4 hasn't wired predict's exit code into any Argo `retryStrategy`/`continueOn` logic yet.

## Related Issues

Closes #26
Related to talmolab/sleap-roots#259 (same exit-code scheme adopted for the traits driver)

## Reviewer Notes

- The exit-code scheme was revised mid-proposal after reconciling with the `sleap-roots#259` session (dropped an initially-planned distinct `2`="aborted" code once we found it collides with `argparse`'s own `sys.exit(2)`) — see `design.md`'s "Alternative considered and reversed" for the full history if the numbering choice looks surprising.
- Two independent post-implementation review rounds found and fixed a real correctness gap in the atomic-write ordering (stale-cleanup running before, then between, the write and the manifest commit) — see the review thread for the full trail. Both are now fixed and re-verified.
- The Argo `WorkflowTemplate`/`retryStrategy` change to actually *act* on exit code `3` (vs. treating it like any other non-zero code) is a separate `sleap-roots-pipeline` repo change, out of scope here.
- GPU tests are now confirmed passing locally (see Testing section correction above).