### PR TITLE
fix: address cross-repo review findings on #36 (Argo exit semantics)

### DIFF
--- a/openspec/changes/harden-argo-exit-semantics/design.md
+++ b/openspec/changes/harden-argo-exit-semantics/design.md
@@ -84,6 +84,19 @@ doc for the "why not the alternative" reasoning.
     entirely, so tests must call the handler directly, never via `os.kill`. This repo's CI runs a
     Windows job; the handler's *logic* is unit-tested directly, while real end-to-end delivery is
     only ever meaningfully validated on Linux (the actual Argo/Kubernetes runtime) or macOS.
+  - **Cross-repo asymmetry, noted explicitly (found in a cross-repo PR review after
+    `sleap-roots#266` landed):** the traits driver's `SIGTERM` handler calls `sys.exit(143)`
+    immediately, with no scan-boundary wait — correctly, for two reasons specific to that driver:
+    (1) a single scan's trait computation is short and CPU-bound (no multi-second uninterruptible
+    native call to protect), and (2) its per-scan writes were already atomic before that PR, so an
+    interrupt at any point can only ever abandon an unfinished temp file, never corrupt a completed
+    `{scan_key}.result.json`. This driver waits for scan-boundary because neither of those is true
+    here: a scan is uninterruptible GPU inference, and (before this proposal) the writes weren't
+    atomic either. Both handlers reach the same outward contract (prompt exit, `143`, no corrupted
+    output); they differ only in how much in-flight work is discarded, as a direct consequence of
+    each driver's own per-scan cost and interruptibility — not an oversight to reconcile. (Traits'
+    own `design.md` for `harden-trait-extractor-exit-semantics` names and contrasts this driver's
+    approach explicitly; this note closes the loop so the cross-reference is mutual.)
 
 ## Risks / Trade-offs
 

--- a/sleap_roots_predict/__main__.py
+++ b/sleap_roots_predict/__main__.py
@@ -16,6 +16,7 @@ import logging
 import signal
 import sys
 import threading
+from types import FrameType
 from typing import Optional, Sequence
 
 
@@ -32,7 +33,7 @@ def _install_sigterm_handler() -> threading.Event:
     """
     event = threading.Event()
 
-    def _handler(signum, frame):
+    def _handler(signum: int, frame: Optional[FrameType]) -> None:
         event.set()
 
     signal.signal(signal.SIGTERM, _handler)

--- a/sleap_roots_predict/batch.py
+++ b/sleap_roots_predict/batch.py
@@ -382,10 +382,12 @@ def _predict_one(
     out_scan_dir.mkdir(parents=True, exist_ok=True)
     # Copy the sidecar BEFORE the manifest: write_prediction_outputs writes the manifest
     # last as the resume commit-marker, so the sidecar must already be present when it
-    # lands — else a crash in between leaves a manifest with no sidecar that resume skips
-    # forever and the trait-extractor then rejects (an incomplete input tree). The copy
-    # itself is atomic (temp file + os.replace), so no reader ever observes a
-    # partially-written sidecar.
+    # lands. This isn't required to protect predict's own resume logic -- a missing
+    # sidecar already makes _previous_identity_key's read raise OSError, caught and
+    # treated as "changed" (re-predict), never a silent skip. It's required because the
+    # trait-extractor expects a self-contained input tree (manifest + sidecar + .slp) and
+    # would reject a manifest with no sidecar. The copy itself is atomic (temp file +
+    # os.replace), so no reader ever observes a partially-written sidecar.
     sidecar_dst = out_scan_dir / f"{scan.scan_key}{_SIDECAR_SUFFIX}"
     tmp_sidecar_dst = sidecar_dst.with_name(sidecar_dst.name + ".tmp")
     try:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -424,6 +424,76 @@ def test_sigterm_overrides_partial_exit_code(
         signal.signal(signal.SIGTERM, prev_handler)
 
 
+def test_main_restores_prior_sigterm_handler_on_normal_completion(
+    scan_input_dir: Path, tmp_path: Path, monkeypatch
+):
+    # The staging-error-path restoration test only exercises main()'s except/raise
+    # branch; this pins the same guarantee on the plain success-return path, so the
+    # unconditional `finally` around the whole function body is tested on both
+    # sides, not just the one that happens to also need the log-then-reraise fix.
+    import signal
+
+    from sleap_roots_predict.__main__ import main
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    monkeypatch.setattr(
+        "sleap_roots_predict.batch.run_batch",
+        lambda *a, **k: type("R", (), {"ok": True, "scans": []})(),
+    )
+    assert main([str(scan_input_dir), str(tmp_path / "out")]) == 0
+    assert signal.getsignal(signal.SIGTERM) is prev_handler
+
+
+def test_sigterm_composes_with_should_stop_across_a_real_multi_scan_batch(
+    all_roots_source, tmp_path: Path, monkeypatch
+):
+    # The boundary-stop test (test_should_stop_stops_after_first_scan) and the
+    # SIGTERM-override tests above each exercise their own half in isolation --
+    # this wires a real SIGTERM delivery (via the actual registered handler,
+    # never os.kill) into should_stop's real per-scan-loop check over a real
+    # two-scan batch, so the full composition is exercised end to end at least
+    # once, not just its two halves independently.
+    import signal
+
+    import sleap_roots_predict.batch as batch_mod
+    from sleap_roots_predict.__main__ import main
+
+    inp = tmp_path / "in"
+    _real_scan(inp, "s1", _RICE)
+    _real_scan(inp, "s2", _RICE)
+    out = tmp_path / "out"
+
+    prev_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        real_run_batch = batch_mod.run_batch
+        calls = {"n": 0}
+
+        def _run_with_signal_after_first_scan(*args, **kwargs):
+            orig_should_stop = kwargs.get("should_stop", lambda: False)
+
+            def _wrapped_should_stop():
+                calls["n"] += 1
+                if calls["n"] == 2:
+                    # Fire the real handler main() already installed -- this sets
+                    # the real threading.Event backing orig_should_stop, so the
+                    # very next line observes it exactly as a genuine delivery
+                    # between scans would.
+                    signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+                return orig_should_stop()
+
+            kwargs["source"] = all_roots_source
+            kwargs["should_stop"] = _wrapped_should_stop
+            return real_run_batch(*args, **kwargs)
+
+        monkeypatch.setattr(batch_mod, "run_batch", _run_with_signal_after_first_scan)
+        assert main([str(inp), str(out)]) == 143
+    finally:
+        signal.signal(signal.SIGTERM, prev_handler)
+
+    assert (out / "s1" / "s1.predictions.json").exists()
+    assert not (out / "s2").exists()
+
+
 @pytest.mark.wandb
 def test_module_cli_over_registry(scan_input_dir: Path, tmp_path: Path):
     import subprocess


### PR DESCRIPTION
## Summary

#36 merged before a final round of cross-repo `/review-pr` feedback (comparing against `talmolab/sleap-roots#266`) landed. This PR carries that one follow-up commit forward onto current `main`.

## Changes

- Fix an inaccurate inline comment in `batch.py`'s sidecar-copy ordering rationale: it claimed a missing sidecar makes resume "skip forever." Tracing `_previous_identity_key` shows a missing sidecar raises `OSError`, caught and treated as "changed" (re-predict), never a silent skip. The real reason for the copy-before-manifest ordering is the trait-extractor's self-contained-tree expectation, not predict's own resume safety — corrected the comment to say so.
- Type-annotate the `SIGTERM` handler callback (`signum: int, frame: Optional[FrameType]`), matching `sleap-roots#266`'s own `_handle_sigterm` signature and this repo's typing conventions elsewhere.
- Add a test asserting the `SIGTERM` handler is restored on the normal-return path too, not just the staging-error path (the unconditional `finally` covers both; only one side had a test).
- Add a composed end-to-end test wiring a real `SIGTERM` delivery (via the actual registered handler, never `os.kill`) into `should_stop`'s real per-scan-loop check over a real two-scan batch — the two mechanisms were previously only tested in isolation from each other.
- Add a `design.md` note explicitly naming and contrasting `sleap-roots#266`'s immediate-`sys.exit` `SIGTERM` approach, mirroring what that PR's own `design.md` already does for this repo's scan-boundary-wait approach (the cross-reference was one-directional).

## Testing

- [x] Full suite: 325 passed
- [x] GPU tests (`pytest -m gpu`): 3 passed (real CUDA hardware)
- [x] `black`, `ruff`, `codespell`: clean
- [x] `openspec validate harden-argo-exit-semantics --strict`: valid

## Related

Follow-up to #36 (predict #26). Cross-repo alignment reviewed against `talmolab/sleap-roots#266`.